### PR TITLE
#1367: Change cg-deploy-action to cg-cli-tools

### DIFF
--- a/.github/workflows/deploy-sandbox.yaml
+++ b/.github/workflows/deploy-sandbox.yaml
@@ -47,16 +47,15 @@ jobs:
       - name: Deploy to cloud.gov sandbox
         uses: cloud-gov/cg-cli-tools@main
         env:
-          DEPLOY_NOW: thanks
           ENVIRONMENT: ${{ needs.variables.outputs.environment }}
           CF_USERNAME: CF_${{ needs.variables.outputs.environment }}_USERNAME
           CF_PASSWORD: CF_${{ needs.variables.outputs.environment }}_PASSWORD
+          MANIFEST: "ops/manifests/manifest-${{ needs.variables.outputs.environment }}.yaml"
         with:
           cf_username: ${{ secrets[env.CF_USERNAME] }}
           cf_password: ${{ secrets[env.CF_PASSWORD] }}
           cf_org: cisa-dotgov
           cf_space: ${{ env.ENVIRONMENT }}
-          push_arguments: "-f ops/manifests/manifest-${{ env.ENVIRONMENT }}.yaml"
   comment:
     runs-on: ubuntu-latest
     needs: [variables, deploy]

--- a/.github/workflows/deploy-sandbox.yaml
+++ b/.github/workflows/deploy-sandbox.yaml
@@ -45,7 +45,7 @@ jobs:
         working-directory: ./src
         run: docker compose run app python manage.py collectstatic --no-input
       - name: Deploy to cloud.gov sandbox
-        uses: 18f/cg-deploy-action@main
+        uses: cloud-gov/cg-cli-tools@main
         env:
           DEPLOY_NOW: thanks
           ENVIRONMENT: ${{ needs.variables.outputs.environment }}

--- a/.github/workflows/deploy-stable.yaml
+++ b/.github/workflows/deploy-stable.yaml
@@ -30,12 +30,11 @@ jobs:
         working-directory: ./src
         run: docker compose run app python manage.py collectstatic --no-input
       - name: Deploy to cloud.gov sandbox
-        uses: 18f/cg-deploy-action@main
+        uses: cloud-gov/cg-cli-tools@main
         env:
-          DEPLOY_NOW: thanks
+          MANIFEST: "ops/manifests/manifest-stable.yaml"
         with:
           cf_username: ${{ secrets.CF_STABLE_USERNAME }}
           cf_password: ${{ secrets.CF_STABLE_PASSWORD }}
           cf_org: cisa-dotgov
           cf_space: stable
-          push_arguments: "-f ops/manifests/manifest-stable.yaml"

--- a/.github/workflows/deploy-staging.yaml
+++ b/.github/workflows/deploy-staging.yaml
@@ -9,7 +9,7 @@ on:
       - 'docs/**'
       - '**.md'
       - '.gitignore'
-      
+
     tags:
       - staging-*
 
@@ -30,12 +30,11 @@ jobs:
         working-directory: ./src
         run: docker compose run app python manage.py collectstatic --no-input
       - name: Deploy to cloud.gov sandbox
-        uses: 18f/cg-deploy-action@main
+        uses: cloud-gov/cg-cli-tools@main
         env:
-          DEPLOY_NOW: thanks
+          MANIFEST: "ops/manifests/manifest-staging.yaml"
         with:
           cf_username: ${{ secrets.CF_STAGING_USERNAME }}
           cf_password: ${{ secrets.CF_STAGING_PASSWORD }}
           cf_org: cisa-dotgov
           cf_space: staging
-          push_arguments: "-f ops/manifests/manifest-staging.yaml"

--- a/.github/workflows/migrate.yaml
+++ b/.github/workflows/migrate.yaml
@@ -35,10 +35,10 @@ jobs:
       CF_PASSWORD: CF_${{ github.event.inputs.environment }}_PASSWORD
     steps:
       - name: Run Django migrations for ${{ github.event.inputs.environment }}
-        uses: 18f/cg-deploy-action@main
+        uses: cloud-gov/cg-deploy-action@main
         with:
           cf_username: ${{ secrets[env.CF_USERNAME] }}
           cf_password: ${{ secrets[env.CF_PASSWORD] }}
           cf_org: cisa-dotgov
           cf_space: ${{ github.event.inputs.environment }}
-          full_command: "cf run-task getgov-${{ github.event.inputs.environment }} --command 'python manage.py migrate' --name migrate"
+          cf_command: "run-task getgov-${{ github.event.inputs.environment }} --command 'python manage.py migrate' --name migrate"

--- a/.github/workflows/reset-db.yaml
+++ b/.github/workflows/reset-db.yaml
@@ -36,28 +36,28 @@ jobs:
       CF_PASSWORD: CF_${{ github.event.inputs.environment }}_PASSWORD
     steps:
       - name: Delete existing data for ${{ github.event.inputs.environment }}
-        uses: 18f/cg-deploy-action@main
+        uses: cloud-gov/cg-cli-tools@main
         with:
           cf_username: ${{ secrets[env.CF_USERNAME] }}
           cf_password: ${{ secrets[env.CF_PASSWORD] }}
           cf_org: cisa-dotgov
           cf_space: ${{ github.event.inputs.environment }}
-          full_command: "cf run-task getgov-${{ github.event.inputs.environment }} --command 'python manage.py flush --no-input' --name flush"
+          cf_command: "run-task getgov-${{ github.event.inputs.environment }} --command 'python manage.py flush --no-input' --name flush"
 
       - name: Run Django migrations for ${{ github.event.inputs.environment }}
-        uses: 18f/cg-deploy-action@main
+        uses: cloud-gov/cg-cli-tools@main
         with:
           cf_username: ${{ secrets[env.CF_USERNAME] }}
           cf_password: ${{ secrets[env.CF_PASSWORD] }}
           cf_org: cisa-dotgov
           cf_space: ${{ github.event.inputs.environment }}
-          full_command: "cf run-task getgov-${{ github.event.inputs.environment }} --command 'python manage.py migrate' --name migrate"
+          cf_command: "run-task getgov-${{ github.event.inputs.environment }} --command 'python manage.py migrate' --name migrate"
 
       - name: Load fake data for ${{ github.event.inputs.environment }}
-        uses: 18f/cg-deploy-action@main
+        uses: cloud-gov/cg-cli-tools@main
         with:
           cf_username: ${{ secrets[env.CF_USERNAME] }}
           cf_password: ${{ secrets[env.CF_PASSWORD] }}
           cf_org: cisa-dotgov
           cf_space: ${{ github.event.inputs.environment }}
-          full_command: "cf run-task getgov-${{ github.event.inputs.environment }} --command 'python manage.py load' --name loaddata"
+          cf_command: "run-task getgov-${{ github.event.inputs.environment }} --command 'python manage.py load' --name loaddata"


### PR DESCRIPTION
## Ticket

Resolves #1367

## Changes

This changes the Github Action that we use to deploy to Cloud.gov environments. The `18f/cg-deploy-action` that we were using has been deprecated and Cloud.gov support suggests the newer `cloud-gov/cg-cli-tools` action instead. This replaces all of our workflows with the suggested action and tweaks the calling syntax to match the new action's interface.

## Setup

As with all CI/CD changes, this one is hard to review. It should work to deploy to the `ab` sandbox at the PR level. It should work to run the reset and migrate jobs on a sandbox from the Github UI. For the staging and stable deploy jobs, we'll have to wait to test until this PR is merged and those run again.

## Code Review Verification Steps

### As the original developer, I have

#### Satisfied acceptance criteria and met development standards

- [X] Met the acceptance criteria, or will meet them in a subsequent PR

### As a code reviewer, I have

#### Reviewed, tested, and left feedback about the changes

- [ ] Pulled this branch locally and tested it
- [ ] Reviewed this code and left comments