### PR TITLE
Issue #1237 - domain bug - unable to manage a domain for a transition domain

### DIFF
--- a/src/registrar/templates/domain_base.html
+++ b/src/registrar/templates/domain_base.html
@@ -26,9 +26,9 @@
       {% if not domain.domain_info %}
         <div class="usa-alert usa-alert--error margin-bottom-2">
           <div class="usa-alert__body">
-            <h4 class="usa-alert__heading larger-font-sizing">Error!</h4>
+            <h4 class="usa-alert__heading larger-font-sizing">Domain missing domain information</h4>
             <p class="usa-alert__text ">
-              You are attempting to manage a domain, {{ domain.name }}, which does not have a Domain Information object. Please correct this in the admin.
+              You are attempting to manage a domain, {{ domain.name }}, which does not have a domain information object. Please correct this in the admin by editing the domain, and adding domain information, as appropriate.
             </p>
           </div>
         </div>

--- a/src/registrar/templates/domain_base.html
+++ b/src/registrar/templates/domain_base.html
@@ -16,49 +16,60 @@
   </div>
   <div class="grid-row grid-gap">
     <div class="tablet:grid-col-3">
-      {% include 'domain_sidebar.html' %}
+      {% if domain.domain_info %}
+        {% include 'domain_sidebar.html' %}
+      {% endif %}
     </div>
 
     <div class="tablet:grid-col-9">
       <main id="main-content" class="grid-container">
-
-      {% if is_analyst_or_superuser and analyst_action == 'edit' and analyst_action_location == domain.pk %}
-      <div class="usa-alert usa-alert--warning margin-bottom-2">
-        <div class="usa-alert__body">
-          <h4 class="usa-alert__heading larger-font-sizing">Attention!</h4>
-          <p class="usa-alert__text ">
-            You are making changes to a registrant’s domain. When finished making changes, close this tab and inform the registrant of your updates.
-          </p>
-        </div>
-      </div>
-      {% else %}
-      <a href="{% url 'home' %}" class="breadcrumb__back">
-        <svg class="usa-icon" aria-hidden="true" focusable="false" role="img">
-        <use xlink:href="{% static 'img/sprite.svg' %}#arrow_back"></use>
-        </svg>
-
-        <p class="margin-left-05 margin-top-0 margin-bottom-0 line-height-sans-1">
-        Back to manage your domains
-        </p>
-      </a>
-      {% endif %}
-      {# messages block is under the back breadcrumb link #}
-      {% if messages %}
-      {% for message in messages %}
-      <div class="usa-alert usa-alert--{{ message.tags }} usa-alert--slim margin-bottom-3">
+      {% if not domain.domain_info %}
+        <div class="usa-alert usa-alert--error margin-bottom-2">
           <div class="usa-alert__body">
-          {{ message }}
+            <h4 class="usa-alert__heading larger-font-sizing">Error!</h4>
+            <p class="usa-alert__text ">
+              You are attempting to manage a domain, {{ domain.name }}, which does not have a Domain Information object. Please correct this in the admin.
+            </p>
           </div>
-      </div>
-      {% endfor %}
+        </div>
+      {% else %}
+        {% if is_analyst_or_superuser and analyst_action == 'edit' and analyst_action_location == domain.pk %}
+        <div class="usa-alert usa-alert--warning margin-bottom-2">
+          <div class="usa-alert__body">
+            <h4 class="usa-alert__heading larger-font-sizing">Attention!</h4>
+            <p class="usa-alert__text ">
+              You are making changes to a registrant’s domain. When finished making changes, close this tab and inform the registrant of your updates.
+            </p>
+          </div>
+        </div>
+        {% else %}
+        <a href="{% url 'home' %}" class="breadcrumb__back">
+          <svg class="usa-icon" aria-hidden="true" focusable="false" role="img">
+          <use xlink:href="{% static 'img/sprite.svg' %}#arrow_back"></use>
+          </svg>
+
+          <p class="margin-left-05 margin-top-0 margin-bottom-0 line-height-sans-1">
+          Back to manage your domains
+          </p>
+        </a>
+        {% endif %}
+        {# messages block is under the back breadcrumb link #}
+        {% if messages %}
+        {% for message in messages %}
+        <div class="usa-alert usa-alert--{{ message.tags }} usa-alert--slim margin-bottom-3">
+            <div class="usa-alert__body">
+            {{ message }}
+            </div>
+        </div>
+        {% endfor %}
+        {% endif %}
+
+        {% block domain_content %}
+
+        <h1 class="break-word">{{ domain.name }}</h1>
+
+        {% endblock %}  {# domain_content #}
       {% endif %}
-
-      {% block domain_content %}
-
-      <h1 class="break-word">{{ domain.name }}</h1>
-
-      {% endblock %}  {# domain_content #}
-
       </main>
     </div>
   </div>

--- a/src/registrar/tests/common.py
+++ b/src/registrar/tests/common.py
@@ -453,7 +453,7 @@ def create_user():
     p = "userpass"
     user = User.objects.create_user(
         username="staffuser",
-        email="user@example.com",
+        email="staff@example.com",
         is_staff=True,
         password=p,
     )

--- a/src/registrar/tests/test_views.py
+++ b/src/registrar/tests/test_views.py
@@ -1293,8 +1293,8 @@ class TestDomainOverview(TestWithDomainPermissions, WebTest):
         # in the session to emulate user clicking Manage Domain
         # in the admin interface
         session = self.client.session
-        session['analyst_action'] = 'foo'
-        session['analyst_action_location'] = self.domain_no_information.id
+        session["analyst_action"] = "foo"
+        session["analyst_action_location"] = self.domain_no_information.id
         session.save()
 
         detail_page = self.client.get(
@@ -1302,7 +1302,7 @@ class TestDomainOverview(TestWithDomainPermissions, WebTest):
         )
 
         self.assertContains(detail_page, "noinformation.gov")
-        self.assertContains(detail_page, "Error")
+        self.assertContains(detail_page, "Domain missing domain information")
 
 
 class TestDomainManagers(TestDomainOverview):

--- a/src/registrar/tests/test_views.py
+++ b/src/registrar/tests/test_views.py
@@ -1105,6 +1105,9 @@ class TestWithDomainPermissions(TestWithUser):
         self.domain_just_nameserver, _ = Domain.objects.get_or_create(
             name="justnameserver.com"
         )
+        self.domain_no_information, _ = Domain.objects.get_or_create(
+            name="noinformation.gov"
+        )
 
         self.domain_dsdata, _ = Domain.objects.get_or_create(name="dnssec-dsdata.gov")
         self.domain_multdsdata, _ = Domain.objects.get_or_create(
@@ -1277,6 +1280,15 @@ class TestDomainOverview(TestWithDomainPermissions, WebTest):
         # Splitting IP addresses bc there is odd whitespace and can't strip text
         self.assertContains(detail_page, "(1.2.3.4,")
         self.assertContains(detail_page, "2.3.4.5)")
+
+    def test_domain_with_no_information_or_application(self):
+        """Test that domain management page returns 200 when no
+        domain information or domain application exist"""
+        detail_page = self.app.get(
+            reverse("domain", kwargs={"pk": self.domain_no_information.id})
+        )
+
+        self.assertContains(detail_page, "noinformation.gov")
 
 
 class TestDomainManagers(TestDomainOverview):

--- a/src/registrar/views/utility/mixins.py
+++ b/src/registrar/views/utility/mixins.py
@@ -99,7 +99,7 @@ class DomainPermission(PermissionsLoginMixin):
         requested_domain = None
         if DomainInformation.objects.filter(id=pk).exists():
             requested_domain = DomainInformation.objects.get(id=pk)
-        
+
         # if no domain information or application exist, the user
         # should be able to manage the domain; however, if domain information
         # and domain application exist, and application is not in valid status,

--- a/src/registrar/views/utility/mixins.py
+++ b/src/registrar/views/utility/mixins.py
@@ -99,8 +99,8 @@ class DomainPermission(PermissionsLoginMixin):
         requested_domain = None
         if DomainInformation.objects.filter(id=pk).exists():
             requested_domain = DomainInformation.objects.get(id=pk)
-
-        # if no domain information or domain application exist, the user
+        
+        # if no domain information or application exist, the user
         # should be able to manage the domain; however, if domain information
         # and domain application exist, and application is not in valid status,
         # user should not be able to manage domain

--- a/src/registrar/views/utility/mixins.py
+++ b/src/registrar/views/utility/mixins.py
@@ -100,7 +100,15 @@ class DomainPermission(PermissionsLoginMixin):
         if DomainInformation.objects.filter(id=pk).exists():
             requested_domain = DomainInformation.objects.get(id=pk)
 
-        if requested_domain.domain_application.status not in valid_domain_statuses:
+        # if no domain information or domain application exist, the user
+        # should be able to manage the domain; however, if domain information
+        # and domain application exist, and application is not in valid status,
+        # user should not be able to manage domain
+        if (
+            requested_domain
+            and requested_domain.domain_application
+            and requested_domain.domain_application.status not in valid_domain_statuses
+        ):
             return False
 
         # Valid session keys exist,


### PR DESCRIPTION
## Ticket

Resolves #1237 
<!--Reminder, when a code change is made that is user facing, beyond content updates, then the following are required:
- a developer approves the PR
- a designer approves the PR or checks off all relevant items in this checklist.

All other changes require just a single approving review.-->

## Changes

<!-- What was added, updated, or removed in this PR. -->
- When analyst clicks Manage Domain in django admin for a domain which does not have a domain information nor a domain application, the analyst will now be presented with an error message rather than a 500 system error.

<!--
    Please add/remove/edit any of the template below to fit the needs
    of this specific PR.
--->

## Context for reviewers

NOTE: This issue is staged in [BL Sandbox](https://getgov-bl.app.cloud.gov/)

This use case is only when an analyst or admin clicks the Manage Domain on the domain detail page in django admin for a domain which does not have a related domain information or domain application object.

<!--Background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers.  -->

## Setup

<!--  Add any steps or code to run in this section to help others run your code.
    
    Example 1:
    ```sh
    echo "Code goes here"
    ``` 
    
    Example 2: If the PR was to add a new link with a redirect, this section could simply be:
    -go to /path/to/start/page
    -click the blue link in the <insert location>
    -notice user is redirected to <proper end location>
-->

Navigate to django admin on the BL Sandbox
https://getgov-bl.app.cloud.gov/admin

Click on domains to bring up list of domains.
Click first domain, domain-with-no-info.gov
Click Manage Domain
You should see the screenshot at the bottom of this description


## Code Review Verification Steps

### As the original developer, I have

#### Satisfied acceptance criteria and met development standards

- [x] Met the acceptance criteria, or will meet them in a subsequent PR
- [x] Created/modified automated tests
- [x] Added at least 2 developers as PR reviewers (only 1 will need to approve)
- [x] Messaged on Slack or in standup to notify the team that a PR is ready for review
- [ ] Changes to “how we do things” are documented in READMEs and or onboarding guide
- [ ] If any model was updated to modify/add/delete columns, makemigrations was ran and the assoicated migrations file has been commited.

#### Ensured code standards are met (Original Developer)

- [x] All new functions and methods are commented using plain language
- [ ] Did dependency updates in Pipfile also get changed in requirements.txt?
- [x] Interactions with external systems are wrapped in try/except
- [x] Error handling exists for unusual or missing values

#### Validated user-facing changes (if applicable)

- [ ] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Checked keyboard navigability
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)
- [ ] Add at least 1 designer as PR reviewer

### As a code reviewer, I have

#### Reviewed, tested, and left feedback about the changes

- [ ] Pulled this branch locally and tested it
- [ ] Reviewed this code and left comments
- [ ] Checked that all code is adequately covered by tests
- [ ] Made it clear which comments need to be addressed before this work is merged
- [ ] If any model was updated to modify/add/delete columns, makemigrations was ran and the assoicated migrations file has been commited.

#### Ensured code standards are met (Code reviewer)

- [ ] All new functions and methods are commented using plain language
- [ ] Interactions with external systems are wrapped in try/except
- [ ] Error handling exists for unusual or missing values
- [ ] (Rarely needed) Did dependency updates in Pipfile also get changed in requirements.txt?

#### Validated user-facing changes as a developer

- [ ] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Checked keyboard navigability
- [ ] Meets all designs and user flows provided by design/product
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)

- [ ] Tested with multiple browsers, the suggestion is to use ones that the developer didn't (check off which ones were used)
  - [ ] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari

- [ ] (Rarely needed) Tested as both an analyst and applicant user

**Note:** Multiple code reviewers can share the checklists above, a second reviewers should not make a duplicate checklist

### As a designer reviewer, I have

#### Verified that the changes match the design intention

- [ ] Checked that the design translated visually
- [ ] Checked behavior
- [ ] Checked different states (empty, one, some, error)
- [ ] Checked for landmarks, page heading structure, and links
- [ ] Tried to break the intended flow

#### Validated user-facing changes as a designer

- [ ] Checked keyboard navigability
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)

- [ ] Tested with multiple browsers (check off which ones were used)
  - [ ] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari

- [ ] (Rarely needed) Tested as both an analyst and applicant user

## Screenshots

<!-- If this PR makes visible interface changes, an image of the finished interface can help reviewers
and casual observers understand the context of the changes.
A before image is optional and can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow.
You may want to use [GIPHY Capture](https://giphy.com/apps/giphycapture) for this! 📸

_Please frame images to show useful context but also highlight the affected regions._
--->

![image](https://github.com/cisagov/manage.get.gov/assets/111779554/d5affb04-d2fe-4d94-800c-444b6dd73f26)

