### PR TITLE
Issue #1235 - error handling for generic error messages in 3 forms

### DIFF
--- a/src/registrar/tests/test_views.py
+++ b/src/registrar/tests/test_views.py
@@ -1743,7 +1743,7 @@ contact help@get.gov
             (
                 "ContactError",
                 form_data_contact_error,
-                "Enter an email address in the required format, like name@example.com."
+                "Enter an email address in the required format, like name@example.com.",
             ),
             (
                 "RegistrySuccess",

--- a/src/registrar/tests/test_views.py
+++ b/src/registrar/tests/test_views.py
@@ -1740,7 +1740,11 @@ and try again. If you continue to receive this error after a few tries,
 contact help@get.gov
                 """,
             ),
-            ("ContactError", form_data_contact_error, "Value entered was wrong."),
+            (
+                "ContactError",
+                form_data_contact_error,
+                "Enter an email address in the required format, like name@example.com."
+            ),
             (
                 "RegistrySuccess",
                 form_data_success,

--- a/src/registrar/tests/test_views.py
+++ b/src/registrar/tests/test_views.py
@@ -13,6 +13,10 @@ import boto3_mocking  # type: ignore
 from registrar.utility.errors import (
     NameserverError,
     NameserverErrorCodes,
+    SecurityEmailError,
+    SecurityEmailErrorCodes,
+    GenericError,
+    GenericErrorCodes,
 )
 
 from registrar.models import (
@@ -1734,16 +1738,12 @@ class TestDomainSecurityEmail(TestDomainOverview):
             (
                 "RegistryError",
                 form_data_registry_error,
-                """
-We’re experiencing a system connection error. Please wait a few minutes
-and try again. If you continue to receive this error after a few tries,
-contact help@get.gov
-                """,
+                str(GenericError(code=GenericErrorCodes.CANNOT_CONTACT_REGISTRY)),
             ),
             (
                 "ContactError",
                 form_data_contact_error,
-                "Enter an email address in the required format, like name@example.com.",
+                str(SecurityEmailError(code=SecurityEmailErrorCodes.BAD_DATA)),
             ),
             (
                 "RegistrySuccess",

--- a/src/registrar/utility/errors.py
+++ b/src/registrar/utility/errors.py
@@ -99,7 +99,8 @@ class NameserverError(Exception):
         NameserverErrorCodes.MISSING_HOST: ("Name server must be provided to enter IP address."),
         NameserverErrorCodes.INVALID_HOST: ("Enter a name server in the required format, like ns1.example.com"),
         NameserverErrorCodes.BAD_DATA: (
-            "There’s something wrong with the name server information you provided. If you need help email us at help@get.gov."
+            "There’s something wrong with the name server information you provided. "
+            "If you need help email us at help@get.gov."
         ),
     }
 

--- a/src/registrar/utility/errors.py
+++ b/src/registrar/utility/errors.py
@@ -69,6 +69,7 @@ class NameserverErrorCodes(IntEnum):
         - 5 UNABLE_TO_UPDATE_DOMAIN unable to update the domain
         - 6 MISSING_HOST host is missing for a nameserver
         - 7 INVALID_HOST host is invalid for a nameserver
+        - 8 BAD_DATA bad data input for nameserver
     """
 
     MISSING_IP = 1
@@ -78,6 +79,7 @@ class NameserverErrorCodes(IntEnum):
     UNABLE_TO_UPDATE_DOMAIN = 5
     MISSING_HOST = 6
     INVALID_HOST = 7
+    BAD_DATA = 8
 
 
 class NameserverError(Exception):
@@ -96,6 +98,9 @@ class NameserverError(Exception):
         ),
         NameserverErrorCodes.MISSING_HOST: ("Name server must be provided to enter IP address."),
         NameserverErrorCodes.INVALID_HOST: ("Enter a name server in the required format, like ns1.example.com"),
+        NameserverErrorCodes.BAD_DATA: (
+            "There’s something wrong with the name server information you provided. If you need help email us at help@get.gov."
+        ),
     }
 
     def __init__(self, *args, code=None, nameserver=None, ip=None, **kwargs):
@@ -109,6 +114,68 @@ class NameserverError(Exception):
                 self.message = self.message.format(str(nameserver))
             elif ip is not None:
                 self.message = self.message.format(str(ip))
+
+    def __str__(self):
+        return f"{self.message}"
+
+
+class DsDataErrorCodes(IntEnum):
+    """Used in the DsDataError class for
+    error mapping.
+    Overview of ds data error codes:
+        - 1 BAD_DATA  bad data input in ds data
+    """
+
+    BAD_DATA = 1
+
+
+class DsDataError(Exception):
+    """
+    DsDataError class used to raise exceptions on
+    the ds data getter
+    """
+
+    _error_mapping = {
+        DsDataErrorCodes.BAD_DATA: (
+            "There’s something wrong with the DS data you provided. If you need help email us at help@get.gov."
+        )
+    }
+
+    def __init__(self, *args, code=None, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.code = code
+        if self.code in self._error_mapping:
+            self.message = self._error_mapping.get(self.code)
+
+    def __str__(self):
+        return f"{self.message}"
+
+
+class SecurityEmailErrorCodes(IntEnum):
+    """Used in the SecurityEmailError class for
+    error mapping.
+    Overview of security email error codes:
+        - 1 BAD_DATA  bad data input in security email
+    """
+
+    BAD_DATA = 1
+
+
+class SecurityEmailError(Exception):
+    """
+    SecurityEmailError class used to raise exceptions on
+    the security email form
+    """
+
+    _error_mapping = {
+        SecurityEmailErrorCodes.BAD_DATA: ("Enter an email address in the required format, like name@example.com.")
+    }
+
+    def __init__(self, *args, code=None, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.code = code
+        if self.code in self._error_mapping:
+            self.message = self._error_mapping.get(self.code)
 
     def __str__(self):
         return f"{self.message}"

--- a/src/registrar/views/domain.py
+++ b/src/registrar/views/domain.py
@@ -28,6 +28,10 @@ from registrar.utility.errors import (
     GenericErrorCodes,
     NameserverError,
     NameserverErrorCodes as nsErrorCodes,
+    DsDataError,
+    DsDataErrorCodes,
+    SecurityEmailError,
+    SecurityEmailErrorCodes,
 )
 from registrar.models.utility.contact_error import ContactError
 
@@ -315,7 +319,7 @@ class DomainNameserversView(DomainFormBaseView):
                 )
                 logger.error(f"Registry connection error: {Err}")
             else:
-                messages.error(self.request, GenericError(code=GenericErrorCodes.GENERIC_ERROR))
+                messages.error(self.request, NameserverError(code=nsErrorCodes.BAD_DATA))
                 logger.error(f"Registry error: {Err}")
         else:
             messages.success(
@@ -491,7 +495,7 @@ class DomainDsDataView(DomainFormBaseView):
                 )
                 logger.error(f"Registry connection error: {err}")
             else:
-                messages.error(self.request, GenericError(code=GenericErrorCodes.GENERIC_ERROR))
+                messages.error(self.request, DsDataError(code=DsDataErrorCodes.BAD_DATA))
                 logger.error(f"Registry error: {err}")
             return self.form_invalid(formset)
         else:
@@ -581,10 +585,10 @@ class DomainSecurityEmailView(DomainFormBaseView):
                 )
                 logger.error(f"Registry connection error: {Err}")
             else:
-                messages.error(self.request, GenericError(code=GenericErrorCodes.GENERIC_ERROR))
+                messages.error(self.request, SecurityEmailError(code=SecurityEmailErrorCodes.BAD_DATA))
                 logger.error(f"Registry error: {Err}")
         except ContactError as Err:
-            messages.error(self.request, GenericError(code=GenericErrorCodes.GENERIC_ERROR))
+            messages.error(self.request, SecurityEmailError(code=SecurityEmailErrorCodes.BAD_DATA))
             logger.error(f"Generic registry error: {Err}")
         else:
             messages.success(self.request, "The security email for this domain has been updated.")


### PR DESCRIPTION
## Ticket

Resolves #1235 

<!--Reminder, when a code change is made that is user facing, beyond content updates, then the following are required:
- a developer approves the PR
- a designer approves the PR or checks off all relevant items in this checklist.

All other changes require just a single approving review.-->

## Changes

<!-- What was added, updated, or removed in this PR. -->
- Generic error messages updated for Nameserver, DS Data and Security Email forms.
- Nameserver message is now: There’s something wrong with the name server information you provided. If you need help email us at help@get.gov.  
- DS Data message is now: There’s something wrong with the DS data you provided. If you need help email us at help@get.gov.
- Security Email message is now: Enter an email address in the required format, like name@example.com.

<!--
    Please add/remove/edit any of the template below to fit the needs
    of this specific PR.
--->

## Context for reviewers

<!--Background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers.  -->

Can currently be tested in [BL Sandbox](https://getgov-bl.app.cloud.gov/)

It is a bit difficult to produce these generic messages because they only occur in edge cases where there is either bad data that is not accounted for in form and field level error handling already, or when there is an error from EPP that is not a connection error.

Not certain how to reproduce generic DNSSEC DS data message, as known error conditions are all caught

Not certain how to reproduce nameserver message, as known error conditions are all caught

To reproduce security email message, go to security email form on a domain management screen.  Enter an invalid email address.

## Setup

<!--  Add any steps or code to run in this section to help others run your code.
    
    Example 1:
    ```sh
    echo "Code goes here"
    ``` 
    
    Example 2: If the PR was to add a new link with a redirect, this section could simply be:
    -go to /path/to/start/page
    -click the blue link in the <insert location>
    -notice user is redirected to <proper end location>
-->

## Code Review Verification Steps

### As the original developer, I have

#### Satisfied acceptance criteria and met development standards

- [ ] Met the acceptance criteria, or will meet them in a subsequent PR
- [ ] Created/modified automated tests
- [ ] Added at least 2 developers as PR reviewers (only 1 will need to approve)
- [ ] Messaged on Slack or in standup to notify the team that a PR is ready for review
- [ ] Changes to “how we do things” are documented in READMEs and or onboarding guide
- [ ] If any model was updated to modify/add/delete columns, makemigrations was ran and the assoicated migrations file has been commited.

#### Ensured code standards are met (Original Developer)

- [ ] All new functions and methods are commented using plain language
- [ ] Did dependency updates in Pipfile also get changed in requirements.txt?
- [ ] Interactions with external systems are wrapped in try/except
- [ ] Error handling exists for unusual or missing values

#### Validated user-facing changes (if applicable)

- [ ] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Checked keyboard navigability
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)
- [ ] Add at least 1 designer as PR reviewer

### As a code reviewer, I have

#### Reviewed, tested, and left feedback about the changes

- [x] Pulled this branch locally and tested it
- [x] Reviewed this code and left comments
- [x] Checked that all code is adequately covered by tests
- [x] Made it clear which comments need to be addressed before this work is merged
- [ ] If any model was updated to modify/add/delete columns, makemigrations was ran and the assoicated migrations file has been commited.

#### Ensured code standards are met (Code reviewer)

- [x] All new functions and methods are commented using plain language
- [ ] Interactions with external systems are wrapped in try/except
- [ ] Error handling exists for unusual or missing values
- [ ] (Rarely needed) Did dependency updates in Pipfile also get changed in requirements.txt?

#### Validated user-facing changes as a developer

- [ ] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [x] Checked keyboard navigability
- [x] Meets all designs and user flows provided by design/product
- [x] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)

- [ ] Tested with multiple browsers, the suggestion is to use ones that the developer didn't (check off which ones were used)
  - [x] Chrome
  - [ ] Microsoft Edge
  - [x] FireFox
  - [ ] Safari

- [ ] (Rarely needed) Tested as both an analyst and applicant user

**Note:** Multiple code reviewers can share the checklists above, a second reviewers should not make a duplicate checklist

### As a designer reviewer, I have

#### Verified that the changes match the design intention

- [ ] Checked that the design translated visually
- [ ] Checked behavior
- [ ] Checked different states (empty, one, some, error)
- [ ] Checked for landmarks, page heading structure, and links
- [ ] Tried to break the intended flow

#### Validated user-facing changes as a designer

- [ ] Checked keyboard navigability
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)

- [ ] Tested with multiple browsers (check off which ones were used)
  - [ ] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari

- [ ] (Rarely needed) Tested as both an analyst and applicant user

## Screenshots

<!-- If this PR makes visible interface changes, an image of the finished interface can help reviewers
and casual observers understand the context of the changes.
A before image is optional and can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow.
You may want to use [GIPHY Capture](https://giphy.com/apps/giphycapture) for this! 📸

_Please frame images to show useful context but also highlight the affected regions._
--->
