### PR TITLE
Issue #1309: Remove double start new domain request button

### DIFF
--- a/src/registrar/templates/home.html
+++ b/src/registrar/templates/home.html
@@ -137,9 +137,9 @@
       class="usa-sr-only usa-table__announcement-region"
       aria-live="polite"
     ></div>
-    <!-- {% else %}
+    {% else %}
     <p>You don't have any active domain requests right now</p>
-    <p><a href="{% url 'application:' %}" class="usa-button">Start a new domain request</a></p> -->
+    <!-- <p><a href="{% url 'application:' %}" class="usa-button">Start a new domain request</a></p> -->
     {% endif %}
   </section>
 

--- a/src/registrar/templates/home.html
+++ b/src/registrar/templates/home.html
@@ -137,9 +137,9 @@
       class="usa-sr-only usa-table__announcement-region"
       aria-live="polite"
     ></div>
-    {% else %}
+    <!-- {% else %}
     <p>You don't have any active domain requests right now</p>
-    <p><a href="{% url 'application:' %}" class="usa-button">Start a new domain request</a></p>
+    <p><a href="{% url 'application:' %}" class="usa-button">Start a new domain request</a></p> -->
     {% endif %}
   </section>
 


### PR DESCRIPTION
## Ticket

Resolves #1309


## Changes

Commented out the button to users don't see the "Start a new domain request" twice. I left it commented in case for future, but if that's not the case let me know and I can remove.

You can see these changes at my sandbox after [log in here](https://getgov-rh.app.cloud.gov/), and/or see screenshots section below for validity.

## Context for reviewers

<!--Background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers.  -->

## Setup

<!--  Add any steps or code to run in this section to help others run your code.
    
    Example 1:
    ```sh
    echo "Code goes here"
    ``` 
    
    Example 2: If the PR was to add a new link with a redirect, this section could simply be:
    -go to /path/to/start/page
    -click the blue link in the <insert location>
    -notice user is redirected to <proper end location>
-->

## Code Review Verification Steps

### As the original developer, I have

#### Satisfied acceptance criteria and met development standards

- [ ] Met the acceptance criteria, or will meet them in a subsequent PR
- [ ] Created/modified automated tests
- [ ] Added at least 2 developers as PR reviewers (only 1 will need to approve)
- [ ] Messaged on Slack or in standup to notify the team that a PR is ready for review
- [ ] Changes to “how we do things” are documented in READMEs and or onboarding guide
- [ ] If any model was updated to modify/add/delete columns, makemigrations was ran and the assoicated migrations file has been commited.

#### Ensured code standards are met (Original Developer)

- [ ] All new functions and methods are commented using plain language
- [ ] Did dependency updates in Pipfile also get changed in requirements.txt?
- [ ] Interactions with external systems are wrapped in try/except
- [ ] Error handling exists for unusual or missing values

#### Validated user-facing changes (if applicable)

- [ ] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Checked keyboard navigability
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)
- [ ] Add at least 1 designer as PR reviewer

### As a code reviewer, I have

#### Reviewed, tested, and left feedback about the changes

- [ ] Pulled this branch locally and tested it
- [ ] Reviewed this code and left comments
- [ ] Checked that all code is adequately covered by tests
- [ ] Made it clear which comments need to be addressed before this work is merged
- [ ] If any model was updated to modify/add/delete columns, makemigrations was ran and the assoicated migrations file has been commited.

#### Ensured code standards are met (Code reviewer)

- [ ] All new functions and methods are commented using plain language
- [ ] Interactions with external systems are wrapped in try/except
- [ ] Error handling exists for unusual or missing values
- [ ] (Rarely needed) Did dependency updates in Pipfile also get changed in requirements.txt?

#### Validated user-facing changes as a developer

- [ ] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Checked keyboard navigability
- [ ] Meets all designs and user flows provided by design/product
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)

- [ ] Tested with multiple browsers, the suggestion is to use ones that the developer didn't (check off which ones were used)
  - [ ] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari

- [ ] (Rarely needed) Tested as both an analyst and applicant user

**Note:** Multiple code reviewers can share the checklists above, a second reviewers should not make a duplicate checklist

### As a designer reviewer, I have

#### Verified that the changes match the design intention

- [ ] Checked that the design translated visually
- [ ] Checked behavior
- [ ] Checked different states (empty, one, some, error)
- [ ] Checked for landmarks, page heading structure, and links
- [ ] Tried to break the intended flow

#### Validated user-facing changes as a designer

- [ ] Checked keyboard navigability
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)

- [ ] Tested with multiple browsers (check off which ones were used)
  - [ ] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari

- [ ] (Rarely needed) Tested as both an analyst and applicant user

## Screenshots

**Previous:** 
![image](https://github.com/cisagov/manage.get.gov/assets/13954664/81023e69-0b5d-447a-82b1-b7b687884160)

**Current:** 
![Screenshot 2023-11-09 at 12 03 30 PM](https://github.com/cisagov/manage.get.gov/assets/13954664/7ee5100a-9fca-47e5-986f-dd0feb0b0c27)


