### PR TITLE
Issue #1209 - updated logic on domain mgmt sidebar

### DIFF
--- a/src/registrar/templates/domain_sidebar.html
+++ b/src/registrar/templates/domain_sidebar.html
@@ -17,6 +17,7 @@
         <a href="{{ url }}" {% if request.path|startswith:url %}class="usa-current"{% endif %}>
           DNS
         </a>
+        {% if request.path|startswith:url %}
         <ul class="usa-sidenav__sublist">
           <li class="usa-sidenav__item">
             {% url 'domain-dns-nameservers' pk=domain.id as url %} 
@@ -34,20 +35,23 @@
             >
                 DNSSEC
             </a>
-            {% if domain.dnssecdata is not None or request.path|startswith:url and request.path|endswith:'dsdata' %}
-            <ul class="usa-sidenav__sublist">
-              <li class="usa-sidenav__item">
-                {% url 'domain-dns-dnssec-dsdata' pk=domain.id as url %}
-                <a href="{{ url }}"
-                  {% if request.path == url %}class="usa-current"{% endif %}
-                >
-                    DS Data
-                </a>
-              </li>
-            </ul>
+            {% if request.path|startswith:url %}
+              {% if domain.dnssecdata is not None or request.path|startswith:url and request.path|endswith:'dsdata' %}
+              <ul class="usa-sidenav__sublist">
+                <li class="usa-sidenav__item">
+                  {% url 'domain-dns-dnssec-dsdata' pk=domain.id as url %}
+                  <a href="{{ url }}"
+                    {% if request.path == url %}class="usa-current"{% endif %}
+                  >
+                      DS Data
+                  </a>
+                </li>
+              </ul>
+              {% endif %}
             {% endif %}
           </li>
         </ul>
+        {% endif %}
       </li>
 
       <li class="usa-sidenav__item">


### PR DESCRIPTION
## Ticket

Resolves #1209 
<!--Reminder, when a code change is made that is user facing, beyond content updates, then the following are required:
- a developer approves the PR
- a designer approves the PR or checks off all relevant items in this checklist.

All other changes require just a single approving review.-->

## Changes

<!-- What was added, updated, or removed in this PR. -->
- Updated logic that dictates the display or hiding of sidebar nav for DNS options.

<!--
    Please add/remove/edit any of the template below to fit the needs
    of this specific PR.
--->

## Context for reviewers

<!--Background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers.  -->
Testing can be performed in DK Sandbox.  Click on any eligible domain and test the side navigation behaves as noted in the ticket (and summarized below)

Test that, in the domain management, on the side nav, elements are hidden until their parent is selected.  At present, this applies to DNS.  The acceptance criteria to be tested are:

- [x] On clicking the DNS page, the Name servers page and DNSSEC unfurl out from under it
- [x]  DS Data page behaves the same way (upon clicking DNSSEC with the condition that the user has added DS Data already). The page shouldn't be present if they haven't added DS Data.

## Setup

<!--  Add any steps or code to run in this section to help others run your code.
    
    Example 1:
    ```sh
    echo "Code goes here"
    ``` 
    
    Example 2: If the PR was to add a new link with a redirect, this section could simply be:
    -go to /path/to/start/page
    -click the blue link in the <insert location>
    -notice user is redirected to <proper end location>
-->

## Code Review Verification Steps

### As the original developer, I have

#### Satisfied acceptance criteria and met development standards

- [ ] Met the acceptance criteria, or will meet them in a subsequent PR
- [ ] Created/modified automated tests
- [ ] Added at least 2 developers as PR reviewers (only 1 will need to approve)
- [ ] Messaged on Slack or in standup to notify the team that a PR is ready for review
- [ ] Changes to “how we do things” are documented in READMEs and or onboarding guide
- [ ] If any model was updated to modify/add/delete columns, makemigrations was ran and the assoicated migrations file has been commited.

#### Ensured code standards are met (Original Developer)

- [ ] All new functions and methods are commented using plain language
- [ ] Did dependency updates in Pipfile also get changed in requirements.txt?
- [ ] Interactions with external systems are wrapped in try/except
- [ ] Error handling exists for unusual or missing values

#### Validated user-facing changes (if applicable)

- [ ] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Checked keyboard navigability
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)
- [ ] Add at least 1 designer as PR reviewer

### As a code reviewer, I have

#### Reviewed, tested, and left feedback about the changes

- [x] Pulled this branch locally and tested it
- [x] Reviewed this code and left comments
- [x] Checked that all code is adequately covered by tests
- [ ] Made it clear which comments need to be addressed before this work is merged
- [ ] If any model was updated to modify/add/delete columns, makemigrations was ran and the assoicated migrations file has been commited.

#### Ensured code standards are met (Code reviewer)

- [ ] All new functions and methods are commented using plain language
- [ ] Interactions with external systems are wrapped in try/except
- [ ] Error handling exists for unusual or missing values
- [ ] (Rarely needed) Did dependency updates in Pipfile also get changed in requirements.txt?

#### Validated user-facing changes as a developer

- [ ] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Checked keyboard navigability
- [ ] Meets all designs and user flows provided by design/product
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)

- [ ] Tested with multiple browsers, the suggestion is to use ones that the developer didn't (check off which ones were used)
  - [x] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari

- [ ] (Rarely needed) Tested as both an analyst and applicant user

**Note:** Multiple code reviewers can share the checklists above, a second reviewers should not make a duplicate checklist

### As a designer reviewer, I have

#### Verified that the changes match the design intention

- [x] Checked that the design translated visually
- [x] Checked behavior
- [ ] Checked different states (empty, one, some, error)
- [x] Checked for landmarks, page heading structure, and links
- [ ] Tried to break the intended flow

#### Validated user-facing changes as a designer

- [x] Checked keyboard navigability
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)

- [ ] Tested with multiple browsers (check off which ones were used)
  - [x] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari

- [ ] (Rarely needed) Tested as both an analyst and applicant user

## Screenshots

<!-- If this PR makes visible interface changes, an image of the finished interface can help reviewers
and casual observers understand the context of the changes.
A before image is optional and can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow.
You may want to use [GIPHY Capture](https://giphy.com/apps/giphycapture) for this! 📸

_Please frame images to show useful context but also highlight the affected regions._
--->
