### PR TITLE
Configure a Login.gov production OIDC provider

### DIFF
--- a/ops/manifests/manifest-stable.yaml
+++ b/ops/manifests/manifest-stable.yaml
@@ -4,7 +4,7 @@ applications:
   buildpacks:
     - python_buildpack
   path: ../../src
-  instances: 1
+  instances: 2
   memory: 512M
   stack: cflinuxfs4
   timeout: 180

--- a/ops/manifests/manifest-stable.yaml
+++ b/ops/manifests/manifest-stable.yaml
@@ -23,6 +23,8 @@ applications:
     DJANGO_LOG_LEVEL: INFO
     # default public site location
     GETGOV_PUBLIC_SITE_URL: https://beta.get.gov
+    # Which OIDC provider to use
+    OIDC_ACTIVE_PROVIDER: login.gov production
   routes:
     - route: getgov-stable.app.cloud.gov
   services:

--- a/ops/manifests/manifest-staging.yaml
+++ b/ops/manifests/manifest-staging.yaml
@@ -4,7 +4,7 @@ applications:
   buildpacks:
     - python_buildpack
   path: ../../src
-  instances: 1
+  instances: 2
   memory: 512M
   stack: cflinuxfs4
   timeout: 180

--- a/src/registrar/config/settings.py
+++ b/src/registrar/config/settings.py
@@ -371,8 +371,7 @@ LOGGING = {
     # each handler has its choice of format
     "formatters": {
         "verbose": {
-            "format": "[%(asctime)s] %(levelname)s [%(name)s:%(lineno)s] "
-            "%(message)s",
+            "format": "[%(asctime)s] %(levelname)s [%(name)s:%(lineno)s] %(message)s",
             "datefmt": "%d/%b/%Y %H:%M:%S",
         },
         "simple": {
@@ -515,13 +514,15 @@ OIDC_PROVIDERS = {
             "acr_value": "http://idmanagement.gov/ns/assurance/ial/2",
         },
         "client_registration": {
-            "client_id": "urn:gov:cisa:openidconnect.profiles:sp:sso:cisa:dotgov_registrar",
+            "client_id": (
+                "urn:gov:cisa:openidconnect.profiles:sp:sso:cisa:dotgov_registrar"
+            ),
             "redirect_uris": [f"{env_base_url}/openid/callback/login/"],
             "post_logout_redirect_uris": [f"{env_base_url}/openid/callback/logout/"],
             "token_endpoint_auth_method": ["private_key_jwt"],
             "sp_private_key": secret_login_key,
         },
-    }
+    },
 }
 
 # endregion

--- a/src/registrar/config/settings.py
+++ b/src/registrar/config/settings.py
@@ -504,6 +504,7 @@ OIDC_PROVIDERS = {
             "token_endpoint_auth_method": ["private_key_jwt"],
             "sp_private_key": secret_login_key,
         },
+    },
     "login.gov production": {
         "srv_discovery_url": "https://secure.login.gov",
         "behaviour": {

--- a/src/registrar/config/settings.py
+++ b/src/registrar/config/settings.py
@@ -49,6 +49,7 @@ env_debug = env.bool("DJANGO_DEBUG", default=False)
 env_log_level = env.str("DJANGO_LOG_LEVEL", "DEBUG")
 env_base_url = env.str("DJANGO_BASE_URL")
 env_getgov_public_site_url = env.str("GETGOV_PUBLIC_SITE_URL", "")
+env_oidc_active_provider = env.str("OIDC_ACTIVE_PROVIDER", "identity sandbox")
 
 secret_login_key = b64decode(secret("DJANGO_SECRET_LOGIN_KEY", ""))
 secret_key = secret("DJANGO_SECRET_KEY")
@@ -482,11 +483,12 @@ OIDC_ALLOW_DYNAMIC_OP = False
 
 # which provider to use if multiple are available
 # (code does not currently support user selection)
-OIDC_ACTIVE_PROVIDER = "login.gov"
+# See above for the default value if the env variable is missing
+OIDC_ACTIVE_PROVIDER = env_oidc_active_provider
 
 
 OIDC_PROVIDERS = {
-    "login.gov": {
+    "identity sandbox": {
         "srv_discovery_url": "https://idp.int.identitysandbox.gov",
         "behaviour": {
             # the 'code' workflow requires direct connectivity from us to Login.gov
@@ -497,6 +499,22 @@ OIDC_PROVIDERS = {
         },
         "client_registration": {
             "client_id": "cisa_dotgov_registrar",
+            "redirect_uris": [f"{env_base_url}/openid/callback/login/"],
+            "post_logout_redirect_uris": [f"{env_base_url}/openid/callback/logout/"],
+            "token_endpoint_auth_method": ["private_key_jwt"],
+            "sp_private_key": secret_login_key,
+        },
+    "login.gov production": {
+        "srv_discovery_url": "https://secure.login.gov",
+        "behaviour": {
+            # the 'code' workflow requires direct connectivity from us to Login.gov
+            "response_type": "code",
+            "scope": ["email", "profile:name", "phone"],
+            "user_info_request": ["email", "first_name", "last_name", "phone"],
+            "acr_value": "http://idmanagement.gov/ns/assurance/ial/2",
+        },
+        "client_registration": {
+            "client_id": "urn:gov:cisa:openidconnect.profiles:sp:sso:cisa:dotgov_registrar",
             "redirect_uris": [f"{env_base_url}/openid/callback/login/"],
             "post_logout_redirect_uris": [f"{env_base_url}/openid/callback/logout/"],
             "token_endpoint_auth_method": ["private_key_jwt"],


### PR DESCRIPTION
As part of #1160 we need to configure the application running on manage.get.gov to be able to use the production Login.gov environment rather than the identity sandbox environment like the rest of our sandboxes use. Fortunately, we made ourselves a design for that using a dict of `OIDC_PROVIDERS` and a settings variable for `OIDC_ACTIVE_PROVIDER`.

## Changes

This makes the `OIDC_ACTIVE_PROVIDER` load from an environment variable and adds the production login.gov provider information. In the stable environment's manifest, we set the `OIDC_ACTIVE_PROVIDER` environment variable to match, while all other environments will continue using the default value of `identity sandbox` when that environment variable is unset.

Also closes #1151 by moving us to two instances in the stable manifest.

## Setup

This is a hard one to test because it depends on having matching private keys for each environment in the `DJANGO_SECRET_LOGIN_KEY` environment variable.  You can at least test that this change keeps your sandbox or local install in working order by pulling the branch, running `docker compose up` and making sure that you can log in through the Identity sandbox.