### PR TITLE
Changed DNS sidebar nav / Put DNS options in a list on DNS landing page

### DIFF
--- a/src/registrar/templates/domain_dns.html
+++ b/src/registrar/templates/domain_dns.html
@@ -12,9 +12,11 @@
   <p>You can enter your name servers, as well as other DNS-related information, in the following sections:</p>
 
   {% url 'domain-dns-nameservers' pk=domain.id as url %}
-  <p><a href="{{ url }}">DNS name servers</a></p>
+<ul>  
+<li><a href="{{ url }}">DNS name servers</a></li>
 
   {% url 'domain-dns-dnssec' pk=domain.id as url %}
-  <p><a href="{{ url }}">DNSSEC</a></p>
+  <li><a href="{{ url }}">DNSSEC</a></li>
+</ul>
 
 {% endblock %}  {# domain_content #}

--- a/src/registrar/templates/domain_dns.html
+++ b/src/registrar/templates/domain_dns.html
@@ -13,7 +13,7 @@
 
   {% url 'domain-dns-nameservers' pk=domain.id as url %}
 <ul>  
-<li><a href="{{ url }}">DNS name servers</a></li>
+<li><a href="{{ url }}">Name servers</a></li>
 
   {% url 'domain-dns-dnssec' pk=domain.id as url %}
   <li><a href="{{ url }}">DNSSEC</a></li>

--- a/src/registrar/templates/domain_sidebar.html
+++ b/src/registrar/templates/domain_sidebar.html
@@ -24,7 +24,7 @@
             <a href="{{ url }}"
               {% if request.path == url %}class="usa-current"{% endif %}
             >
-                DNS name servers
+                Name servers
             </a>
           </li>
 

--- a/src/registrar/templates/domain_sidebar.html
+++ b/src/registrar/templates/domain_sidebar.html
@@ -24,7 +24,7 @@
             <a href="{{ url }}"
               {% if request.path == url %}class="usa-current"{% endif %}
             >
-                Name servers
+                DNS name servers
             </a>
           </li>
 
@@ -43,7 +43,7 @@
                   <a href="{{ url }}"
                     {% if request.path == url %}class="usa-current"{% endif %}
                   >
-                      DS Data
+                      DS data
                   </a>
                 </li>
               </ul>


### PR DESCRIPTION
## Changes

<!-- What was added, updated, or removed in this PR. -->
- Changed "Name servers" to "DNS name servers"
- Changed "DS Data" to "DS data" (related to https://github.com/cisagov/manage.get.gov/issues/1388)
- Bulleted DNS options on DNS landing page