### PR TITLE
Set Cache-Control: no-cache on every response

### DIFF
--- a/src/registrar/config/settings.py
+++ b/src/registrar/config/settings.py
@@ -136,6 +136,8 @@ MIDDLEWARE = [
     "allow_cidr.middleware.AllowCIDRMiddleware",
     # django-cors-headers: listen to cors responses
     "corsheaders.middleware.CorsMiddleware",
+    # custom middleware to stop caching from CloudFront
+    "registrar.no_cache_middleware.NoCacheMiddleware",
     # serve static assets in production
     "whitenoise.middleware.WhiteNoiseMiddleware",
     # provide security enhancements to the request/response cycle

--- a/src/registrar/no_cache_middleware.py
+++ b/src/registrar/no_cache_middleware.py
@@ -4,6 +4,7 @@ Used to force Cloudfront caching to leave us alone while we develop
 better caching responses.
 """
 
+
 class NoCacheMiddleware:
 
     """Middleware to add a single header to every response."""

--- a/src/registrar/no_cache_middleware.py
+++ b/src/registrar/no_cache_middleware.py
@@ -1,0 +1,17 @@
+"""Middleware to add Cache-control: no-cache to every response.
+
+Used to force Cloudfront caching to leave us alone while we develop
+better caching responses.
+"""
+
+class NoCacheMiddleware:
+
+    """Middleware to add a single header to every response."""
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        response = self.get_response(request)
+        response["Cache-Control"] = "no-cache"
+        return response

--- a/src/zap.conf
+++ b/src/zap.conf
@@ -62,6 +62,9 @@
 10038	OUTOFSCOPE	http://app:8080/delete
 10038	OUTOFSCOPE	http://app:8080/withdraw 
 10038	OUTOFSCOPE	http://app:8080/withdrawconfirmed 
+10038	OUTOFSCOPE	http://app:8080/dns
+10038	OUTOFSCOPE	http://app:8080/dnssec
+10038	OUTOFSCOPE	http://app:8080/dns/dnssec
 # This URL always returns 404, so include it as well.
 10038	OUTOFSCOPE	http://app:8080/todo
 # OIDC isn't configured in the test environment and DEBUG=True so this gives a 500 without CSP headers


### PR DESCRIPTION
This attempts to simplify our production situation by setting the Cache-Control header to "no-cache" on every response. This is mostly a temporary fix while we understand how to better use these caching headers.

**To test:** `curl -vvv localhost:8080`
