### PR TITLE
#513: Add google analytics code in production

### DIFF
--- a/src/docker-compose.yml
+++ b/src/docker-compose.yml
@@ -27,6 +27,8 @@ services:
       - DJANGO_DEBUG=True
       # Tell Django where it is being hosted
       - DJANGO_BASE_URL=http://localhost:8080
+      # Is this a production environment
+      - IS_PRODUCTION
       # Public site URL link
       - GETGOV_PUBLIC_SITE_URL=https://beta.get.gov
       # Set a username for accessing the registry

--- a/src/registrar/config/settings.py
+++ b/src/registrar/config/settings.py
@@ -210,6 +210,7 @@ TEMPLATES = [
                 "registrar.context_processors.language_code",
                 "registrar.context_processors.canonical_path",
                 "registrar.context_processors.is_demo_site",
+                "registrar.context_processors.is_production",
             ],
         },
     },

--- a/src/registrar/context_processors.py
+++ b/src/registrar/context_processors.py
@@ -31,3 +31,8 @@ def is_demo_site(request):
     should not appear.
     """
     return {"IS_DEMO_SITE": settings.IS_DEMO_SITE}
+
+
+def is_production(request):
+    """Add a boolean if this is our production site."""
+    return {"IS_PRODUCTION": settings.IS_PRODUCTION}

--- a/src/registrar/templates/base.html
+++ b/src/registrar/templates/base.html
@@ -3,6 +3,14 @@
 <html class="no-js" lang="{{ LANGUAGE_CODE }}">
 
 <head>
+  {% if IS_PRODUCTION %}
+  <!-- Google tag (gtag.js) --> 
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-PZ5QSP6QPL"></script>
+  <script> 
+    window.dataLayer = window.dataLayer || []; function gtag(){dataLayer.push(arguments);} gtag('js', new Date()); gtag('config', 'G-PZ5QSP6QPL');
+  </script>
+  {% endif %}
+
   <meta charset="utf-8">
   <meta http-equiv="x-ua-compatible" content="ie=edge">
   <title>

--- a/src/registrar/templates/base.html
+++ b/src/registrar/templates/base.html
@@ -4,9 +4,9 @@
 
 <head>
   {% if IS_PRODUCTION %}
-  <!-- Google tag (gtag.js) --> 
+  <!-- Google tag (gtag.js) -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-PZ5QSP6QPL"></script>
-  <script> 
+  <script>
     window.dataLayer = window.dataLayer || []; function gtag(){dataLayer.push(arguments);} gtag('js', new Date()); gtag('config', 'G-PZ5QSP6QPL');
   </script>
   {% endif %}

--- a/src/registrar/templates/home.html
+++ b/src/registrar/templates/home.html
@@ -13,7 +13,7 @@
   <h1>Manage your domains</h2>
 
   <p class="margin-top-4">
-    {% if is_production %}
+    {% if IS_PRODUCTION %}
     <a href="javascript:void(0)" 
     class="usa-button usa-tooltip disabled-link"
     data-position="right"

--- a/src/registrar/views/index.py
+++ b/src/registrar/views/index.py
@@ -2,7 +2,6 @@ from django.db.models import F
 from django.shortcuts import render
 
 from registrar.models import DomainApplication
-from django.conf import settings
 
 
 def index(request):
@@ -23,5 +22,4 @@ def index(request):
             state=F("domain__state"),
         )
         context["domains"] = domains
-        context["is_production"] = settings.IS_PRODUCTION
     return render(request, "home.html", context)


### PR DESCRIPTION
## Ticket

Resolves #513 

## Changes

This includes the Google analytics Javascript code only on our production environment. 

It also refactors the way that the `IS_PRODUCTION` context processor works so it is available on all pages and capitalized to emphasize that it comes from `settings` and an environment variable. <---- @zandercymatics 

## Setup

To test this, run the code locally and you should see no Google analytics in the page source. If you add `IS_PRODUCTION="true"` to your `.env` file and restart the docker container, then you should see the Google analytics code.

## Code Review Verification Steps

### As the original developer, I have

#### Satisfied acceptance criteria and met development standards

- [X] Met the acceptance criteria, or will meet them in a subsequent PR
- [X] Added at least 2 developers as PR reviewers (only 1 will need to approve)
- [X] Messaged on Slack or in standup to notify the team that a PR is ready for review

#### Ensured code standards are met (Original Developer)

- [X] All new functions and methods are commented using plain language

### As a code reviewer, I have

#### Reviewed, tested, and left feedback about the changes

- [ ] Pulled this branch locally and tested it
- [ ] Reviewed this code and left comments
- [ ] Checked that all code is adequately covered by tests
- [ ] Made it clear which comments need to be addressed before this work is merged
- [ ] If any model was updated to modify/add/delete columns, makemigrations was ran and the assoicated migrations file has been commited.

#### Ensured code standards are met (Code reviewer)

- [ ] All new functions and methods are commented using plain language
- [ ] Interactions with external systems are wrapped in try/except
- [ ] Error handling exists for unusual or missing values
- [ ] (Rarely needed) Did dependency updates in Pipfile also get changed in requirements.txt?

- [ ] Tested with multiple browsers, the suggestion is to use ones that the developer didn't (check off which ones were used)
  - [ ] Chrome
  - [ ] Microsoft Edge
  - [X] FireFox
  - [ ] Safari

**Note:** Multiple code reviewers can share the checklists above, a second reviewers should not make a duplicate checklist

## Screenshots

![Screenshot 2023-11-09 at 1 46 06 PM](https://github.com/cisagov/manage.get.gov/assets/443389/129c7276-c83e-4cb9-8bf6-d8e81ba2f1db)
