### PR TITLE
Issue #1220 - updated check availability message

### DIFF
--- a/src/api/views.py
+++ b/src/api/views.py
@@ -21,6 +21,8 @@ DOMAIN_API_MESSAGES = {
     " For example, if you want www.city.gov, you would enter “city”"
     " (without the quotes).",
     "extra_dots": "Enter the .gov domain you want without any periods.",
+    # message below is considered safe; no user input can be inserted into the message
+    # body; public_site_url() function reads from local app settings and therefore safe
     "unavailable": mark_safe(  # nosec
         "That domain isn’t available. "
         "<a class='usa-link' href='{}' target='_blank'>"

--- a/src/api/views.py
+++ b/src/api/views.py
@@ -2,6 +2,9 @@
 from django.apps import apps
 from django.views.decorators.http import require_http_methods
 from django.http import JsonResponse
+from django.utils.safestring import mark_safe
+
+from registrar.templatetags.url_helpers import public_site_url
 
 import requests
 
@@ -18,8 +21,11 @@ DOMAIN_API_MESSAGES = {
     " For example, if you want www.city.gov, you would enter “city”"
     " (without the quotes).",
     "extra_dots": "Enter the .gov domain you want without any periods.",
-    "unavailable": "That domain isn’t available. Try entering another one."
-    " Contact us if you need help coming up with a domain.",
+    "unavailable": mark_safe(  # nosec
+        "That domain isn’t available. "
+        "<a class='usa-link' href='{}' target='_blank'>"
+        "Read more about choosing your .gov domain.</a>".format(public_site_url("domains/choosing"))
+    ),
     "invalid": "Enter a domain using only letters, numbers, or hyphens (though we don't recommend using hyphens).",
     "success": "That domain is available!",
     "error": "Error finding domain availability.",

--- a/src/registrar/assets/js/get-gov.js
+++ b/src/registrar/assets/js/get-gov.js
@@ -115,7 +115,7 @@ function inlineToast(el, id, style, msg) {
       toast.className = `usa-alert usa-alert--${style} usa-alert--slim`;
       toastBody.classList.add("usa-alert__body");
       p.classList.add("usa-alert__text");
-      p.innerText = msg;
+      p.innerHTML = msg;
       toastBody.appendChild(p);
       toast.appendChild(toastBody);
       el.parentNode.insertBefore(toast, el.nextSibling);

--- a/src/registrar/assets/js/get-gov.js
+++ b/src/registrar/assets/js/get-gov.js
@@ -122,7 +122,7 @@ function inlineToast(el, id, style, msg) {
     } else {
       // update and show the existing message div
       toast.className = `usa-alert usa-alert--${style} usa-alert--slim`;
-      toast.querySelector("div p").innerText = msg;
+      toast.querySelector("div p").innerHTML = msg;
       makeVisible(toast);
     }
   } else {

--- a/src/registrar/tests/test_views.py
+++ b/src/registrar/tests/test_views.py
@@ -1219,6 +1219,8 @@ class TestDomainOverview(TestWithDomainPermissions, WebTest):
         self.app.set_user(self.user.username)
         self.client.force_login(self.user)
 
+
+class TestDomainDetail(TestDomainOverview):
     def test_domain_detail_link_works(self):
         home_page = self.app.get("/")
         self.assertContains(home_page, "igorville.gov")
@@ -1227,7 +1229,7 @@ class TestDomainOverview(TestWithDomainPermissions, WebTest):
         self.assertContains(detail_page, "igorville.gov")
         self.assertContains(detail_page, "Status")
 
-    def test_domain_overview_blocked_for_ineligible_user(self):
+    def test_domain_detail_blocked_for_ineligible_user(self):
         """We could easily duplicate this test for all domain management
         views, but a single url test should be solid enough since all domain
         management pages share the same permissions class"""
@@ -1239,7 +1241,7 @@ class TestDomainOverview(TestWithDomainPermissions, WebTest):
             response = self.client.get(reverse("domain", kwargs={"pk": self.domain.id}))
             self.assertEqual(response.status_code, 403)
 
-    def test_domain_overview_allowed_for_on_hold(self):
+    def test_domain_detail_allowed_for_on_hold(self):
         """Test that the domain overview page displays for on hold domain"""
         home_page = self.app.get("/")
         self.assertContains(home_page, "on-hold.gov")
@@ -1248,7 +1250,7 @@ class TestDomainOverview(TestWithDomainPermissions, WebTest):
         detail_page = self.client.get(reverse("domain", kwargs={"pk": self.domain_on_hold.id}))
         self.assertNotContains(detail_page, "Edit")
 
-    def test_domain_see_just_nameserver(self):
+    def test_domain_detail_see_just_nameserver(self):
         home_page = self.app.get("/")
         self.assertContains(home_page, "justnameserver.com")
 
@@ -1259,7 +1261,7 @@ class TestDomainOverview(TestWithDomainPermissions, WebTest):
         self.assertContains(detail_page, "ns1.justnameserver.com")
         self.assertContains(detail_page, "ns2.justnameserver.com")
 
-    def test_domain_see_nameserver_and_ip(self):
+    def test_domain_detail_see_nameserver_and_ip(self):
         home_page = self.app.get("/")
         self.assertContains(home_page, "nameserverwithip.gov")
 
@@ -1275,7 +1277,7 @@ class TestDomainOverview(TestWithDomainPermissions, WebTest):
         self.assertContains(detail_page, "(1.2.3.4,")
         self.assertContains(detail_page, "2.3.4.5)")
 
-    def test_domain_with_no_information_or_application(self):
+    def test_domain_detail_with_no_information_or_application(self):
         """Test that domain management page returns 200 and displays error
         when no domain information or domain application exist"""
         # have to use staff user for this test


### PR DESCRIPTION
## Ticket

Resolves #1220 
<!--Reminder, when a code change is made that is user facing, beyond content updates, then the following are required:
- a developer approves the PR
- a designer approves the PR or checks off all relevant items in this checklist.

All other changes require just a single approving review.-->

## Changes

<!-- What was added, updated, or removed in this PR. -->
- Updated check availability message in domain application form, .gov domain section

<!--
    Please add/remove/edit any of the template below to fit the needs
    of this specific PR.
--->

## Context for reviewers

<!--Background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers.  -->

This change is to messaging in the domain request form.

To test, go to the home page of the sandbox and click Edit next to an existing domain request (or create a new domain request)
Go through each step in the form until you reach the 6th step, .gov domain.  In this step, you are supposed to check availability of a domain.  In order to produce the error message, you need to enter in a domain that is not available, such as 'whitehouse' and click Check Availability.  Note the error message.  You should also get the same error message if you click Save and continue.  And you should also get the same error message if you enter an unavailable domain into the Alternative domains field.

The proper error message is:
That domain isn’t available. [Read more about choosing your .gov domain.](https://beta.get.gov/domains/choosing/)

## Setup

<!--  Add any steps or code to run in this section to help others run your code.
    
    Example 1:
    ```sh
    echo "Code goes here"
    ``` 
    
    Example 2: If the PR was to add a new link with a redirect, this section could simply be:
    -go to /path/to/start/page
    -click the blue link in the <insert location>
    -notice user is redirected to <proper end location>
-->

## Code Review Verification Steps

### As the original developer, I have

#### Satisfied acceptance criteria and met development standards

- [ ] Met the acceptance criteria, or will meet them in a subsequent PR
- [ ] Created/modified automated tests
- [ ] Added at least 2 developers as PR reviewers (only 1 will need to approve)
- [ ] Messaged on Slack or in standup to notify the team that a PR is ready for review
- [ ] Changes to “how we do things” are documented in READMEs and or onboarding guide
- [ ] If any model was updated to modify/add/delete columns, makemigrations was ran and the assoicated migrations file has been commited.

#### Ensured code standards are met (Original Developer)

- [ ] All new functions and methods are commented using plain language
- [ ] Did dependency updates in Pipfile also get changed in requirements.txt?
- [ ] Interactions with external systems are wrapped in try/except
- [ ] Error handling exists for unusual or missing values

#### Validated user-facing changes (if applicable)

- [ ] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Checked keyboard navigability
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)
- [ ] Add at least 1 designer as PR reviewer

### As a code reviewer, I have

#### Reviewed, tested, and left feedback about the changes

- [ ] Pulled this branch locally and tested it
- [ ] Reviewed this code and left comments
- [ ] Checked that all code is adequately covered by tests
- [ ] Made it clear which comments need to be addressed before this work is merged
- [ ] If any model was updated to modify/add/delete columns, makemigrations was ran and the assoicated migrations file has been commited.

#### Ensured code standards are met (Code reviewer)

- [ ] All new functions and methods are commented using plain language
- [ ] Interactions with external systems are wrapped in try/except
- [ ] Error handling exists for unusual or missing values
- [ ] (Rarely needed) Did dependency updates in Pipfile also get changed in requirements.txt?

#### Validated user-facing changes as a developer

- [ ] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Checked keyboard navigability
- [ ] Meets all designs and user flows provided by design/product
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)

- [ ] Tested with multiple browsers, the suggestion is to use ones that the developer didn't (check off which ones were used)
  - [ ] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari

- [ ] (Rarely needed) Tested as both an analyst and applicant user

**Note:** Multiple code reviewers can share the checklists above, a second reviewers should not make a duplicate checklist

### As a designer reviewer, I have

#### Verified that the changes match the design intention

- [ ] Checked that the design translated visually
- [ ] Checked behavior
- [ ] Checked different states (empty, one, some, error)
- [ ] Checked for landmarks, page heading structure, and links
- [ ] Tried to break the intended flow

#### Validated user-facing changes as a designer

- [ ] Checked keyboard navigability
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)

- [ ] Tested with multiple browsers (check off which ones were used)
  - [ ] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari

- [ ] (Rarely needed) Tested as both an analyst and applicant user

## Screenshots

<!-- If this PR makes visible interface changes, an image of the finished interface can help reviewers
and casual observers understand the context of the changes.
A before image is optional and can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow.
You may want to use [GIPHY Capture](https://giphy.com/apps/giphycapture) for this! 📸

_Please frame images to show useful context but also highlight the affected regions._
--->
