### PR TITLE
Issue #872 - Prevent user from submitting multiple applications (STAGED IN DK SANDBOX)

### DIFF
--- a/src/registrar/templates/application_form.html
+++ b/src/registrar/templates/application_form.html
@@ -23,7 +23,7 @@
 {% endblock %}
 
 {% if pending_requests_message %}
-<div class="usa-alert usa-alert--info margin-bottom-2">
+<div class="usa-alert usa-alert--info margin-bottom-3">
   <div class="usa-alert__body">
     {{ pending_requests_message }}
   </div>

--- a/src/registrar/templates/application_form.html
+++ b/src/registrar/templates/application_form.html
@@ -66,6 +66,13 @@
               value="next"
               class="usa-button"
             >Save and continue</button>
+            {% elif pending_requests_exist %}
+            <button
+              type="submit"
+              name="submit_button"
+              value="save_and_return"
+              class="usa-button usa-button--outline"
+            >Save and return to manage your domains</button>
             {% else %}
             <button
               type="submit"

--- a/src/registrar/templates/application_form.html
+++ b/src/registrar/templates/application_form.html
@@ -22,6 +22,14 @@
           {% include "includes/form_messages.html" %}
 {% endblock %}
 
+{% if pending_requests_message %}
+<div class="usa-alert usa-alert--info margin-bottom-2">
+  <div class="usa-alert__body">
+    {{ pending_requests_message }}
+  </div>
+</div>
+{% endif %}
+
 {% block form_errors %}
         {% comment %}
            to make sense of this loop, consider that 

--- a/src/registrar/templates/domain_dnssec.html
+++ b/src/registrar/templates/domain_dnssec.html
@@ -40,9 +40,9 @@
     >
     {% else %}
     <div id="enable-dnssec">
-      <div class="usa-alert usa-alert--info usa-alert--slim">
+      <div class="usa-alert usa-alert--info">
         <div class="usa-alert__body">
-          It is strongly recommended that you only enable DNSSEC if you know how to set it up properly at your hosting service. If you make a mistake, it could cause your domain name to stop working.
+          <p>It is strongly recommended that you only enable DNSSEC if you know how to set it up properly at your hosting service. If you make a mistake, it could cause your domain name to stop working.</p>
         </div>
       </div>
       <a href="{% url 'domain-dns-dnssec-dsdata' pk=domain.id %}" class="usa-button">Enable DNSSEC</a>

--- a/src/registrar/templates/domain_dnssec.html
+++ b/src/registrar/templates/domain_dnssec.html
@@ -42,7 +42,7 @@
     <div id="enable-dnssec">
       <div class="usa-alert usa-alert--info">
         <div class="usa-alert__body">
-          <p>It is strongly recommended that you only enable DNSSEC if you know how to set it up properly at your hosting service. If you make a mistake, it could cause your domain name to stop working.</p>
+          <p class="margin-y-0">It is strongly recommended that you only enable DNSSEC if you know how to set it up properly at your hosting service. If you make a mistake, it could cause your domain name to stop working.</p>
         </div>
       </div>
       <a href="{% url 'domain-dns-dnssec-dsdata' pk=domain.id %}" class="usa-button">Enable DNSSEC</a>

--- a/src/registrar/templates/domain_nameservers.html
+++ b/src/registrar/templates/domain_nameservers.html
@@ -15,7 +15,7 @@
 
   <p>Add a name server record by entering the address (e.g., ns1.nameserver.com) in the name server fields below. You must add at least two name servers (13 max).</p>
 
-  <div class="usa-alert usa-alert--slim usa-alert--info">
+  <div class="usa-alert usa-alert--info">
     <div class="usa-alert__body">
       <p class="margin-top-0">Add an IP address only when your name server's address includes your domain name (e.g., if your domain name is “example.gov” and your name server is “ns1.example.gov,” then an IP address is required). Multiple IP addresses must be separated with commas.</p>
       <p class="margin-bottom-0">This step is uncommon unless you self-host your DNS or use custom addresses for your nameserver.</p>

--- a/src/registrar/tests/test_views.py
+++ b/src/registrar/tests/test_views.py
@@ -1255,6 +1255,8 @@ class TestDomainOverview(TestWithDomainPermissions, WebTest):
         self.app.set_user(self.user.username)
         self.client.force_login(self.user)
 
+
+class TestDomainDetail(TestDomainOverview):
     def test_domain_detail_link_works(self):
         home_page = self.app.get("/")
         self.assertContains(home_page, "igorville.gov")
@@ -1263,7 +1265,7 @@ class TestDomainOverview(TestWithDomainPermissions, WebTest):
         self.assertContains(detail_page, "igorville.gov")
         self.assertContains(detail_page, "Status")
 
-    def test_domain_overview_blocked_for_ineligible_user(self):
+    def test_domain_detail_blocked_for_ineligible_user(self):
         """We could easily duplicate this test for all domain management
         views, but a single url test should be solid enough since all domain
         management pages share the same permissions class"""
@@ -1275,7 +1277,7 @@ class TestDomainOverview(TestWithDomainPermissions, WebTest):
             response = self.client.get(reverse("domain", kwargs={"pk": self.domain.id}))
             self.assertEqual(response.status_code, 403)
 
-    def test_domain_overview_allowed_for_on_hold(self):
+    def test_domain_detail_allowed_for_on_hold(self):
         """Test that the domain overview page displays for on hold domain"""
         home_page = self.app.get("/")
         self.assertContains(home_page, "on-hold.gov")
@@ -1284,7 +1286,7 @@ class TestDomainOverview(TestWithDomainPermissions, WebTest):
         detail_page = self.client.get(reverse("domain", kwargs={"pk": self.domain_on_hold.id}))
         self.assertNotContains(detail_page, "Edit")
 
-    def test_domain_see_just_nameserver(self):
+    def test_domain_detail_see_just_nameserver(self):
         home_page = self.app.get("/")
         self.assertContains(home_page, "justnameserver.com")
 
@@ -1295,7 +1297,7 @@ class TestDomainOverview(TestWithDomainPermissions, WebTest):
         self.assertContains(detail_page, "ns1.justnameserver.com")
         self.assertContains(detail_page, "ns2.justnameserver.com")
 
-    def test_domain_see_nameserver_and_ip(self):
+    def test_domain_detail_see_nameserver_and_ip(self):
         home_page = self.app.get("/")
         self.assertContains(home_page, "nameserverwithip.gov")
 
@@ -1311,7 +1313,7 @@ class TestDomainOverview(TestWithDomainPermissions, WebTest):
         self.assertContains(detail_page, "(1.2.3.4,")
         self.assertContains(detail_page, "2.3.4.5)")
 
-    def test_domain_with_no_information_or_application(self):
+    def test_domain_detail_with_no_information_or_application(self):
         """Test that domain management page returns 200 and displays error
         when no domain information or domain application exist"""
         # have to use staff user for this test

--- a/src/registrar/tests/test_views.py
+++ b/src/registrar/tests/test_views.py
@@ -146,7 +146,7 @@ class DomainApplicationTests(TestWithUser, WebTest):
 
     def test_application_multiple_applications_exist(self):
         """Test that an info message appears when user has multiple applications already"""
-        # create and submit an application, and set ti in_review status
+        # create and submit an application
         contact = Contact.objects.create()
         com_website, _ = Website.objects.get_or_create(website="igorville.com")
         gov_website, _ = Website.objects.get_or_create(website="igorville.gov")
@@ -173,10 +173,7 @@ class DomainApplicationTests(TestWithUser, WebTest):
         application.alternative_domains.add(gov_website)
         application.other_contacts.add(contact)
         application.submit()
-        application.in_review()
         application.save()
-        print(application.creator)
-        print(application.status)
 
         # now, attempt to create another one
         with less_console_noise():

--- a/src/registrar/tests/test_views.py
+++ b/src/registrar/tests/test_views.py
@@ -147,31 +147,7 @@ class DomainApplicationTests(TestWithUser, WebTest):
     def test_application_multiple_applications_exist(self):
         """Test that an info message appears when user has multiple applications already"""
         # create and submit an application
-        contact = Contact.objects.create()
-        com_website, _ = Website.objects.get_or_create(website="igorville.com")
-        gov_website, _ = Website.objects.get_or_create(website="igorville.gov")
-        domain, _ = DraftDomain.objects.get_or_create(name="igorville.gov")
-        application = DomainApplication.objects.create(
-            creator=self.user,
-            investigator=self.user,
-            organization_type=DomainApplication.OrganizationChoices.FEDERAL,
-            federal_type=DomainApplication.BranchChoices.EXECUTIVE,
-            is_election_board=False,
-            organization_name="Test",
-            address_line1="100 Main St.",
-            address_line2="APT 1A",
-            state_territory="CA",
-            zipcode="12345-6789",
-            authorizing_official=contact,
-            requested_domain=domain,
-            submitter=contact,
-            purpose="Igorville rules!",
-            anything_else="All of Igorville loves the dotgov program.",
-            is_policy_acknowledged=True,
-        )
-        application.current_websites.add(com_website)
-        application.alternative_domains.add(gov_website)
-        application.other_contacts.add(contact)
+        application = completed_application(user=self.user)
         application.submit()
         application.save()
 

--- a/src/registrar/tests/test_views.py
+++ b/src/registrar/tests/test_views.py
@@ -36,9 +36,7 @@ from registrar.models import (
 from registrar.views.application import ApplicationWizard, Step
 
 from .common import less_console_noise
-import logging
 
-logger = logging.getLogger(__name__)
 
 class TestViews(TestCase):
     def setUp(self):

--- a/src/registrar/views/application.py
+++ b/src/registrar/views/application.py
@@ -382,7 +382,6 @@ class ApplicationWizard(ApplicationWizardPermissionView, TemplateView):
         # if user opted to save progress and return,
         # return them to the home page
         if button == "save_and_return":
-            messages.success(request, "Your progress has been saved!")
             return HttpResponseRedirect(reverse("home"))
         # otherwise, proceed as normal
         return self.goto_next_step()

--- a/src/registrar/views/application.py
+++ b/src/registrar/views/application.py
@@ -314,8 +314,10 @@ class ApplicationWizard(ApplicationWizardPermissionView, TemplateView):
         if self.application.status == DomainApplication.ACTION_NEEDED:
             return []
         check_statuses = [DomainApplication.SUBMITTED, DomainApplication.IN_REVIEW, DomainApplication.ACTION_NEEDED]
-        filter_conditions = Q(creator=self.request.user) & Q(status__in=check_statuses)
-        return DomainApplication.objects.filter(filter_conditions)
+    return DomainApplication.objects.filter(
+        creator=self.request.user,
+        status__in=check_statuses
+    )
 
     def get_context_data(self):
         """Define context for access on all wizard pages."""

--- a/src/registrar/views/application.py
+++ b/src/registrar/views/application.py
@@ -313,7 +313,7 @@ class ApplicationWizard(ApplicationWizardPermissionView, TemplateView):
         # if the current application has ACTION_NEEDED status, this check should not be performed
         if self.application.status == DomainApplication.ACTION_NEEDED:
             return []
-        check_statuses = [DomainApplication.APPROVED, DomainApplication.IN_REVIEW, DomainApplication.ACTION_NEEDED]
+        check_statuses = [DomainApplication.SUBMITTED, DomainApplication.IN_REVIEW, DomainApplication.ACTION_NEEDED]
         filter_conditions = Q(creator=self.request.user) & Q(status__in=check_statuses)
         return DomainApplication.objects.filter(filter_conditions)
 

--- a/src/registrar/views/application.py
+++ b/src/registrar/views/application.py
@@ -8,7 +8,6 @@ from django.utils.safestring import mark_safe
 from django.utils.translation import gettext_lazy as _
 from django.views.generic import TemplateView
 from django.contrib import messages
-from typing import List
 
 from registrar.forms import application_wizard as forms
 from registrar.models import DomainApplication
@@ -231,11 +230,11 @@ class ApplicationWizard(ApplicationWizardPermissionView, TemplateView):
             message_content = (
                 f"<h4 class='usa-alert__heading'>{message_header}</h4>"
                 "<p>New domain requests cannot be submitted until we have finished reviewing your pending request: "
-                f"<strong>{pending_requests[0].requested_domain}</strong>. You can continue to fill out this request and "
-                "save it as a draft to be submitted later. "
+                f"<strong>{pending_requests[0].requested_domain}</strong>. You can continue to fill out this request "
+                "and save it as a draft to be submitted later. "
                 f"<a class='usa-link' href='{reverse('home')}'>View your pending requests.</a></p>"
             )
-            messages.info(request, mark_safe(message_content))
+            messages.info(request, mark_safe(message_content))  # nosec
         context["pending_requests_exist"] = len(pending_requests) > 0
 
         return render(request, self.template_name, context)
@@ -286,30 +285,29 @@ class ApplicationWizard(ApplicationWizardPermissionView, TemplateView):
 
         return instantiated
 
-    def pending_requests(self) -> List[DomainApplication]:
+    def pending_requests(self):
         """return an array of pending requests if user has pending requests
         and no approved requests"""
         if self.approved_applications_exist() or self.approved_domains_exist():
             return []
         else:
             return self.pending_applications()
-    
-    def approved_applications_exist(self) -> bool:
+
+    def approved_applications_exist(self):
         """Checks if user is creator of applications with APPROVED status"""
         approved_application_count = DomainApplication.objects.filter(
-            creator=self.request.user,
-            status=DomainApplication.APPROVED
+            creator=self.request.user, status=DomainApplication.APPROVED
         ).count()
         return approved_application_count > 0
 
-    def approved_domains_exist(self) -> bool:
+    def approved_domains_exist(self):
         """Checks if user has permissions on approved domains
-        
+
         This additional check is necessary to account for domains which were migrated
         and do not have an application"""
         return self.request.user.permissions.count() > 0
-    
-    def pending_applications(self) -> List[DomainApplication]:
+
+    def pending_applications(self):
         """Returns a List of user's applications with one of the following states:
         SUBMITTED, IN_REVIEW, ACTION_NEEDED"""
         # if the current application has ACTION_NEEDED status, this check should not be performed

--- a/src/registrar/views/application.py
+++ b/src/registrar/views/application.py
@@ -221,18 +221,19 @@ class ApplicationWizard(ApplicationWizardPermissionView, TemplateView):
         context["forms"] = self.get_forms()
 
         # if pending requests exist and user does not have approved domains,
-        #     present message that domain application cannot be submitted
+        # present message that domain application cannot be submitted
         pending_requests = self.pending_requests()
         if len(pending_requests) > 0:
             message_header = "You cannot submit this request yet"
             message_content = (
-                f"<h4 class='usa-alert__heading'>{message_header}</h4>"
+                f"<h4 class='usa-alert__heading'>{message_header}</h4> "
                 "<p class='margin-bottom-0'>New domain requests cannot be submitted until we have finished "
                 f"reviewing your pending request: <strong>{pending_requests[0].requested_domain}</strong>. "
                 "You can continue to fill out this request and save it as a draft to be submitted later. "
                 f"<a class='usa-link' href='{reverse('home')}'>View your pending requests.</a></p>"
             )
-            messages.info(request, mark_safe(message_content))  # nosec
+            context["pending_requests_message"] = mark_safe(message_content)  # nosec
+
         context["pending_requests_exist"] = len(pending_requests) > 0
 
         return render(request, self.template_name, context)

--- a/src/registrar/views/application.py
+++ b/src/registrar/views/application.py
@@ -224,7 +224,6 @@ class ApplicationWizard(ApplicationWizardPermissionView, TemplateView):
         #     present message that domain application cannot be submitted
         pending_requests = self.pending_requests()
         if len(pending_requests) > 0:
-            # TODO may want to move this whole thing to utility/errors.py
             message_header = "You cannot submit this request yet"
             message_content = (
                 f"<h4 class='usa-alert__heading'>{message_header}</h4>"

--- a/src/registrar/views/application.py
+++ b/src/registrar/views/application.py
@@ -227,7 +227,7 @@ class ApplicationWizard(ApplicationWizardPermissionView, TemplateView):
             message_header = "You cannot submit this request yet"
             message_content = (
                 f"<h4 class='usa-alert__heading'>{message_header}</h4>"
-                "<p>New domain requests cannot be submitted until we have finished reviewing your pending request: "
+                "<p class="margin-bottom-0">New domain requests cannot be submitted until we have finished reviewing your pending request: "
                 f"<strong>{pending_requests[0].requested_domain}</strong>. You can continue to fill out this request "
                 "and save it as a draft to be submitted later. "
                 f"<a class='usa-link' href='{reverse('home')}'>View your pending requests.</a></p>"

--- a/src/registrar/views/application.py
+++ b/src/registrar/views/application.py
@@ -227,9 +227,9 @@ class ApplicationWizard(ApplicationWizardPermissionView, TemplateView):
             message_header = "You cannot submit this request yet"
             message_content = (
                 f"<h4 class='usa-alert__heading'>{message_header}</h4>"
-                "<p class="margin-bottom-0">New domain requests cannot be submitted until we have finished reviewing your pending request: "
-                f"<strong>{pending_requests[0].requested_domain}</strong>. You can continue to fill out this request "
-                "and save it as a draft to be submitted later. "
+                "<p class='margin-bottom-0'>New domain requests cannot be submitted until we have finished "
+                f"reviewing your pending request: <strong>{pending_requests[0].requested_domain}</strong>. "
+                "You can continue to fill out this request and save it as a draft to be submitted later. "
                 f"<a class='usa-link' href='{reverse('home')}'>View your pending requests.</a></p>"
             )
             messages.info(request, mark_safe(message_content))  # nosec

--- a/src/registrar/views/application.py
+++ b/src/registrar/views/application.py
@@ -1,11 +1,14 @@
 import logging
 
 from django.http import Http404, HttpResponse, HttpResponseRedirect
+from django.db.models import Q
 from django.shortcuts import redirect, render
 from django.urls import resolve, reverse
+from django.utils.safestring import mark_safe
 from django.utils.translation import gettext_lazy as _
 from django.views.generic import TemplateView
 from django.contrib import messages
+from typing import List
 
 from registrar.forms import application_wizard as forms
 from registrar.models import DomainApplication
@@ -218,6 +221,23 @@ class ApplicationWizard(ApplicationWizardPermissionView, TemplateView):
         self.steps.current = current_url
         context = self.get_context_data()
         context["forms"] = self.get_forms()
+
+        # if pending requests exist and user does not have approved domains,
+        #     present message that domain application cannot be submitted
+        pending_requests = self.pending_requests()
+        if len(pending_requests) > 0:
+            # TODO may want to move this whole thing to utility/errors.py
+            message_header = "You cannot submit this request yet"
+            message_content = (
+                f"<h4 class='usa-alert__heading'>{message_header}</h4>"
+                "<p>New domain requests cannot be submitted until we have finished reviewing your pending request: "
+                f"<strong>{pending_requests[0].requested_domain}</strong>. You can continue to fill out this request and "
+                "save it as a draft to be submitted later. "
+                f"<a class='usa-link' href='{reverse('home')}'>View your pending requests.</a></p>"
+            )
+            messages.info(request, mark_safe(message_content))
+        context["pending_requests_exist"] = len(pending_requests) > 0
+
         return render(request, self.template_name, context)
 
     def get_all_forms(self, **kwargs) -> list:
@@ -265,6 +285,39 @@ class ApplicationWizard(ApplicationWizardPermissionView, TemplateView):
                 instantiated.append(form(initial=data, **kwargs))
 
         return instantiated
+
+    def pending_requests(self) -> List[DomainApplication]:
+        """return an array of pending requests if user has pending requests
+        and no approved requests"""
+        if self.approved_applications_exist() or self.approved_domains_exist():
+            return []
+        else:
+            return self.pending_applications()
+    
+    def approved_applications_exist(self) -> bool:
+        """Checks if user is creator of applications with APPROVED status"""
+        approved_application_count = DomainApplication.objects.filter(
+            creator=self.request.user,
+            status=DomainApplication.APPROVED
+        ).count()
+        return approved_application_count > 0
+
+    def approved_domains_exist(self) -> bool:
+        """Checks if user has permissions on approved domains
+        
+        This additional check is necessary to account for domains which were migrated
+        and do not have an application"""
+        return self.request.user.permissions.count() > 0
+    
+    def pending_applications(self) -> List[DomainApplication]:
+        """Returns a List of user's applications with one of the following states:
+        SUBMITTED, IN_REVIEW, ACTION_NEEDED"""
+        # if the current application has ACTION_NEEDED status, this check should not be performed
+        if self.application.status == DomainApplication.ACTION_NEEDED:
+            return []
+        check_statuses = [DomainApplication.APPROVED, DomainApplication.IN_REVIEW, DomainApplication.ACTION_NEEDED]
+        filter_conditions = Q(creator=self.request.user) & Q(status__in=check_statuses)
+        return DomainApplication.objects.filter(filter_conditions)
 
     def get_context_data(self):
         """Define context for access on all wizard pages."""
@@ -328,6 +381,11 @@ class ApplicationWizard(ApplicationWizardPermissionView, TemplateView):
         if button == "save":
             messages.success(request, "Your progress has been saved!")
             return self.goto(self.steps.current)
+        # if user opted to save progress and return,
+        # return them to the home page
+        if button == "save_and_return":
+            messages.success(request, "Your progress has been saved!")
+            return HttpResponseRedirect(reverse("home"))
         # otherwise, proceed as normal
         return self.goto_next_step()
 

--- a/src/registrar/views/application.py
+++ b/src/registrar/views/application.py
@@ -1,7 +1,6 @@
 import logging
 
 from django.http import Http404, HttpResponse, HttpResponseRedirect
-from django.db.models import Q
 from django.shortcuts import redirect, render
 from django.urls import resolve, reverse
 from django.utils.safestring import mark_safe
@@ -314,10 +313,7 @@ class ApplicationWizard(ApplicationWizardPermissionView, TemplateView):
         if self.application.status == DomainApplication.ACTION_NEEDED:
             return []
         check_statuses = [DomainApplication.SUBMITTED, DomainApplication.IN_REVIEW, DomainApplication.ACTION_NEEDED]
-    return DomainApplication.objects.filter(
-        creator=self.request.user,
-        status__in=check_statuses
-    )
+        return DomainApplication.objects.filter(creator=self.request.user, status__in=check_statuses)
 
     def get_context_data(self):
         """Define context for access on all wizard pages."""


### PR DESCRIPTION
## Ticket

Resolves #872 
<!--Reminder, when a code change is made that is user facing, beyond content updates, then the following are required:
- a developer approves the PR
- a designer approves the PR or checks off all relevant items in this checklist.

All other changes require just a single approving review.-->

## Changes

<!-- What was added, updated, or removed in this PR. -->
- Checks added for conditions that prevent user from submitting multiple applications
- Informational message displayed when conditions are met
- Submit button is changed on review page in application when conditions are met

<!--
    Please add/remove/edit any of the template below to fit the needs
    of this specific PR.
--->

### Alerts refactoring

Full size alert is only used for informational purposes and never for alerts that are triggered by form interaction. 
Alerts that are triggered by form interaction are slim. See [slack thread](https://cisa-corp.slack.com/archives/C05BGB4L5NF/p1701257550133219) for reference.

- There are large triggered alerts. The one we're using on 872 is one such alert. We can refactor those instances to use a large variant (for future documentation, this alert will be `pending_requests_message` in the code)
- On domain management pages: There are currently 21 alerts triggered by form success/error/warning. They are all small one liners except for this guy (see screenshot)
- Revised persistent alerts on DNSSEC and nameservers to use full variant (screenshots)
- Kept DS Data persistent alert slim

## Context for reviewers

<!--Background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers.  -->

**This PR is staged in [DK Sandbox](https://getgov-dk.app.cloud.gov/)**

Here is the [FIGMA link](https://www.figma.com/proto/aJbuDLJNNikqQObTuCNKQa/GetGov_Designs_ECS-Truss?page-id=4829%3A39692&type=design&node-id=754-30047&viewport=1151%2C-64%2C0.28&t=06tdmsLsE9S8vmBx-1&scaling=min-zoom&starting-point-node-id=754%3A29647&show-proto-sidebar=1) which shows the desired user interactions.

**Design review:**
The first test assumes that you have at least one domain in your account.
For the first test, click 'Start a new domain request' on the home page.  When you do so, you should see no blue info message at the top of the page.  If no info message, then this test is successful, and go through the setup outlined in the SetUp section below for other tests.

Once you follow the setup below, you should have zero domains on your home page.  Under Domains, it should read 'You don't have any registered domains yet'.  And you should have at least one domain requests with one of the following statuses: IN_REVIEW, APPROVED, ACTION_NEEDED

For the second test, you will be testing that the presence of zero approved domains, and one or more requests in the above states, will produce an blue info message at the top of the application screen.
Go to the home page, and click 'Start a new domain request'. Test that you receive an info message 'You cannot submit this request yet' at the top of the application page.  Continue to fill out the application, and verify that this message appears at the top of every page in the application process.  On the review page, the button should be an outlined button that reads, 'Save and return to manage your domains'.  When this is clicked, changes will be saved and you will be directed to home page.  You should now see the application you created, and the status should be Started.  If you click Edit, you should see your application and the same info message at the top of the page.

For the third test, test that you don't receive the info message when you click on a domain application with a Status of Action Needed.  On the home page, find a domain request with Status of 'Action Needed'.  When you click 'Edit' you should see the domain application page, and there should be no blue info message at the top of the screen.

**Developer Code Review:**
templates/application_form.html - added a new conditional button when user should be blocked from submitting; button has value of save_and_return, which is handled in the view
views/application.py - added methods which determine if approved domain applications exist, if domains exist, and if domain applications with status in (IN_REVIEW, ACTION_NEEDED, or SUBMITTED) exist; info message added in get() if conditions met; variable added to context in order to display the proper submit button; post set up to handle new submit button

## Setup

It is likely that you already have at least one domain in your account.  If so, perform the first test above before following the rest of the setup.

The setup for this can be quite involved, depending upon how many domains and domain applications you have associated with your user.

For each domain which is showing on your home page, you need to perform the following in django admin:
- delete each contact associated with the domain
- delete the domain
- delete the domain application associated with the domain

Once you have deleted all domains associated with the user, you need to make sure there exists at least one domain application that is either IN_REVIEW, APPROVED, or ACTION_NEEDED.  In order to test ACTION_NEEDED, you should have at least one domain application with ACTION_NEEDED status.

<!--  Add any steps or code to run in this section to help others run your code.
    
    Example 1:
    ```sh
    echo "Code goes here"
    ``` 
    
    Example 2: If the PR was to add a new link with a redirect, this section could simply be:
    -go to /path/to/start/page
    -click the blue link in the <insert location>
    -notice user is redirected to <proper end location>
-->

## Code Review Verification Steps

### As the original developer, I have

#### Satisfied acceptance criteria and met development standards

- [ ] Met the acceptance criteria, or will meet them in a subsequent PR
- [ ] Created/modified automated tests
- [ ] Added at least 2 developers as PR reviewers (only 1 will need to approve)
- [ ] Messaged on Slack or in standup to notify the team that a PR is ready for review
- [ ] Changes to “how we do things” are documented in READMEs and or onboarding guide
- [ ] If any model was updated to modify/add/delete columns, makemigrations was ran and the assoicated migrations file has been commited.

#### Ensured code standards are met (Original Developer)

- [ ] All new functions and methods are commented using plain language
- [ ] Did dependency updates in Pipfile also get changed in requirements.txt?
- [ ] Interactions with external systems are wrapped in try/except
- [ ] Error handling exists for unusual or missing values

#### Validated user-facing changes (if applicable)

- [ ] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Checked keyboard navigability
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)
- [ ] Add at least 1 designer as PR reviewer

### As a code reviewer, I have

#### Reviewed, tested, and left feedback about the changes

- [x] Pulled this branch locally and tested it
- [x] Reviewed this code and left comments
- [x] Checked that all code is adequately covered by tests
- [x] Made it clear which comments need to be addressed before this work is merged
- [ ] If any model was updated to modify/add/delete columns, makemigrations was ran and the assoicated migrations file has been commited.

#### Ensured code standards are met (Code reviewer)

- [x] All new functions and methods are commented using plain language
- [x] Interactions with external systems are wrapped in try/except
- [x] Error handling exists for unusual or missing values
- [ ] (Rarely needed) Did dependency updates in Pipfile also get changed in requirements.txt?

#### Validated user-facing changes as a developer

- [ ] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Checked keyboard navigability
- [ ] Meets all designs and user flows provided by design/product
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)

- [ ] Tested with multiple browsers, the suggestion is to use ones that the developer didn't (check off which ones were used)
  - [ ] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari

- [ ] (Rarely needed) Tested as both an analyst and applicant user

**Note:** Multiple code reviewers can share the checklists above, a second reviewers should not make a duplicate checklist

### As a designer reviewer, I have

#### Verified that the changes match the design intention

- [ ] Checked that the design translated visually
- [ ] Checked behavior
- [ ] Checked different states (empty, one, some, error)
- [ ] Checked for landmarks, page heading structure, and links
- [ ] Tried to break the intended flow

#### Validated user-facing changes as a designer

- [ ] Checked keyboard navigability
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)

- [ ] Tested with multiple browsers (check off which ones were used)
  - [ ] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari

- [ ] (Rarely needed) Tested as both an analyst and applicant user

## Screenshots

<!-- If this PR makes visible interface changes, an image of the finished interface can help reviewers
and casual observers understand the context of the changes.
A before image is optional and can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow.
You may want to use [GIPHY Capture](https://giphy.com/apps/giphycapture) for this! 📸

_Please frame images to show useful context but also highlight the affected regions._
--->
