### PR TITLE
Issue #1217 - Domain expiration date - EPP

### DIFF
--- a/src/registrar/admin.py
+++ b/src/registrar/admin.py
@@ -736,7 +736,7 @@ class DomainAdmin(ListHeaderAdmin):
     search_help_text = "Search by domain name."
     change_form_template = "django/admin/domain_change_form.html"
     change_list_template = "django/admin/domain_change_list.html"
-    readonly_fields = ["state"]
+    readonly_fields = ["state", "expiration_date"]
 
     def export_data_type(self, request):
         # match the CSV example with all the fields

--- a/src/registrar/models/domain.py
+++ b/src/registrar/models/domain.py
@@ -233,6 +233,7 @@ class Domain(TimeStampedModel, DomainHelper):
         try:
             cur_exp_date = self.registry_expiration_date
         except KeyError:
+            logger.warning("current expiration date not set; setting to today")
             cur_exp_date = date.today()
 
         # create RenewDomain request

--- a/src/registrar/models/domain.py
+++ b/src/registrar/models/domain.py
@@ -216,7 +216,46 @@ class Domain(TimeStampedModel, DomainHelper):
 
     @registry_expiration_date.setter  # type: ignore
     def registry_expiration_date(self, ex_date: date):
-        pass
+        """
+        Direct setting of the expiration date in the registry is not implemented.
+        
+        To update the expiration date, use renew_domain method."""
+        raise NotImplementedError()
+
+    def renew_domain(self, length: int = 1, unit: epp.Unit = epp.Unit.YEAR):
+        """
+        Renew the domain to a length and unit of time relative to the current
+        expiration date.
+        
+        Default length and unit of time are 1 year.
+        """
+        # if no expiration date from registry, set to today
+        try:
+            cur_exp_date = self.registry_expiration_date
+        except KeyError:
+            cur_exp_date = date.today()
+
+        # create RenewDomain request
+        request = commands.RenewDomain(
+            name=self.name,
+            cur_exp_date=cur_exp_date,
+            period = epp.Period(length, unit)
+        )
+
+        try:
+            # update expiration date in registry, and set the updated
+            # expiration date in the registrar, and in the cache
+            self._cache["ex_date"] = registry.send(request, cleaned=True).res_data[0].ex_date
+            self.expiration_date = self._cache["ex_date"]
+            self.save()
+        except RegistryError as err:
+            # if registry error occurs, log the error, and raise it as well
+            logger.error(f"registry error renewing domain: {err}")
+            raise (err)
+        except Exception as e:
+            # exception raised during the save to registrar
+            logger.error(f"error updating expiration date in registrar: {e}")
+            raise (e)
 
     @Cache
     def password(self) -> str:

--- a/src/registrar/models/domain.py
+++ b/src/registrar/models/domain.py
@@ -211,8 +211,16 @@ class Domain(TimeStampedModel, DomainHelper):
 
     @Cache
     def registry_expiration_date(self) -> date:
-        """Get or set the `ex_date` element from the registry."""
-        return self._get_property("ex_date")
+        """Get or set the `ex_date` element from the registry.
+        Additionally, update the expiration date in the registrar"""
+        try:
+            self.expiration_date = self._get_property("ex_date")
+            self.save()
+            return self.expiration_date
+        except Exception as e:
+            # exception raised during the save to registrar
+            logger.error(f"error updating expiration date in registrar: {e}")
+            raise (e)
 
     @registry_expiration_date.setter  # type: ignore
     def registry_expiration_date(self, ex_date: date):

--- a/src/registrar/models/domain.py
+++ b/src/registrar/models/domain.py
@@ -218,7 +218,7 @@ class Domain(TimeStampedModel, DomainHelper):
     def registry_expiration_date(self, ex_date: date):
         """
         Direct setting of the expiration date in the registry is not implemented.
-        
+
         To update the expiration date, use renew_domain method."""
         raise NotImplementedError()
 
@@ -226,7 +226,7 @@ class Domain(TimeStampedModel, DomainHelper):
         """
         Renew the domain to a length and unit of time relative to the current
         expiration date.
-        
+
         Default length and unit of time are 1 year.
         """
         # if no expiration date from registry, set to today
@@ -236,11 +236,7 @@ class Domain(TimeStampedModel, DomainHelper):
             cur_exp_date = date.today()
 
         # create RenewDomain request
-        request = commands.RenewDomain(
-            name=self.name,
-            cur_exp_date=cur_exp_date,
-            period = epp.Period(length, unit)
-        )
+        request = commands.RenewDomain(name=self.name, cur_exp_date=cur_exp_date, period=epp.Period(length, unit))
 
         try:
             # update expiration date in registry, and set the updated

--- a/src/registrar/tests/common.py
+++ b/src/registrar/tests/common.py
@@ -556,6 +556,7 @@ class MockEppLib(TestCase):
             avail=...,
             addrs=...,
             registrant=...,
+            ex_date=...,
         ):
             self.auth_info = auth_info
             self.cr_date = cr_date
@@ -565,6 +566,7 @@ class MockEppLib(TestCase):
             self.avail = avail  # use for CheckDomain
             self.addrs = addrs
             self.registrant = registrant
+            self.ex_date = ex_date
 
         def dummyInfoContactResultData(
             self,
@@ -811,6 +813,11 @@ class MockEppLib(TestCase):
         ],
     )
 
+    mockRenewedDomainExpDate = fakedEppObject(
+        "fake.gov",
+        ex_date=datetime.date(2023, 5, 25),
+    )
+
     def _mockDomainName(self, _name, _avail=False):
         return MagicMock(
             res_data=[
@@ -870,6 +877,8 @@ class MockEppLib(TestCase):
                 return self.mockCheckDomainCommand(_request, cleaned)
             case commands.DeleteDomain:
                 return self.mockDeleteDomainCommands(_request, cleaned)
+            case commands.RenewDomain:
+                return self.mockRenewDomainCommand(_request, cleaned)
             case _:
                 return MagicMock(res_data=[self.mockDataInfoHosts])
 
@@ -890,6 +899,15 @@ class MockEppLib(TestCase):
                 raise RegistryError(code=ErrorCode.OBJECT_ASSOCIATION_PROHIBITS_OPERATION)
         return None
 
+    def mockRenewDomainCommand(self, _request, cleaned):
+        if getattr(_request, "name", None) == "fake-error.gov":
+            raise RegistryError(code=ErrorCode.PARAMETER_VALUE_RANGE_ERROR)
+        else:
+            return MagicMock(
+                res_data=[self.mockRenewedDomainExpDate],
+                code=ErrorCode.COMMAND_COMPLETED_SUCCESSFULLY,
+            )
+    
     def mockInfoDomainCommands(self, _request, cleaned):
         request_name = getattr(_request, "name", None)
 

--- a/src/registrar/tests/common.py
+++ b/src/registrar/tests/common.py
@@ -907,7 +907,7 @@ class MockEppLib(TestCase):
                 res_data=[self.mockRenewedDomainExpDate],
                 code=ErrorCode.COMMAND_COMPLETED_SUCCESSFULLY,
             )
-    
+
     def mockInfoDomainCommands(self, _request, cleaned):
         request_name = getattr(_request, "name", None)
 

--- a/src/registrar/tests/test_models_domain.py
+++ b/src/registrar/tests/test_models_domain.py
@@ -1972,7 +1972,7 @@ class TestExpirationDate(MockEppLib):
 
     def test_expiration_date_setter_not_implemented(self):
         """assert that the setter for expiration date is not implemented and will raise error"""
-        with self.assertRaises(NotImplementedError) as err:
+        with self.assertRaises(NotImplementedError):
             self.domain.registry_expiration_date = datetime.date.today()
 
     def test_renew_domain(self):
@@ -1984,10 +1984,10 @@ class TestExpirationDate(MockEppLib):
 
     def test_renew_domain_error(self):
         """assert that the renew_domain raises an exception when registry raises error"""
-        with self.assertRaises(RegistryError) as err:
+        with self.assertRaises(RegistryError):
             self.domain_w_error.renew_domain()
 
-        
+
 class TestAnalystClientHold(MockEppLib):
     """Rule: Analysts may suspend or restore a domain by using client hold"""
 

--- a/src/registrar/tests/test_models_domain.py
+++ b/src/registrar/tests/test_models_domain.py
@@ -56,7 +56,7 @@ class TestDomainCache(MockEppLib):
         self.assertFalse("avail" in domain._cache.keys())
 
         # using a setter should clear the cache
-        domain.registry_expiration_date = datetime.date.today()
+        domain.dnssecdata = []
         self.assertEquals(domain._cache, {})
 
         # send should have been called only once
@@ -1953,6 +1953,41 @@ class TestRegistrantDNSSEC(MockEppLib):
             self.assertTrue(err.is_client_error() or err.is_session_error() or err.is_server_error())
 
 
+class TestExpirationDate(MockEppLib):
+    """User may renew expiration date by a number of units of time"""
+
+    def setUp(self):
+        """
+        Domain exists in registry
+        """
+        super().setUp()
+        # for the tests, need a domain in the ready state
+        self.domain, _ = Domain.objects.get_or_create(name="fake.gov", state=Domain.State.READY)
+        # for the test, need a domain that will raise an exception
+        self.domain_w_error, _ = Domain.objects.get_or_create(name="fake-error.gov", state=Domain.State.READY)
+
+    def tearDown(self):
+        Domain.objects.all().delete()
+        super().tearDown()
+
+    def test_expiration_date_setter_not_implemented(self):
+        """assert that the setter for expiration date is not implemented and will raise error"""
+        with self.assertRaises(NotImplementedError) as err:
+            self.domain.registry_expiration_date = datetime.date.today()
+
+    def test_renew_domain(self):
+        """assert that the renew_domain sets new expiration date in cache and saves to registrar"""
+        self.domain.renew_domain()
+        test_date = datetime.date(2023, 5, 25)
+        self.assertEquals(self.domain._cache["ex_date"], test_date)
+        self.assertEquals(self.domain.expiration_date, test_date)
+
+    def test_renew_domain_error(self):
+        """assert that the renew_domain raises an exception when registry raises error"""
+        with self.assertRaises(RegistryError) as err:
+            self.domain_w_error.renew_domain()
+
+        
 class TestAnalystClientHold(MockEppLib):
     """Rule: Analysts may suspend or restore a domain by using client hold"""
 


### PR DESCRIPTION
## Ticket

Resolves #1217
<!--Reminder, when a code change is made that is user facing, beyond content updates, then the following are required:
- a developer approves the PR
- a designer approves the PR or checks off all relevant items in this checklist.

All other changes require just a single approving review.-->

## Changes

<!-- What was added, updated, or removed in this PR. -->
- Updated django admin so that expiration date is read only
- Disabled expiration date setter (not implemented)
- Implemented renew domain, which sets the expiration date in the registry, registrar, and cache

<!--
    Please add/remove/edit any of the template below to fit the needs
    of this specific PR.
--->

## Context for reviewers

<!--Background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers.  -->

Test in [DK Sandbox](https://getgov-dk.app.cloud.gov/)

For **design review**, all that needs to be verified for this one is that the expiration date is readonly in django admin.  Navigate to a domain detail page in django admin.  Note that the expiration date is now readonly instead of editable.

For **developer code review**, note the following changes:
**admin.py**  set the expiration date to readonly to satisfy django admin requirement
**models/domain.py**  disabled the expiration date setter, as setting an exact date is not implemented at this time; implemented renew_domain which sets the expiration date to some unit of time in the future from the current expiration date (if no expiration date exists, sets from today); getter modified to also update registrar and cache when retrieving expiration date from registry

For **developer verification**, there is no UI for testing this.  So, you will need to go into sandbox command line and run a few commands, and note the output.
```
# connect to sandbox, and to python shell
cf ssh getgov-dk
/tmp/lifecycle/shell
./manage.py shell
```
```
# run the following code

from epplib.models import common
from epplibwrapper import CLIENT as registry, commands
from registrar.models.domain import Domain

domain, _ = Domain.objects.get_or_create(name="fake.gov")
domain._get_or_create_domain()
domain.expiration_date
# this should print out current expiration date

domain.renew_domain()
domain.expiration_date
# this should print out new expiration date (verifying date set in registrar)
domain.registry_expiration_date
# this should print out the new expiration date (verifying date set in cache)
```

## Setup

<!--  Add any steps or code to run in this section to help others run your code.
    
    Example 1:
    ```sh
    echo "Code goes here"
    ``` 
    
    Example 2: If the PR was to add a new link with a redirect, this section could simply be:
    -go to /path/to/start/page
    -click the blue link in the <insert location>
    -notice user is redirected to <proper end location>
-->

## Code Review Verification Steps

### As the original developer, I have

#### Satisfied acceptance criteria and met development standards

- [x] Met the acceptance criteria, or will meet them in a subsequent PR
- [x] Created/modified automated tests
- [x] Added at least 2 developers as PR reviewers (only 1 will need to approve)
- [x] Messaged on Slack or in standup to notify the team that a PR is ready for review
- [ ] Changes to “how we do things” are documented in READMEs and or onboarding guide
- [ ] If any model was updated to modify/add/delete columns, makemigrations was ran and the assoicated migrations file has been commited.

#### Ensured code standards are met (Original Developer)

- [x] All new functions and methods are commented using plain language
- [ ] Did dependency updates in Pipfile also get changed in requirements.txt?
- [x] Interactions with external systems are wrapped in try/except
- [x] Error handling exists for unusual or missing values

#### Validated user-facing changes (if applicable)

- [ ] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Checked keyboard navigability
- [x] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)
- [x] Add at least 1 designer as PR reviewer

### As a code reviewer, I have

#### Reviewed, tested, and left feedback about the changes

- [ ] Pulled this branch locally and tested it
- [ ] Reviewed this code and left comments
- [ ] Checked that all code is adequately covered by tests
- [ ] Made it clear which comments need to be addressed before this work is merged
- [ ] If any model was updated to modify/add/delete columns, makemigrations was ran and the assoicated migrations file has been commited.

#### Ensured code standards are met (Code reviewer)

- [ ] All new functions and methods are commented using plain language
- [ ] Interactions with external systems are wrapped in try/except
- [ ] Error handling exists for unusual or missing values
- [ ] (Rarely needed) Did dependency updates in Pipfile also get changed in requirements.txt?

#### Validated user-facing changes as a developer

- [ ] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Checked keyboard navigability
- [ ] Meets all designs and user flows provided by design/product
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)

- [ ] Tested with multiple browsers, the suggestion is to use ones that the developer didn't (check off which ones were used)
  - [ ] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari

- [ ] (Rarely needed) Tested as both an analyst and applicant user

**Note:** Multiple code reviewers can share the checklists above, a second reviewers should not make a duplicate checklist

### As a designer reviewer, I have

#### Verified that the changes match the design intention

- [ ] Checked that the design translated visually
- [ ] Checked behavior
- [ ] Checked different states (empty, one, some, error)
- [ ] Checked for landmarks, page heading structure, and links
- [ ] Tried to break the intended flow

#### Validated user-facing changes as a designer

- [ ] Checked keyboard navigability
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)

- [ ] Tested with multiple browsers (check off which ones were used)
  - [ ] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari

- [ ] (Rarely needed) Tested as both an analyst and applicant user

## Screenshots

<!-- If this PR makes visible interface changes, an image of the finished interface can help reviewers
and casual observers understand the context of the changes.
A before image is optional and can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow.
You may want to use [GIPHY Capture](https://giphy.com/apps/giphycapture) for this! 📸

_Please frame images to show useful context but also highlight the affected regions._
--->
