### PR TITLE
#984: Update form error messages on domain management contacts

### DIFF
--- a/src/registrar/forms/__init__.py
+++ b/src/registrar/forms/__init__.py
@@ -5,6 +5,7 @@ from .domain import (
     DomainSecurityEmailForm,
     DomainOrgNameAddressForm,
     ContactForm,
+    AuthorizingOfficialContactForm,
     DomainDnssecForm,
     DomainDsdataFormset,
     DomainDsdataForm,

--- a/src/registrar/forms/domain.py
+++ b/src/registrar/forms/domain.py
@@ -185,7 +185,7 @@ class AuthorizingOfficialContactForm(ContactForm):
 class DomainSecurityEmailForm(forms.Form):
     """Form for adding or editing a security email to a domain."""
 
-    security_email = forms.EmailField(label="Security email (optional)", required=False)
+    security_email = forms.EmailField(label="Security email", required=False)
 
 
 class DomainOrgNameAddressForm(forms.ModelForm):

--- a/src/registrar/forms/domain.py
+++ b/src/registrar/forms/domain.py
@@ -125,6 +125,19 @@ class ContactForm(forms.ModelForm):
     class Meta:
         model = Contact
         fields = ["first_name", "middle_name", "last_name", "title", "email", "phone"]
+        error_messages = {
+            "first_name": {"required": "Enter your first name / given name."},
+            "last_name": {"required": "Enter your last name / family name."},
+            "title": {
+                "required": "Enter your title or role in your organization (e.g., Chief Information Officer)."
+            },
+            "email": {
+                "required": "Enter your email address in the required format, like name@example.com."
+            },
+            "phone": {
+                "required": "Enter your phone number."
+            },
+        }
         widgets = {
             "first_name": forms.TextInput,
             "middle_name": forms.TextInput,

--- a/src/registrar/forms/domain.py
+++ b/src/registrar/forms/domain.py
@@ -167,16 +167,19 @@ class AuthorizingOfficialContactForm(ContactForm):
         super().__init__(*args, **kwargs)
 
         # Set custom error messages
-        self.fields["first_name"].error_messages = {"required": "Enter the first name / given name of this contact."}
-        self.fields["last_name"].error_messages = {"required": "Enter the last name / family name of this contact."}
+        self.fields["first_name"].error_messages = {
+            "required": "Enter the first name / given name of your authorizing official."
+        }
+        self.fields["last_name"].error_messages = {
+            "required": "Enter the last name / family name of your authorizing official."
+        }
         self.fields["title"].error_messages = {
-            "required": "Enter the title or role in your organization of this contact \
-            (e.g., Chief Information Officer)."
+            "required": "Enter the title or role your authorizing official has in your organization (e.g., Chief Information Officer)."
         }
         self.fields["email"].error_messages = {
             "required": "Enter an email address in the required format, like name@example.com."
         }
-        self.fields["phone"].error_messages = {"required": "Enter a phone number for this contact."}
+        self.fields["phone"].error_messages = {"required": "Enter a phone number for your authorizing official."}
 
 
 class DomainSecurityEmailForm(forms.Form):

--- a/src/registrar/forms/domain.py
+++ b/src/registrar/forms/domain.py
@@ -147,7 +147,7 @@ class ContactForm(forms.ModelForm):
 
         for field_name in self.required:
             self.fields[field_name].required = True
-        
+
         # Set custom error messages
         self.fields["first_name"].error_messages = {'required': 'Enter your first name / given name.'}
         self.fields["last_name"].error_messages = {'required': 'Enter your last name / family name.'}
@@ -158,6 +158,7 @@ class ContactForm(forms.ModelForm):
             'required': 'Enter your email address in the required format, like name@example.com.'
         }
         self.fields["phone"].error_messages = {'required': 'Enter your phone number.'}
+
 
 class AuthorizingOfficialContactForm(ContactForm):
     """Form for updating authorizing official contacts."""

--- a/src/registrar/forms/domain.py
+++ b/src/registrar/forms/domain.py
@@ -149,33 +149,34 @@ class ContactForm(forms.ModelForm):
             self.fields[field_name].required = True
 
         # Set custom error messages
-        self.fields["first_name"].error_messages = {'required': 'Enter your first name / given name.'}
-        self.fields["last_name"].error_messages = {'required': 'Enter your last name / family name.'}
+        self.fields["first_name"].error_messages = {"required": "Enter your first name / given name."}
+        self.fields["last_name"].error_messages = {"required": "Enter your last name / family name."}
         self.fields["title"].error_messages = {
-            'required': 'Enter your title or role in your organization (e.g., Chief Information Officer)'
+            "required": "Enter your title or role in your organization (e.g., Chief Information Officer)"
         }
         self.fields["email"].error_messages = {
-            'required': 'Enter your email address in the required format, like name@example.com.'
+            "required": "Enter your email address in the required format, like name@example.com."
         }
-        self.fields["phone"].error_messages = {'required': 'Enter your phone number.'}
+        self.fields["phone"].error_messages = {"required": "Enter your phone number."}
 
 
 class AuthorizingOfficialContactForm(ContactForm):
     """Form for updating authorizing official contacts."""
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
         # Set custom error messages
-        self.fields["first_name"].error_messages = {'required': 'Enter the first name / given name of this contact.'}
-        self.fields["last_name"].error_messages = {'required': 'Enter the last name / family name of this contact.'}
+        self.fields["first_name"].error_messages = {"required": "Enter the first name / given name of this contact."}
+        self.fields["last_name"].error_messages = {"required": "Enter the last name / family name of this contact."}
         self.fields["title"].error_messages = {
-            'required': 'Enter the title or role in your organization of this contact \
-            (e.g., Chief Information Officer).'
+            "required": "Enter the title or role in your organization of this contact \
+            (e.g., Chief Information Officer)."
         }
         self.fields["email"].error_messages = {
-            'required': 'Enter an email address in the required format, like name@example.com.'
+            "required": "Enter an email address in the required format, like name@example.com."
         }
-        self.fields["phone"].error_messages = {'required': 'Enter a phone number for this contact.'}
+        self.fields["phone"].error_messages = {"required": "Enter a phone number for this contact."}
 
 
 class DomainSecurityEmailForm(forms.Form):

--- a/src/registrar/forms/domain.py
+++ b/src/registrar/forms/domain.py
@@ -125,19 +125,6 @@ class ContactForm(forms.ModelForm):
     class Meta:
         model = Contact
         fields = ["first_name", "middle_name", "last_name", "title", "email", "phone"]
-        error_messages = {
-            "first_name": {"required": "Enter your first name / given name."},
-            "last_name": {"required": "Enter your last name / family name."},
-            "title": {
-                "required": "Enter your title or role in your organization (e.g., Chief Information Officer)."
-            },
-            "email": {
-                "required": "Enter your email address in the required format, like name@example.com."
-            },
-            "phone": {
-                "required": "Enter your phone number."
-            },
-        }
         widgets = {
             "first_name": forms.TextInput,
             "middle_name": forms.TextInput,
@@ -160,12 +147,23 @@ class ContactForm(forms.ModelForm):
 
         for field_name in self.required:
             self.fields[field_name].required = True
+        
+        # Set custom error messages
+        self.fields["first_name"].error_messages = {'required': 'Enter your first name / given name.'}
+        self.fields["last_name"].error_messages = {'required': 'Enter your last name / family name.'}
+        self.fields["title"].error_messages = {
+            'required': 'Enter your title or role in your organization (e.g., Chief Information Officer)'
+        }
+        self.fields["email"].error_messages = {
+            'required': 'Enter your email address in the required format, like name@example.com.'
+        }
+        self.fields["phone"].error_messages = {'required': 'Enter your phone number.'}
 
 
 class DomainSecurityEmailForm(forms.Form):
     """Form for adding or editing a security email to a domain."""
 
-    security_email = forms.EmailField(label="Security email", required=False)
+    security_email = forms.EmailField(label="Security email (optional)", required=False)
 
 
 class DomainOrgNameAddressForm(forms.ModelForm):

--- a/src/registrar/forms/domain.py
+++ b/src/registrar/forms/domain.py
@@ -174,7 +174,8 @@ class AuthorizingOfficialContactForm(ContactForm):
             "required": "Enter the last name / family name of your authorizing official."
         }
         self.fields["title"].error_messages = {
-            "required": "Enter the title or role your authorizing official has in your organization (e.g., Chief Information Officer)."
+            "required": "Enter the title or role your authorizing official has in your \
+            organization (e.g., Chief Information Officer)."
         }
         self.fields["email"].error_messages = {
             "required": "Enter an email address in the required format, like name@example.com."

--- a/src/registrar/forms/domain.py
+++ b/src/registrar/forms/domain.py
@@ -147,9 +147,6 @@ class ContactForm(forms.ModelForm):
 
         for field_name in self.required:
             self.fields[field_name].required = True
-
-        # Set custom form label
-        self.fields["middle_name"].label = "Middle name (optional)"
         
         # Set custom error messages
         self.fields["first_name"].error_messages = {'required': 'Enter your first name / given name.'}

--- a/src/registrar/forms/domain.py
+++ b/src/registrar/forms/domain.py
@@ -147,6 +147,9 @@ class ContactForm(forms.ModelForm):
 
         for field_name in self.required:
             self.fields[field_name].required = True
+
+        # Set custom form label
+        self.fields["middle_name"].label = "Middle name (optional)"
         
         # Set custom error messages
         self.fields["first_name"].error_messages = {'required': 'Enter your first name / given name.'}
@@ -158,6 +161,23 @@ class ContactForm(forms.ModelForm):
             'required': 'Enter your email address in the required format, like name@example.com.'
         }
         self.fields["phone"].error_messages = {'required': 'Enter your phone number.'}
+
+class AuthorizingOfficialContactForm(ContactForm):
+    """Form for updating authorizing official contacts."""
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        # Set custom error messages
+        self.fields["first_name"].error_messages = {'required': 'Enter the first name / given name of this contact.'}
+        self.fields["last_name"].error_messages = {'required': 'Enter the last name / family name of this contact.'}
+        self.fields["title"].error_messages = {
+            'required': 'Enter the title or role in your organization of this contact \
+            (e.g., Chief Information Officer).'
+        }
+        self.fields["email"].error_messages = {
+            'required': 'Enter an email address in the required format, like name@example.com.'
+        }
+        self.fields["phone"].error_messages = {'required': 'Enter a phone number for this contact.'}
 
 
 class DomainSecurityEmailForm(forms.Form):

--- a/src/registrar/views/domain.py
+++ b/src/registrar/views/domain.py
@@ -33,6 +33,7 @@ from registrar.models.utility.contact_error import ContactError
 
 from ..forms import (
     ContactForm,
+    AuthorizingOfficialContactForm,
     DomainOrgNameAddressForm,
     DomainAddUserForm,
     DomainSecurityEmailForm,
@@ -182,7 +183,7 @@ class DomainAuthorizingOfficialView(DomainFormBaseView):
     model = Domain
     template_name = "domain_authorizing_official.html"
     context_object_name = "domain"
-    form_class = ContactForm
+    form_class = AuthorizingOfficialContactForm
 
     def get_form_kwargs(self, *args, **kwargs):
         """Add domain_info.authorizing_official instance to make a bound form."""


### PR DESCRIPTION
## Ticket

Resolves #984 
<!--Reminder, when a code change is made that is user facing, beyond content updates, then the following are required:
- a developer approves the PR
- a designer approves the PR or checks off all relevant items in this checklist.

All other changes require just a single approving review.-->

## Changes

<!-- What was added, updated, or removed in this PR. -->
- Overrides error messages for Contact Form on domain management page. Error messages updated to reflect the [content doc](https://docs.google.com/document/d/1EHMzgmig6vaSFRvCiih87Cx38lD2rWrkEE4BzDzev9Q/edit) (also linked in the issue).
- Creates a child class of ContactForm called AuthorizingOfficialContactForm which specifies custom error messages for Authorizing Official page of domain management page. 

**Your contact information error messages**
<img width="688" alt="image" src="https://github.com/cisagov/manage.get.gov/assets/121973038/0e427335-9c86-4511-b97a-ce0abc4f76fb">

**Authorizing official error messages**
<img width="710" alt="image" src="https://github.com/cisagov/manage.get.gov/assets/121973038/eb816326-fa32-4491-9c94-f7b745f0e2fd">


<!--
    Please add/remove/edit any of the template below to fit the needs
    of this specific PR.
--->

## Context for reviewers

<!--Background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers.  -->

## Setup

<!--  Add any steps or code to run in this section to help others run your code.
    
    Example 1:
    ```sh
    echo "Code goes here"
    ``` 
    
    Example 2: If the PR was to add a new link with a redirect, this section could simply be:
    -go to /path/to/start/page
    -click the blue link in the <insert location>
    -notice user is redirected to <proper end location>
-->
Go to [staging link](https://getgov-es.app.cloud.gov) and go to manage domain.

- Navigate to Your contact information page and enter empty inputs for required fields. The form should output error messages for the specific fields that were not entered.
- Navigate to Authorizing official page and repeat the same steps as above.

## Code Review Verification Steps

### As the original developer, I have

#### Satisfied acceptance criteria and met development standards

- [x] Met the acceptance criteria, or will meet them in a subsequent PR
- [x] Created/modified automated tests
- [x] Added at least 2 developers as PR reviewers (only 1 will need to approve)
- [x] Messaged on Slack or in standup to notify the team that a PR is ready for review
- [ ] Changes to “how we do things” are documented in READMEs and or onboarding guide
- [ ] If any model was updated to modify/add/delete columns, makemigrations was ran and the assoicated migrations file has been commited.

#### Ensured code standards are met (Original Developer)

- [ ] All new functions and methods are commented using plain language
- [ ] Did dependency updates in Pipfile also get changed in requirements.txt?
- [ ] Interactions with external systems are wrapped in try/except
- [ ] Error handling exists for unusual or missing values

#### Validated user-facing changes (if applicable)

- [ ] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Checked keyboard navigability
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)
- [ ] Add at least 1 designer as PR reviewer

### As a code reviewer, I have

#### Reviewed, tested, and left feedback about the changes

- [ ] Pulled this branch locally and tested it
- [ ] Reviewed this code and left comments
- [ ] Checked that all code is adequately covered by tests
- [ ] Made it clear which comments need to be addressed before this work is merged
- [ ] If any model was updated to modify/add/delete columns, makemigrations was ran and the assoicated migrations file has been commited.

#### Ensured code standards are met (Code reviewer)

- [ ] All new functions and methods are commented using plain language
- [ ] Interactions with external systems are wrapped in try/except
- [ ] Error handling exists for unusual or missing values
- [ ] (Rarely needed) Did dependency updates in Pipfile also get changed in requirements.txt?

#### Validated user-facing changes as a developer

- [ ] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Checked keyboard navigability
- [ ] Meets all designs and user flows provided by design/product
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)

- [ ] Tested with multiple browsers, the suggestion is to use ones that the developer didn't (check off which ones were used)
  - [ ] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari

- [ ] (Rarely needed) Tested as both an analyst and applicant user

**Note:** Multiple code reviewers can share the checklists above, a second reviewers should not make a duplicate checklist

### As a designer reviewer, I have

#### Verified that the changes match the design intention

- [ ] Checked that the design translated visually
- [ ] Checked behavior
- [ ] Checked different states (empty, one, some, error)
- [ ] Checked for landmarks, page heading structure, and links
- [ ] Tried to break the intended flow

#### Validated user-facing changes as a designer

- [ ] Checked keyboard navigability
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)

- [ ] Tested with multiple browsers (check off which ones were used)
  - [ ] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari

- [ ] (Rarely needed) Tested as both an analyst and applicant user

## Screenshots

<!-- If this PR makes visible interface changes, an image of the finished interface can help reviewers
and casual observers understand the context of the changes.
A before image is optional and can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow.
You may want to use [GIPHY Capture](https://giphy.com/apps/giphycapture) for this! 📸

_Please frame images to show useful context but also highlight the affected regions._
--->
