### PR TITLE
Set transition domain's email_sent flag as the emails are sent

### DIFF
--- a/src/registrar/management/commands/send_domain_invitations.py
+++ b/src/registrar/management/commands/send_domain_invitations.py
@@ -2,6 +2,7 @@
 
 import logging
 import copy
+import time
 
 from django.core.management import BaseCommand
 from registrar.models import TransitionDomain
@@ -112,6 +113,9 @@ class Command(BaseCommand):
         if len(self.emails_to_send) > 0:
             for email_data in self.emails_to_send:
                 self.send_email(email_data)
+                # wait 1/10 second until sending the next email to keep us
+                # safely under a rate of 10 emails per second
+                time.sleep(0.1)
         else:
             logger.info("no emails to send")
 

--- a/src/registrar/tests/test_transition_domain_migrations.py
+++ b/src/registrar/tests/test_transition_domain_migrations.py
@@ -13,8 +13,6 @@ from registrar.models import (
     UserDomainRole,
 )
 
-import boto3_mocking  # type: ignore
-
 from django.core.management import call_command
 from unittest.mock import patch
 
@@ -415,15 +413,3 @@ class TestMigrations(TestCase):
         self.assertIn("Found 2 transition domains", output)
         self.assertTrue("would send email to testuser@gmail.com", output)
         self.assertTrue("would send email to agustina.wyman7@test.com", output)
-
-    # this tries to actually send an email, so mock it out
-    @boto3_mocking.patching
-    def test_send_domain_invitations_email_sent(self):
-        """A transition domain is marked email_sent."""
-        with less_console_noise():
-            self.run_load_domains()
-            self.run_transfer_domains()
-            call_command("send_domain_invitations", "-s", "testuser@gmail.com")
-
-        self.assertTrue(TransitionDomain.objects.get(username="testuser@gmail.com").email_sent)
-        self.assertFalse(TransitionDomain.objects.get(username="agustina.wyman7@test.com").email_sent)

--- a/src/registrar/tests/test_transition_domain_migrations.py
+++ b/src/registrar/tests/test_transition_domain_migrations.py
@@ -13,6 +13,8 @@ from registrar.models import (
     UserDomainRole,
 )
 
+import boto3_mocking  # type: ignore
+
 from django.core.management import call_command
 from unittest.mock import patch
 
@@ -413,3 +415,15 @@ class TestMigrations(TestCase):
         self.assertIn("Found 2 transition domains", output)
         self.assertTrue("would send email to testuser@gmail.com", output)
         self.assertTrue("would send email to agustina.wyman7@test.com", output)
+
+    # this tries to actually send an email, so mock it out
+    @boto3_mocking.patching
+    def test_send_domain_invitations_email_sent(self):
+        """A transition domain is marked email_sent."""
+        with less_console_noise():
+            self.run_load_domains()
+            self.run_transfer_domains()
+            call_command("send_domain_invitations", "-s", "testuser@gmail.com")
+
+        self.assertTrue(TransitionDomain.objects.get(username="testuser@gmail.com").email_sent)
+        self.assertFalse(TransitionDomain.objects.get(username="agustina.wyman7@test.com").email_sent)


### PR DESCRIPTION
## Changes

When we are sending domain invitation emails, we want to mark each transition domain as `email_sent=True` as we go so that we can stop the script and start it again without sending any duplicate emails.

## Context for reviewers

In testing today, we sent more than 500 emails, then CTRL-C to stop the `send_domain_invitations` command and none of the domain invitations that were sent were marked in the database as `email_sent` because of how we were doing that at the end rather than as we went. This takes care of that.

## Setup

The easiest way to test this is to use the test data in registrar/tests/data/test_*.txt:

```
$ docker compose run app ./manage.py load_transition_domain.py registrar/tests/data/test_domain_contacts.txt registrar/tests/data/test_contacts.txt registrar/tests/data/test_domain_statuses.txt
$ docker compose run app ./manage.py transfer_transition_domains_to_domains
$ docker compose run app ./manage.py send_domain_invitations -s susy.martin4@test.com
```

Then check in the Django Admin or in `manage.py shell` that the transition domain for that email address has `email_sent=True`.

## Code Review Verification Steps

### As the original developer, I have

#### Satisfied acceptance criteria and met development standards

- [X] Met the acceptance criteria, or will meet them in a subsequent PR
- [X] Created/modified automated tests
- [X] Added at least 2 developers as PR reviewers (only 1 will need to approve)
- [X] Messaged on Slack or in standup to notify the team that a PR is ready for review

#### Ensured code standards are met (Original Developer)

- [X] All new functions and methods are commented using plain language

### As a code reviewer, I have

#### Reviewed, tested, and left feedback about the changes

- [ ] Pulled this branch locally and tested it
- [ ] Reviewed this code and left comments
- [ ] Checked that all code is adequately covered by tests
- [ ] Made it clear which comments need to be addressed before this work is merged
- [ ] If any model was updated to modify/add/delete columns, makemigrations was ran and the assoicated migrations file has been commited.

#### Ensured code standards are met (Code reviewer)

- [ ] All new functions and methods are commented using plain language
- [ ] Interactions with external systems are wrapped in try/except
- [ ] Error handling exists for unusual or missing values
- [ ] (Rarely needed) Did dependency updates in Pipfile also get changed in requirements.txt?
