### PR TITLE
Add migration to recreate user-group permissions

### DIFF
--- a/src/registrar/migrations/0044_create_groups_v04.py
+++ b/src/registrar/migrations/0044_create_groups_v04.py
@@ -25,7 +25,7 @@ def create_groups(apps, schema_editor) -> Any:
 
 class Migration(migrations.Migration):
     dependencies = [
-        ("registrar", "0043_domain_expiration_date.py"),
+        ("registrar", "0043_domain_expiration_date"),
     ]
 
     operations = [

--- a/src/registrar/migrations/0044_create_groups_v04.py
+++ b/src/registrar/migrations/0044_create_groups_v04.py
@@ -1,0 +1,37 @@
+# This migration creates the create_full_access_group and create_cisa_analyst_group groups
+# It is dependent on 0035 (which populates ContentType and Permissions)
+# If permissions on the groups need changing, edit CISA_ANALYST_GROUP_PERMISSIONS
+# in the user_group model then:
+# [NOT RECOMMENDED]
+# step 1: docker-compose exec app ./manage.py migrate --fake registrar 0035_contenttypes_permissions
+# step 2: docker-compose exec app ./manage.py migrate registrar 0036_create_groups
+# step 3: fake run the latest migration in the migrations list
+# [RECOMMENDED]
+# Alternatively:
+# step 1: duplicate the migration that loads data
+# step 2: docker-compose exec app ./manage.py migrate
+
+from django.db import migrations
+from registrar.models import UserGroup
+from typing import Any
+
+
+# For linting: RunPython expects a function reference,
+# so let's give it one
+def create_groups(apps, schema_editor) -> Any:
+    UserGroup.create_cisa_analyst_group(apps, schema_editor)
+    UserGroup.create_full_access_group(apps, schema_editor)
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("registrar", "0043_domain_expiration_date.py"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            create_groups,
+            reverse_code=migrations.RunPython.noop,
+            atomic=True,
+        ),
+    ]


### PR DESCRIPTION
This adds a migration to re-create our user-groups with permissions. This is Rachid's recommended technique for adding back this data. We needed to do this because we flushed the stable database, but not the whole migrations table, so it is not re-running the existing migrations for creating this data. So here's a new one!

When we merge this PR, we will make the hotfix release to `stable` from THIS BRANCH instead of from `main`.