### PR TITLE
Issue #1208 - DNSSEC additional items

### DIFF
--- a/src/registrar/forms/domain.py
+++ b/src/registrar/forms/domain.py
@@ -233,6 +233,12 @@ class DomainDsdataForm(forms.Form):
     """Form for adding or editing DNSSEC DS Data to a domain."""
 
     def validate_hexadecimal(value):
+        """
+        Tests that string matches all hexadecimal values.
+        
+        Raise validation error to display error in form
+        if invalid caracters entered
+        """
         if not re.match(r"^[0-9a-fA-F]+$", value):
             raise forms.ValidationError(str(DsDataError(code=DsDataErrorCodes.INVALID_DIGEST_CHARS)))
 

--- a/src/registrar/forms/domain.py
+++ b/src/registrar/forms/domain.py
@@ -235,7 +235,7 @@ class DomainDsdataForm(forms.Form):
     def validate_hexadecimal(value):
         """
         Tests that string matches all hexadecimal values.
-        
+
         Raise validation error to display error in form
         if invalid caracters entered
         """

--- a/src/registrar/forms/domain.py
+++ b/src/registrar/forms/domain.py
@@ -162,8 +162,8 @@ class DomainSecurityEmailForm(forms.Form):
         label="Security email",
         required=False,
         error_messages={
-            'invalid': str(SecurityEmailError(code=SecurityEmailErrorCodes.BAD_DATA)),
-        }
+            "invalid": str(SecurityEmailError(code=SecurityEmailErrorCodes.BAD_DATA)),
+        },
     )
 
 

--- a/src/registrar/forms/domain.py
+++ b/src/registrar/forms/domain.py
@@ -280,10 +280,8 @@ class DomainDsdataForm(forms.Form):
         required=True,
         label="Digest",
         validators=[validate_hexadecimal],
-        max_length=64,
         error_messages={
             "required": "Digest is required.",
-            "max_length": str(DsDataError(code=DsDataErrorCodes.INVALID_DIGEST_LENGTH)),
         },
     )
 

--- a/src/registrar/forms/domain.py
+++ b/src/registrar/forms/domain.py
@@ -10,6 +10,8 @@ from registrar.utility.errors import (
     NameserverErrorCodes as nsErrorCodes,
     DsDataError,
     DsDataErrorCodes,
+    SecurityEmailError,
+    SecurityEmailErrorCodes,
 )
 
 from ..models import Contact, DomainInformation, Domain
@@ -156,7 +158,13 @@ class ContactForm(forms.ModelForm):
 class DomainSecurityEmailForm(forms.Form):
     """Form for adding or editing a security email to a domain."""
 
-    security_email = forms.EmailField(label="Security email", required=False)
+    security_email = forms.EmailField(
+        label="Security email",
+        required=False,
+        error_messages={
+            'invalid': str(SecurityEmailError(code=SecurityEmailErrorCodes.BAD_DATA)),
+        }
+    )
 
 
 class DomainOrgNameAddressForm(forms.ModelForm):
@@ -237,7 +245,7 @@ class DomainDsdataForm(forms.Form):
         Tests that string matches all hexadecimal values.
 
         Raise validation error to display error in form
-        if invalid caracters entered
+        if invalid characters entered
         """
         if not re.match(r"^[0-9a-fA-F]+$", value):
             raise forms.ValidationError(str(DsDataError(code=DsDataErrorCodes.INVALID_DIGEST_CHARS)))

--- a/src/registrar/forms/domain.py
+++ b/src/registrar/forms/domain.py
@@ -233,7 +233,7 @@ class DomainDsdataForm(forms.Form):
     """Form for adding or editing DNSSEC DS Data to a domain."""
 
     def validate_hexadecimal(value):
-        if not re.match(r'^[0-9a-fA-F]+$', value):
+        if not re.match(r"^[0-9a-fA-F]+$", value):
             raise forms.ValidationError(str(DsDataError(code=DsDataErrorCodes.INVALID_DIGEST_CHARS)))
 
     key_tag = forms.IntegerField(

--- a/src/registrar/models/domain.py
+++ b/src/registrar/models/domain.py
@@ -598,7 +598,7 @@ class Domain(TimeStampedModel, DomainHelper):
 
         # if unable to update domain raise error and stop
         if responseCode != ErrorCode.COMMAND_COMPLETED_SUCCESSFULLY:
-            raise NameserverError(code=nsErrorCodes.UNABLE_TO_UPDATE_DOMAIN)
+            raise NameserverError(code=nsErrorCodes.BAD_DATA)
 
         successTotalNameservers = len(oldNameservers) - deleteCount + addToDomainCount
 

--- a/src/registrar/templates/domain_dsdata.html
+++ b/src/registrar/templates/domain_dsdata.html
@@ -114,7 +114,7 @@
     aria-describedby="Your DNSSEC records will be deleted from the registry."
     data-force-action
   >
-      {% include 'includes/modal.html' with cancel_button_resets_ds_form=True modal_heading="Warning: You are about to delete all DS records on your domain" modal_description="To fully disable DNSSEC: In addition to deleting your DS records here you’ll also need to delete the DS records at your DNS host. To avoid causing your domain to appear offline you should wait to delete your DS records at your DNS host until the Time to Live (TTL) expires. This is often less than 24 hours, but confirm with your provider." modal_button=modal_button|safe %}
+      {% include 'includes/modal.html' with cancel_button_resets_ds_form=True modal_heading="Warning: You are about to remove all DS records on your domain" modal_description="To fully disable DNSSEC: In addition to removing your DS records here you’ll also need to delete the DS records at your DNS host. To avoid causing your domain to appear offline you should wait to delete your DS records at your DNS host until the Time to Live (TTL) expires. This is often less than 24 hours, but confirm with your provider." modal_button=modal_button|safe %}
   </div>
 
 {% endblock %}  {# domain_content #}

--- a/src/registrar/tests/test_views.py
+++ b/src/registrar/tests/test_views.py
@@ -1925,7 +1925,6 @@ class TestDomainDNSSEC(TestDomainOverview):
             result, str(DsDataError(code=DsDataErrorCodes.INVALID_KEYTAG_SIZE)), count=2, status_code=200
         )
 
-
     def test_ds_data_form_invalid_digest_chars(self):
         """DS Data form errors with invalid data (digest contains non hexadecimal chars)
 

--- a/src/registrar/tests/test_views.py
+++ b/src/registrar/tests/test_views.py
@@ -17,6 +17,8 @@ from registrar.utility.errors import (
     SecurityEmailErrorCodes,
     GenericError,
     GenericErrorCodes,
+    DsDataError,
+    DsDataErrorCodes,
 )
 
 from registrar.models import (
@@ -1878,7 +1880,30 @@ class TestDomainDNSSEC(TestDomainOverview):
         self.assertContains(page, "The DS Data records for this domain have been updated.")
 
     def test_ds_data_form_invalid(self):
-        """DS Data form errors with invalid data
+        """DS Data form errors with invalid data (missing required fields)
+
+        Uses self.app WebTest because we need to interact with forms.
+        """
+        add_data_page = self.app.get(reverse("domain-dns-dnssec-dsdata", kwargs={"pk": self.domain_dsdata.id}))
+        session_id = self.app.cookies[settings.SESSION_COOKIE_NAME]
+        self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
+        # all four form fields are required, so will test with each blank
+        add_data_page.forms[0]["form-0-key_tag"] = ""
+        add_data_page.forms[0]["form-0-algorithm"] = ""
+        add_data_page.forms[0]["form-0-digest_type"] = ""
+        add_data_page.forms[0]["form-0-digest"] = ""
+        with less_console_noise():  # swallow logged warning message
+            result = add_data_page.forms[0].submit()
+        # form submission was a post with an error, response should be a 200
+        # error text appears twice, once at the top of the page, once around
+        # the field.
+        self.assertContains(result, "Key tag is required", count=2, status_code=200)
+        self.assertContains(result, "Algorithm is required", count=2, status_code=200)
+        self.assertContains(result, "Digest type is required", count=2, status_code=200)
+        self.assertContains(result, "Digest is required", count=2, status_code=200)
+
+    def test_ds_data_form_invalid_keytag(self):
+        """DS Data form errors with invalid data (key tag too large)
 
         Uses self.app WebTest because we need to interact with forms.
         """
@@ -1887,13 +1912,100 @@ class TestDomainDNSSEC(TestDomainOverview):
         self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
         # first two nameservers are required, so if we empty one out we should
         # get a form error
-        add_data_page.forms[0]["form-0-key_tag"] = ""
+        add_data_page.forms[0]["form-0-key_tag"] = "65536"  # > 65535
+        add_data_page.forms[0]["form-0-algorithm"] = ""
+        add_data_page.forms[0]["form-0-digest_type"] = ""
+        add_data_page.forms[0]["form-0-digest"] = ""
         with less_console_noise():  # swallow logged warning message
             result = add_data_page.forms[0].submit()
         # form submission was a post with an error, response should be a 200
         # error text appears twice, once at the top of the page, once around
         # the field.
-        self.assertContains(result, "Key tag is required", count=2, status_code=200)
+        self.assertContains(result, str(DsDataError(code=DsDataErrorCodes.INVALID_KEYTAG_SIZE)), count=2, status_code=200)
+
+    def test_ds_data_form_invalid_digest_length(self):
+        """DS Data form errors with invalid data (digest too long)
+
+        Uses self.app WebTest because we need to interact with forms.
+        """
+        add_data_page = self.app.get(reverse("domain-dns-dnssec-dsdata", kwargs={"pk": self.domain_dsdata.id}))
+        session_id = self.app.cookies[settings.SESSION_COOKIE_NAME]
+        self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
+        # first two nameservers are required, so if we empty one out we should
+        # get a form error
+        add_data_page.forms[0]["form-0-key_tag"] = "1234"
+        add_data_page.forms[0]["form-0-algorithm"] = "3"
+        add_data_page.forms[0]["form-0-digest_type"] = "1"
+        add_data_page.forms[0]["form-0-digest"] = "1234567890123456789012345678901234567890123456789012345678901234567890"
+        with less_console_noise():  # swallow logged warning message
+            result = add_data_page.forms[0].submit()
+        # form submission was a post with an error, response should be a 200
+        # error text appears twice, once at the top of the page, once around
+        # the field.
+        self.assertContains(result, str(DsDataError(code=DsDataErrorCodes.INVALID_DIGEST_LENGTH)), count=2, status_code=200)
+
+    def test_ds_data_form_invalid_digest_chars(self):
+        """DS Data form errors with invalid data (digest contains non hexadecimal chars)
+
+        Uses self.app WebTest because we need to interact with forms.
+        """
+        add_data_page = self.app.get(reverse("domain-dns-dnssec-dsdata", kwargs={"pk": self.domain_dsdata.id}))
+        session_id = self.app.cookies[settings.SESSION_COOKIE_NAME]
+        self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
+        # first two nameservers are required, so if we empty one out we should
+        # get a form error
+        add_data_page.forms[0]["form-0-key_tag"] = "1234"
+        add_data_page.forms[0]["form-0-algorithm"] = "3"
+        add_data_page.forms[0]["form-0-digest_type"] = "1"
+        add_data_page.forms[0]["form-0-digest"] = "GG1234"
+        with less_console_noise():  # swallow logged warning message
+            result = add_data_page.forms[0].submit()
+        # form submission was a post with an error, response should be a 200
+        # error text appears twice, once at the top of the page, once around
+        # the field.
+        self.assertContains(result, str(DsDataError(code=DsDataErrorCodes.INVALID_DIGEST_CHARS)), count=2, status_code=200)
+
+    def test_ds_data_form_invalid_digest_sha1(self):
+        """DS Data form errors with invalid data (digest is invalid sha-1)
+
+        Uses self.app WebTest because we need to interact with forms.
+        """
+        add_data_page = self.app.get(reverse("domain-dns-dnssec-dsdata", kwargs={"pk": self.domain_dsdata.id}))
+        session_id = self.app.cookies[settings.SESSION_COOKIE_NAME]
+        self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
+        # first two nameservers are required, so if we empty one out we should
+        # get a form error
+        add_data_page.forms[0]["form-0-key_tag"] = "1234"
+        add_data_page.forms[0]["form-0-algorithm"] = "3"
+        add_data_page.forms[0]["form-0-digest_type"] = "1"  # SHA-1
+        add_data_page.forms[0]["form-0-digest"] = "A123"
+        with less_console_noise():  # swallow logged warning message
+            result = add_data_page.forms[0].submit()
+        # form submission was a post with an error, response should be a 200
+        # error text appears twice, once at the top of the page, once around
+        # the field.
+        self.assertContains(result, str(DsDataError(code=DsDataErrorCodes.INVALID_DIGEST_SHA1)), count=2, status_code=200)
+
+    def test_ds_data_form_invalid_digest_sha256(self):
+        """DS Data form errors with invalid data (digest is invalid sha-256)
+
+        Uses self.app WebTest because we need to interact with forms.
+        """
+        add_data_page = self.app.get(reverse("domain-dns-dnssec-dsdata", kwargs={"pk": self.domain_dsdata.id}))
+        session_id = self.app.cookies[settings.SESSION_COOKIE_NAME]
+        self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
+        # first two nameservers are required, so if we empty one out we should
+        # get a form error
+        add_data_page.forms[0]["form-0-key_tag"] = "1234"
+        add_data_page.forms[0]["form-0-algorithm"] = "3"
+        add_data_page.forms[0]["form-0-digest_type"] = "2"  # SHA-256
+        add_data_page.forms[0]["form-0-digest"] = "GG1234"
+        with less_console_noise():  # swallow logged warning message
+            result = add_data_page.forms[0].submit()
+        # form submission was a post with an error, response should be a 200
+        # error text appears twice, once at the top of the page, once around
+        # the field.
+        self.assertContains(result, str(DsDataError(code=DsDataErrorCodes.INVALID_DIGEST_SHA256)), count=2, status_code=200)
 
 
 class TestApplicationStatus(TestWithUser, WebTest):

--- a/src/registrar/tests/test_views.py
+++ b/src/registrar/tests/test_views.py
@@ -1925,30 +1925,6 @@ class TestDomainDNSSEC(TestDomainOverview):
             result, str(DsDataError(code=DsDataErrorCodes.INVALID_KEYTAG_SIZE)), count=2, status_code=200
         )
 
-    def test_ds_data_form_invalid_digest_length(self):
-        """DS Data form errors with invalid data (digest too long)
-
-        Uses self.app WebTest because we need to interact with forms.
-        """
-        add_data_page = self.app.get(reverse("domain-dns-dnssec-dsdata", kwargs={"pk": self.domain_dsdata.id}))
-        session_id = self.app.cookies[settings.SESSION_COOKIE_NAME]
-        self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
-        # first two nameservers are required, so if we empty one out we should
-        # get a form error
-        add_data_page.forms[0]["form-0-key_tag"] = "1234"
-        add_data_page.forms[0]["form-0-algorithm"] = "3"
-        add_data_page.forms[0]["form-0-digest_type"] = "1"
-        add_data_page.forms[0][
-            "form-0-digest"
-        ] = "1234567890123456789012345678901234567890123456789012345678901234567890"
-        with less_console_noise():  # swallow logged warning message
-            result = add_data_page.forms[0].submit()
-        # form submission was a post with an error, response should be a 200
-        # error text appears twice, once at the top of the page, once around
-        # the field.
-        self.assertContains(
-            result, str(DsDataError(code=DsDataErrorCodes.INVALID_DIGEST_LENGTH)), count=2, status_code=200
-        )
 
     def test_ds_data_form_invalid_digest_chars(self):
         """DS Data form errors with invalid data (digest contains non hexadecimal chars)

--- a/src/registrar/tests/test_views.py
+++ b/src/registrar/tests/test_views.py
@@ -1921,7 +1921,9 @@ class TestDomainDNSSEC(TestDomainOverview):
         # form submission was a post with an error, response should be a 200
         # error text appears twice, once at the top of the page, once around
         # the field.
-        self.assertContains(result, str(DsDataError(code=DsDataErrorCodes.INVALID_KEYTAG_SIZE)), count=2, status_code=200)
+        self.assertContains(
+            result, str(DsDataError(code=DsDataErrorCodes.INVALID_KEYTAG_SIZE)), count=2, status_code=200
+        )
 
     def test_ds_data_form_invalid_digest_length(self):
         """DS Data form errors with invalid data (digest too long)
@@ -1936,13 +1938,17 @@ class TestDomainDNSSEC(TestDomainOverview):
         add_data_page.forms[0]["form-0-key_tag"] = "1234"
         add_data_page.forms[0]["form-0-algorithm"] = "3"
         add_data_page.forms[0]["form-0-digest_type"] = "1"
-        add_data_page.forms[0]["form-0-digest"] = "1234567890123456789012345678901234567890123456789012345678901234567890"
+        add_data_page.forms[0][
+            "form-0-digest"
+        ] = "1234567890123456789012345678901234567890123456789012345678901234567890"
         with less_console_noise():  # swallow logged warning message
             result = add_data_page.forms[0].submit()
         # form submission was a post with an error, response should be a 200
         # error text appears twice, once at the top of the page, once around
         # the field.
-        self.assertContains(result, str(DsDataError(code=DsDataErrorCodes.INVALID_DIGEST_LENGTH)), count=2, status_code=200)
+        self.assertContains(
+            result, str(DsDataError(code=DsDataErrorCodes.INVALID_DIGEST_LENGTH)), count=2, status_code=200
+        )
 
     def test_ds_data_form_invalid_digest_chars(self):
         """DS Data form errors with invalid data (digest contains non hexadecimal chars)
@@ -1963,7 +1969,9 @@ class TestDomainDNSSEC(TestDomainOverview):
         # form submission was a post with an error, response should be a 200
         # error text appears twice, once at the top of the page, once around
         # the field.
-        self.assertContains(result, str(DsDataError(code=DsDataErrorCodes.INVALID_DIGEST_CHARS)), count=2, status_code=200)
+        self.assertContains(
+            result, str(DsDataError(code=DsDataErrorCodes.INVALID_DIGEST_CHARS)), count=2, status_code=200
+        )
 
     def test_ds_data_form_invalid_digest_sha1(self):
         """DS Data form errors with invalid data (digest is invalid sha-1)
@@ -1984,7 +1992,9 @@ class TestDomainDNSSEC(TestDomainOverview):
         # form submission was a post with an error, response should be a 200
         # error text appears twice, once at the top of the page, once around
         # the field.
-        self.assertContains(result, str(DsDataError(code=DsDataErrorCodes.INVALID_DIGEST_SHA1)), count=2, status_code=200)
+        self.assertContains(
+            result, str(DsDataError(code=DsDataErrorCodes.INVALID_DIGEST_SHA1)), count=2, status_code=200
+        )
 
     def test_ds_data_form_invalid_digest_sha256(self):
         """DS Data form errors with invalid data (digest is invalid sha-256)
@@ -2005,7 +2015,9 @@ class TestDomainDNSSEC(TestDomainOverview):
         # form submission was a post with an error, response should be a 200
         # error text appears twice, once at the top of the page, once around
         # the field.
-        self.assertContains(result, str(DsDataError(code=DsDataErrorCodes.INVALID_DIGEST_SHA256)), count=2, status_code=200)
+        self.assertContains(
+            result, str(DsDataError(code=DsDataErrorCodes.INVALID_DIGEST_SHA256)), count=2, status_code=200
+        )
 
 
 class TestApplicationStatus(TestWithUser, WebTest):

--- a/src/registrar/utility/errors.py
+++ b/src/registrar/utility/errors.py
@@ -125,9 +125,19 @@ class DsDataErrorCodes(IntEnum):
     error mapping.
     Overview of ds data error codes:
         - 1 BAD_DATA  bad data input in ds data
+        - 2 INVALID_DIGEST_SHA1 invalid digest for digest type SHA-1
+        - 3 INVALID_DIGEST_SHA256 invalid digest for digest type SHA-256
+        - 4 INVALID_DIGEST_LENGTH invalid digest length exceeds 64
+        - 5 INVALID_DIGEST_CHARS invalid chars in digest
+        - 6 INVALID_KEYTAG_SIZE invalid key tag size > 65535
     """
 
     BAD_DATA = 1
+    INVALID_DIGEST_SHA1 = 2
+    INVALID_DIGEST_SHA256 = 3
+    INVALID_DIGEST_LENGTH = 4
+    INVALID_DIGEST_CHARS = 5
+    INVALID_KEYTAG_SIZE = 6
 
 
 class DsDataError(Exception):
@@ -139,7 +149,22 @@ class DsDataError(Exception):
     _error_mapping = {
         DsDataErrorCodes.BAD_DATA: (
             "There’s something wrong with the DS data you provided. If you need help email us at help@get.gov."
-        )
+        ),
+        DsDataErrorCodes.INVALID_DIGEST_SHA1: (
+            "SHA-1 digest must be exactly 40 characters."
+        ),
+        DsDataErrorCodes.INVALID_DIGEST_SHA256: (
+            "SHA-256 digest must be exactly 64 characters."
+        ),
+        DsDataErrorCodes.INVALID_DIGEST_LENGTH: (
+            "Digest must be at most 64 characters."
+        ),
+        DsDataErrorCodes.INVALID_DIGEST_CHARS: (
+            "Digest must contain only alphanumeric characters [0-9,a-f]."
+        ),
+        DsDataErrorCodes.INVALID_KEYTAG_SIZE: (
+            "Key tag must be less than 65535"
+        ),
     }
 
     def __init__(self, *args, code=None, **kwargs):

--- a/src/registrar/utility/errors.py
+++ b/src/registrar/utility/errors.py
@@ -122,17 +122,15 @@ class DsDataErrorCodes(IntEnum):
         - 1 BAD_DATA  bad data input in ds data
         - 2 INVALID_DIGEST_SHA1 invalid digest for digest type SHA-1
         - 3 INVALID_DIGEST_SHA256 invalid digest for digest type SHA-256
-        - 4 INVALID_DIGEST_LENGTH invalid digest length exceeds 64
-        - 5 INVALID_DIGEST_CHARS invalid chars in digest
-        - 6 INVALID_KEYTAG_SIZE invalid key tag size > 65535
+        - 4 INVALID_DIGEST_CHARS invalid chars in digest
+        - 5 INVALID_KEYTAG_SIZE invalid key tag size > 65535
     """
 
     BAD_DATA = 1
     INVALID_DIGEST_SHA1 = 2
     INVALID_DIGEST_SHA256 = 3
-    INVALID_DIGEST_LENGTH = 4
-    INVALID_DIGEST_CHARS = 5
-    INVALID_KEYTAG_SIZE = 6
+    INVALID_DIGEST_CHARS = 4
+    INVALID_KEYTAG_SIZE = 5
 
 
 class DsDataError(Exception):
@@ -147,7 +145,6 @@ class DsDataError(Exception):
         ),
         DsDataErrorCodes.INVALID_DIGEST_SHA1: ("SHA-1 digest must be exactly 40 characters."),
         DsDataErrorCodes.INVALID_DIGEST_SHA256: ("SHA-256 digest must be exactly 64 characters."),
-        DsDataErrorCodes.INVALID_DIGEST_LENGTH: ("Digest must be at most 64 characters."),
         DsDataErrorCodes.INVALID_DIGEST_CHARS: ("Digest must contain only alphanumeric characters [0-9,a-f]."),
         DsDataErrorCodes.INVALID_KEYTAG_SIZE: ("Key tag must be less than 65535"),
     }

--- a/src/registrar/utility/errors.py
+++ b/src/registrar/utility/errors.py
@@ -66,20 +66,18 @@ class NameserverErrorCodes(IntEnum):
                                     value but is not a subdomain
         - 3 INVALID_IP  invalid ip address format or invalid version
         - 4 TOO_MANY_HOSTS  more than the max allowed host values
-        - 5 UNABLE_TO_UPDATE_DOMAIN unable to update the domain
-        - 6 MISSING_HOST host is missing for a nameserver
-        - 7 INVALID_HOST host is invalid for a nameserver
-        - 8 BAD_DATA bad data input for nameserver
+        - 5 MISSING_HOST host is missing for a nameserver
+        - 6 INVALID_HOST host is invalid for a nameserver
+        - 7 BAD_DATA bad data input for nameserver
     """
 
     MISSING_IP = 1
     GLUE_RECORD_NOT_ALLOWED = 2
     INVALID_IP = 3
     TOO_MANY_HOSTS = 4
-    UNABLE_TO_UPDATE_DOMAIN = 5
-    MISSING_HOST = 6
-    INVALID_HOST = 7
-    BAD_DATA = 8
+    MISSING_HOST = 5
+    INVALID_HOST = 6
+    BAD_DATA = 7
 
 
 class NameserverError(Exception):
@@ -93,9 +91,6 @@ class NameserverError(Exception):
         NameserverErrorCodes.GLUE_RECORD_NOT_ALLOWED: ("Name server address does not match domain name"),
         NameserverErrorCodes.INVALID_IP: ("{}: Enter an IP address in the required format."),
         NameserverErrorCodes.TOO_MANY_HOSTS: ("Too many hosts provided, you may not have more than 13 nameservers."),
-        NameserverErrorCodes.UNABLE_TO_UPDATE_DOMAIN: (
-            "Unable to update domain, changes were not applied. Check logs as a Registry Error is the likely cause"
-        ),
         NameserverErrorCodes.MISSING_HOST: ("Name server must be provided to enter IP address."),
         NameserverErrorCodes.INVALID_HOST: ("Enter a name server in the required format, like ns1.example.com"),
         NameserverErrorCodes.BAD_DATA: (

--- a/src/registrar/utility/errors.py
+++ b/src/registrar/utility/errors.py
@@ -150,21 +150,11 @@ class DsDataError(Exception):
         DsDataErrorCodes.BAD_DATA: (
             "There’s something wrong with the DS data you provided. If you need help email us at help@get.gov."
         ),
-        DsDataErrorCodes.INVALID_DIGEST_SHA1: (
-            "SHA-1 digest must be exactly 40 characters."
-        ),
-        DsDataErrorCodes.INVALID_DIGEST_SHA256: (
-            "SHA-256 digest must be exactly 64 characters."
-        ),
-        DsDataErrorCodes.INVALID_DIGEST_LENGTH: (
-            "Digest must be at most 64 characters."
-        ),
-        DsDataErrorCodes.INVALID_DIGEST_CHARS: (
-            "Digest must contain only alphanumeric characters [0-9,a-f]."
-        ),
-        DsDataErrorCodes.INVALID_KEYTAG_SIZE: (
-            "Key tag must be less than 65535"
-        ),
+        DsDataErrorCodes.INVALID_DIGEST_SHA1: ("SHA-1 digest must be exactly 40 characters."),
+        DsDataErrorCodes.INVALID_DIGEST_SHA256: ("SHA-256 digest must be exactly 64 characters."),
+        DsDataErrorCodes.INVALID_DIGEST_LENGTH: ("Digest must be at most 64 characters."),
+        DsDataErrorCodes.INVALID_DIGEST_CHARS: ("Digest must contain only alphanumeric characters [0-9,a-f]."),
+        DsDataErrorCodes.INVALID_KEYTAG_SIZE: ("Key tag must be less than 65535"),
     }
 
     def __init__(self, *args, code=None, **kwargs):

--- a/src/registrar/views/domain.py
+++ b/src/registrar/views/domain.py
@@ -445,7 +445,7 @@ class DomainDsDataView(DomainFormBaseView):
             modal_button = (
                 '<button type="submit" '
                 'class="usa-button usa-button--secondary" '
-                'name="disable-override-click">Delete all records</button>'
+                'name="disable-override-click">Remove all DS Data</button>'
             )
 
             # context to back out of a broken form on all fields delete

--- a/src/registrar/views/domain.py
+++ b/src/registrar/views/domain.py
@@ -308,7 +308,7 @@ class DomainNameserversView(DomainFormBaseView):
         except NameserverError as Err:
             # NamserverErrors *should* be caught in form; if reached here,
             # there was an uncaught error in submission (through EPP)
-            messages.error(self.request, NameserverError(code=nsErrorCodes.UNABLE_TO_UPDATE_DOMAIN))
+            messages.error(self.request, NameserverError(code=nsErrorCodes.BAD_DATA))
             logger.error(f"Nameservers error: {Err}")
         # TODO: registry is not throwing an error when no connection
         except RegistryError as Err:


### PR DESCRIPTION
## Ticket

Resolves #1208
<!--Reminder, when a code change is made that is user facing, beyond content updates, then the following are required:
- a developer approves the PR
- a designer approves the PR or checks off all relevant items in this checklist.

All other changes require just a single approving review.-->

## Changes

<!-- What was added, updated, or removed in this PR. -->
- Copy on modal button changed to 'Remove all DS Data'
- Error message for invalid key tag on DS Data updated to 'Key tag must be less than 65535'
- Digest validation with the following rules:
    - Only hexadecimal characters allowed in digest [0-9, a-f, A-F]
    - Digest length maximum is 64 characters
    - SHA-1 digest must be 40 characters
    - SHA-2 digest must be 64 characters

<!--
    Please add/remove/edit any of the template below to fit the needs
    of this specific PR.
--->

## Context for reviewers

<!--Background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers.  -->

Test in [BL Sandbox](https://getgov-bl.app.cloud.gov/)

For **design review**

All changes are in the DS Data form under DNSSEC in domain management.

Manage a domain.  From domain management, click DNSSEC, and enable DNSSEC.  This brings up DS Data form.

To test the validation described above:
On the DS Data Form, enter invalid data that doesn't satisfy the conditions described above, and review the error messages.  Error messages should be relevant to the specific form field, and display on the form field and at the top of the form.  The following conditions can be tested:
- empty or unselected values for required fields (key tag, algorithm, digest type, and digest)
- invalid key tag (number greater than 65535; ex.: 65536)
- invalid characters in digest (ex: 0000GG)
- invalid digest length (> 64 characters, ex: 1234567890123456789012345678901234567890123456789012345678901234567890)
- invalid SHA-1 digest ( length != 40; ex: 12345678901234567890123456789012345678)
- invalid SHA-256 digest (length != 256; ex: 12345678901234567890123456789012345678)

Form should also submit successfully when data is valid.  Below are two sample sets of valid ds data:
Key tag: 1234
Algorithm: 3
Digest type: 1 (SHA-1)
Digest: EC0BDD990B39FEEAD889F0BA613DB4ADECB4ADEC

Key tag: 2345
Algorithm: 3
Digest type: 2 (SHA-256)
Digest: EC0BDD990B39FEEAD889F0BA613DB4ADECB4ADECEC0BDD990B39FEFEEAD889F0

Once you have successfully saved one or more ds data records, need to also verify that the modal displays the correct button text.  Using the delete link, delete ds data records until there are no more, then click Save.  A modal should appear.  Verify that the text on the red button reads 'Remove all DS Data'

For **developer code review**

In forms/domain.py - form level validation is in clean; this validates digest based on value in both digest and digest type; field level validation also added for digest; error messages updated for digest type and key tag

utility/errors.py - DsDataError, DsDataErrorCodes, SecurityEmailError, SecurityEmailErrorCodes were added in Issue 1235, which has not yet been merged, but were required for this Issue.  These do not need to be reviewed as part of this PR.

views/domain.py - minor change to button text on modal

## Setup

<!--  Add any steps or code to run in this section to help others run your code.
    
    Example 1:
    ```sh
    echo "Code goes here"
    ``` 
    
    Example 2: If the PR was to add a new link with a redirect, this section could simply be:
    -go to /path/to/start/page
    -click the blue link in the <insert location>
    -notice user is redirected to <proper end location>
-->

## Code Review Verification Steps

### As the original developer, I have

#### Satisfied acceptance criteria and met development standards

- [x] Met the acceptance criteria, or will meet them in a subsequent PR
- [x] Created/modified automated tests
- [x] Added at least 2 developers as PR reviewers (only 1 will need to approve)
- [x] Messaged on Slack or in standup to notify the team that a PR is ready for review
- [ ] Changes to “how we do things” are documented in READMEs and or onboarding guide
- [ ] If any model was updated to modify/add/delete columns, makemigrations was ran and the assoicated migrations file has been commited.

#### Ensured code standards are met (Original Developer)

- [x] All new functions and methods are commented using plain language
- [ ] Did dependency updates in Pipfile also get changed in requirements.txt?
- [x] Interactions with external systems are wrapped in try/except
- [x] Error handling exists for unusual or missing values

#### Validated user-facing changes (if applicable)

- [ ] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [x] Checked keyboard navigability
- [x] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)
- [x] Add at least 1 designer as PR reviewer

### As a code reviewer, I have

#### Reviewed, tested, and left feedback about the changes

- [ ] Pulled this branch locally and tested it
- [ ] Reviewed this code and left comments
- [ ] Checked that all code is adequately covered by tests
- [ ] Made it clear which comments need to be addressed before this work is merged
- [ ] If any model was updated to modify/add/delete columns, makemigrations was ran and the assoicated migrations file has been commited.

#### Ensured code standards are met (Code reviewer)

- [ ] All new functions and methods are commented using plain language
- [ ] Interactions with external systems are wrapped in try/except
- [ ] Error handling exists for unusual or missing values
- [ ] (Rarely needed) Did dependency updates in Pipfile also get changed in requirements.txt?

#### Validated user-facing changes as a developer

- [ ] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Checked keyboard navigability
- [ ] Meets all designs and user flows provided by design/product
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)

- [ ] Tested with multiple browsers, the suggestion is to use ones that the developer didn't (check off which ones were used)
  - [ ] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari

- [ ] (Rarely needed) Tested as both an analyst and applicant user

**Note:** Multiple code reviewers can share the checklists above, a second reviewers should not make a duplicate checklist

### As a designer reviewer, I have

#### Verified that the changes match the design intention

- [ ] Checked that the design translated visually
- [ ] Checked behavior
- [ ] Checked different states (empty, one, some, error)
- [ ] Checked for landmarks, page heading structure, and links
- [ ] Tried to break the intended flow

#### Validated user-facing changes as a designer

- [ ] Checked keyboard navigability
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)

- [ ] Tested with multiple browsers (check off which ones were used)
  - [ ] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari

- [ ] (Rarely needed) Tested as both an analyst and applicant user

## Screenshots

<!-- If this PR makes visible interface changes, an image of the finished interface can help reviewers
and casual observers understand the context of the changes.
A before image is optional and can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow.
You may want to use [GIPHY Capture](https://giphy.com/apps/giphycapture) for this! 📸

_Please frame images to show useful context but also highlight the affected regions._
--->
