### PR TITLE
Issue #1218 - Update the stored expiration date value anytime it's received (STAGED ON BL)

### DIFF
--- a/src/registrar/models/domain.py
+++ b/src/registrar/models/domain.py
@@ -214,9 +214,7 @@ class Domain(TimeStampedModel, DomainHelper):
         """Get or set the `ex_date` element from the registry.
         Additionally, update the expiration date in the registrar"""
         try:
-            self.expiration_date = self._get_property("ex_date")
-            self.save()
-            return self.expiration_date
+            return self._get_property("ex_date")
         except Exception as e:
             # exception raised during the save to registrar
             logger.error(f"error updating expiration date in registrar: {e}")
@@ -1601,6 +1599,12 @@ class Domain(TimeStampedModel, DomainHelper):
                 cleaned["hosts"] = self._get_hosts(cleaned.get("_hosts", []))
                 if old_cache_contacts is not None:
                     cleaned["contacts"] = old_cache_contacts
+
+            # if expiration date from registry does not match what is in db,
+            # update the db
+            if "ex_date" in cleaned and cleaned["ex_date"] != self.expiration_date:
+                self.expiration_date = cleaned["ex_date"]
+                self.save()
 
             self._cache = cleaned
 

--- a/src/registrar/models/domain.py
+++ b/src/registrar/models/domain.py
@@ -212,7 +212,7 @@ class Domain(TimeStampedModel, DomainHelper):
     @Cache
     def registry_expiration_date(self) -> date:
         """Get or set the `ex_date` element from the registry.
-        Additionally, update the expiration date in the registrar"""
+        Additionally, _get_property updates the expiration date in the registrar"""
         try:
             return self._get_property("ex_date")
         except Exception as e:

--- a/src/registrar/tests/common.py
+++ b/src/registrar/tests/common.py
@@ -617,6 +617,7 @@ class MockEppLib(TestCase):
             common.Status(state="serverTransferProhibited", description="", lang="en"),
             common.Status(state="inactive", description="", lang="en"),
         ],
+        ex_date=datetime.date(2023, 5, 25),
     )
     mockDataInfoContact = mockDataInfoDomain.dummyInfoContactResultData(
         "123", "123@mail.gov", datetime.datetime(2023, 5, 25, 19, 45, 35), "lastPw"

--- a/src/registrar/tests/test_models_domain.py
+++ b/src/registrar/tests/test_models_domain.py
@@ -1987,6 +1987,13 @@ class TestExpirationDate(MockEppLib):
         with self.assertRaises(RegistryError):
             self.domain_w_error.renew_domain()
 
+    def test_expiration_date_updated_on_info_domain_call(self):
+        """assert that expiration date in db is updated on info domain call"""
+        # force fetch_cache to be called
+        self.domain.statuses
+        test_date = datetime.date(2023, 5, 25)
+        self.assertEquals(self.domain.expiration_date, test_date)
+
 
 class TestAnalystClientHold(MockEppLib):
     """Rule: Analysts may suspend or restore a domain by using client hold"""


### PR DESCRIPTION
## Ticket

Resolves #1218
<!--Reminder, when a code change is made that is user facing, beyond content updates, then the following are required:
- a developer approves the PR
- a designer approves the PR or checks off all relevant items in this checklist.

All other changes require just a single approving review.-->

## Changes

<!-- What was added, updated, or removed in this PR. -->
- Expiration date is updated in db when fetch_cache in domain model is called

<!--
    Please add/remove/edit any of the template below to fit the needs
    of this specific PR.
--->

## Context for reviewers

<!--Background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers.  -->
This change is staged in [BL Sandbox](https://getgov-bl.app.cloud.gov/)

Go to django admin.  Find a domain that is Ready and has an expiration date in the registry, but not in the database.  If you click on the domain in django admin, you will see -- for the expiration date rather than a date.  Now, Add a UserDomainRole for your user as a Manager for that domain.  Once you do that, go to the app, and you should see that domain in your list of domains.  Click the domain to manage it.  Clicking the domain will call InfoDomain.  Now go back to django admin and look again at this domain.  You should now see the expiration date in the db that was set from the registry.

## Setup

<!--  Add any steps or code to run in this section to help others run your code.
    
    Example 1:
    ```sh
    echo "Code goes here"
    ``` 
    
    Example 2: If the PR was to add a new link with a redirect, this section could simply be:
    -go to /path/to/start/page
    -click the blue link in the <insert location>
    -notice user is redirected to <proper end location>
-->

## Code Review Verification Steps

### As the original developer, I have

#### Satisfied acceptance criteria and met development standards

- [ ] Met the acceptance criteria, or will meet them in a subsequent PR
- [ ] Created/modified automated tests
- [ ] Added at least 2 developers as PR reviewers (only 1 will need to approve)
- [ ] Messaged on Slack or in standup to notify the team that a PR is ready for review
- [ ] Changes to “how we do things” are documented in READMEs and or onboarding guide
- [ ] If any model was updated to modify/add/delete columns, makemigrations was ran and the assoicated migrations file has been commited.

#### Ensured code standards are met (Original Developer)

- [ ] All new functions and methods are commented using plain language
- [ ] Did dependency updates in Pipfile also get changed in requirements.txt?
- [ ] Interactions with external systems are wrapped in try/except
- [ ] Error handling exists for unusual or missing values

#### Validated user-facing changes (if applicable)

- [ ] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Checked keyboard navigability
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)
- [ ] Add at least 1 designer as PR reviewer

### As a code reviewer, I have

#### Reviewed, tested, and left feedback about the changes

- [ ] Pulled this branch locally and tested it
- [ ] Reviewed this code and left comments
- [ ] Checked that all code is adequately covered by tests
- [ ] Made it clear which comments need to be addressed before this work is merged
- [ ] If any model was updated to modify/add/delete columns, makemigrations was ran and the assoicated migrations file has been commited.

#### Ensured code standards are met (Code reviewer)

- [ ] All new functions and methods are commented using plain language
- [ ] Interactions with external systems are wrapped in try/except
- [ ] Error handling exists for unusual or missing values
- [ ] (Rarely needed) Did dependency updates in Pipfile also get changed in requirements.txt?

#### Validated user-facing changes as a developer

- [ ] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Checked keyboard navigability
- [ ] Meets all designs and user flows provided by design/product
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)

- [ ] Tested with multiple browsers, the suggestion is to use ones that the developer didn't (check off which ones were used)
  - [ ] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari

- [ ] (Rarely needed) Tested as both an analyst and applicant user

**Note:** Multiple code reviewers can share the checklists above, a second reviewers should not make a duplicate checklist

### As a designer reviewer, I have

#### Verified that the changes match the design intention

- [ ] Checked that the design translated visually
- [ ] Checked behavior
- [ ] Checked different states (empty, one, some, error)
- [ ] Checked for landmarks, page heading structure, and links
- [ ] Tried to break the intended flow

#### Validated user-facing changes as a designer

- [ ] Checked keyboard navigability
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)

- [ ] Tested with multiple browsers (check off which ones were used)
  - [ ] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari

- [ ] (Rarely needed) Tested as both an analyst and applicant user

## Screenshots

<!-- If this PR makes visible interface changes, an image of the finished interface can help reviewers
and casual observers understand the context of the changes.
A before image is optional and can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow.
You may want to use [GIPHY Capture](https://giphy.com/apps/giphycapture) for this! 📸

_Please frame images to show useful context but also highlight the affected regions._
--->
