### PR TITLE
Issue #1214 - de-emphasize place / remove hold, as well as remove from registry

### DIFF
--- a/src/registrar/assets/sass/_theme/_admin.scss
+++ b/src/registrar/assets/sass/_theme/_admin.scss
@@ -161,6 +161,26 @@ h1, h2, h3 {
     font-size: 14px;
 }
 
+// right justify custom buttons and display as links
+.submit-row input.custom-link-button,
+.submit-row input.custom-link-button:hover {
+    background: none;
+    border: none;
+    color: var(--link-fg);
+    cursor: pointer;
+    text-decoration: none;
+    padding: 0;
+    font-size: inherit;
+    margin-left: auto;
+}
+.submit-row div.spacer {
+    flex-grow: 1;
+}
+.submit-row span {
+    align-items: center;
+}
+
+// Customize 
 // Keep th from collapsing 
 .min-width-25 {
     min-width: 25px;

--- a/src/registrar/assets/sass/_theme/_admin.scss
+++ b/src/registrar/assets/sass/_theme/_admin.scss
@@ -177,7 +177,7 @@ h1, h2, h3 {
     flex-grow: 1;
 }
 .submit-row span {
-    align-items: center;
+    margin-top: units(1);
 }
 
 // Customize 

--- a/src/registrar/templates/django/admin/domain_change_form.html
+++ b/src/registrar/templates/django/admin/domain_change_form.html
@@ -8,15 +8,19 @@
 
 {% block field_sets %}
     <div class="submit-row">
-        {% if original.state == original.State.READY %}
-          <input type="submit" value="Place hold" name="_place_client_hold">
-        {% elif original.state == original.State.ON_HOLD %}
-          <input type="submit" value="Remove hold" name="_remove_client_hold">
-        {% endif %}
         <input id="manageDomainSubmitButton" type="submit" value="Manage domain" name="_edit_domain">
         <input type="submit" value="Get registry status" name="_get_status">
+        <div class="spacer"></div>
+        {% if original.state == original.State.READY %}
+        <input type="submit" value="Place hold" name="_place_client_hold" class="custom-link-button">
+        {% elif original.state == original.State.ON_HOLD %}
+        <input type="submit" value="Remove hold" name="_remove_client_hold" class="custom-link-button">
+        {% endif %}
+        {% if original.state == original.State.READY or original.state == original.State.ON_HOLD %}
+        <span> | </span>
+        {% endif %}
         {% if original.state != original.State.DELETED %}
-        <input type="submit" value="Delete domain in registry" name="_delete_domain">
+        <input type="submit" value="Remove from registry" name="_delete_domain" class="custom-link-button">
         {% endif %}
     </div>
     {{ block.super }}

--- a/src/registrar/tests/test_admin.py
+++ b/src/registrar/tests/test_admin.py
@@ -130,12 +130,12 @@ class TestDomainAdmin(MockEppLib):
         )
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, domain.name)
-        self.assertContains(response, "Delete domain in registry")
+        self.assertContains(response, "Remove from registry")
 
         # Test the info dialog
         request = self.factory.post(
             "/admin/registrar/domain/{}/change/".format(domain.pk),
-            {"_delete_domain": "Delete domain in registry", "name": domain.name},
+            {"_delete_domain": "Remove from registry", "name": domain.name},
             follow=True,
         )
         request.user = self.client
@@ -170,12 +170,12 @@ class TestDomainAdmin(MockEppLib):
         )
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, domain.name)
-        self.assertContains(response, "Delete domain in registry")
+        self.assertContains(response, "Remove from registry")
 
         # Test the error
         request = self.factory.post(
             "/admin/registrar/domain/{}/change/".format(domain.pk),
-            {"_delete_domain": "Delete domain in registry", "name": domain.name},
+            {"_delete_domain": "Remove from registry", "name": domain.name},
             follow=True,
         )
         request.user = self.client
@@ -215,12 +215,12 @@ class TestDomainAdmin(MockEppLib):
         )
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, domain.name)
-        self.assertContains(response, "Delete domain in registry")
+        self.assertContains(response, "Remove from registry")
 
         # Test the info dialog
         request = self.factory.post(
             "/admin/registrar/domain/{}/change/".format(domain.pk),
-            {"_delete_domain": "Delete domain in registry", "name": domain.name},
+            {"_delete_domain": "Remove from registry", "name": domain.name},
             follow=True,
         )
         request.user = self.client
@@ -242,7 +242,7 @@ class TestDomainAdmin(MockEppLib):
         # Test the info dialog
         request = self.factory.post(
             "/admin/registrar/domain/{}/change/".format(domain.pk),
-            {"_delete_domain": "Delete domain in registry", "name": domain.name},
+            {"_delete_domain": "Remove from registry", "name": domain.name},
             follow=True,
         )
         request.user = self.client


### PR DESCRIPTION


## Ticket

Resolves #1214
<!--Reminder, when a code change is made that is user facing, beyond content updates, then the following are required:
- a developer approves the PR
- a designer approves the PR or checks off all relevant items in this checklist.

All other changes require just a single approving review.-->

## Changes

<!-- What was added, updated, or removed in this PR. -->
- Delete domain from registry was renamed to 'Remove from registry' and moved to the right of the submit row
- Place / remove hold button moved to the right of the submit row
- Both buttons styled to display as text links
- In the event that both text links display, there is a | separator

<!--
    Please add/remove/edit any of the template below to fit the needs
    of this specific PR.
--->

## Context for reviewers

<!--Background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers.  -->

Review on [DK Sandbox](https://getgov-dk.app.cloud.gov/)

Go to Django admin
Go to domains list
Click on a domain that is either Ready or On hold
You should see a Place / Remove hold link on the right hand side, followed by a Remove from registry link

Go back to domains list
Click on a domain that is Unknown
You should see a Remove from Registry link

## Setup

<!--  Add any steps or code to run in this section to help others run your code.
    
    Example 1:
    ```sh
    echo "Code goes here"
    ``` 
    
    Example 2: If the PR was to add a new link with a redirect, this section could simply be:
    -go to /path/to/start/page
    -click the blue link in the <insert location>
    -notice user is redirected to <proper end location>
-->

## Code Review Verification Steps

### As the original developer, I have

#### Satisfied acceptance criteria and met development standards

- [x] Met the acceptance criteria, or will meet them in a subsequent PR
- [ ] Created/modified automated tests
- [x] Added at least 2 developers as PR reviewers (only 1 will need to approve)
- [x] Messaged on Slack or in standup to notify the team that a PR is ready for review
- [ ] Changes to “how we do things” are documented in READMEs and or onboarding guide
- [ ] If any model was updated to modify/add/delete columns, makemigrations was ran and the assoicated migrations file has been commited.

#### Ensured code standards are met (Original Developer)

- [x] All new functions and methods are commented using plain language
- [ ] Did dependency updates in Pipfile also get changed in requirements.txt?
- [ ] Interactions with external systems are wrapped in try/except
- [x] Error handling exists for unusual or missing values

#### Validated user-facing changes (if applicable)

- [ ] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Checked keyboard navigability
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)
- [ ] Add at least 1 designer as PR reviewer

### As a code reviewer, I have

#### Reviewed, tested, and left feedback about the changes

- [ ] Pulled this branch locally and tested it
- [ ] Reviewed this code and left comments
- [ ] Checked that all code is adequately covered by tests
- [ ] Made it clear which comments need to be addressed before this work is merged
- [ ] If any model was updated to modify/add/delete columns, makemigrations was ran and the assoicated migrations file has been commited.

#### Ensured code standards are met (Code reviewer)

- [ ] All new functions and methods are commented using plain language
- [ ] Interactions with external systems are wrapped in try/except
- [ ] Error handling exists for unusual or missing values
- [ ] (Rarely needed) Did dependency updates in Pipfile also get changed in requirements.txt?

#### Validated user-facing changes as a developer

- [ ] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Checked keyboard navigability
- [ ] Meets all designs and user flows provided by design/product
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)

- [ ] Tested with multiple browsers, the suggestion is to use ones that the developer didn't (check off which ones were used)
  - [ ] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari

- [ ] (Rarely needed) Tested as both an analyst and applicant user

**Note:** Multiple code reviewers can share the checklists above, a second reviewers should not make a duplicate checklist

### As a designer reviewer, I have

#### Verified that the changes match the design intention

- [ ] Checked that the design translated visually
- [ ] Checked behavior
- [ ] Checked different states (empty, one, some, error)
- [ ] Checked for landmarks, page heading structure, and links
- [ ] Tried to break the intended flow

#### Validated user-facing changes as a designer

- [ ] Checked keyboard navigability
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)

- [ ] Tested with multiple browsers (check off which ones were used)
  - [ ] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari

- [ ] (Rarely needed) Tested as both an analyst and applicant user

## Screenshots

<!-- If this PR makes visible interface changes, an image of the finished interface can help reviewers
and casual observers understand the context of the changes.
A before image is optional and can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow.
You may want to use [GIPHY Capture](https://giphy.com/apps/giphycapture) for this! 📸

_Please frame images to show useful context but also highlight the affected regions._
--->
