### PR TITLE
Switch to allowing non-identity-verified logins

### DIFF
--- a/src/registrar/config/settings.py
+++ b/src/registrar/config/settings.py
@@ -518,7 +518,7 @@ OIDC_PROVIDERS = {
             "response_type": "code",
             "scope": ["email", "profile:name", "phone"],
             "user_info_request": ["email", "first_name", "last_name", "phone"],
-            "acr_value": "http://idmanagement.gov/ns/assurance/ial/2",
+            "acr_value": "http://idmanagement.gov/ns/assurance/ial/1",
         },
         "client_registration": {
             "client_id": "cisa_dotgov_registrar",
@@ -535,7 +535,7 @@ OIDC_PROVIDERS = {
             "response_type": "code",
             "scope": ["email", "profile:name", "phone"],
             "user_info_request": ["email", "first_name", "last_name", "phone"],
-            "acr_value": "http://idmanagement.gov/ns/assurance/ial/2",
+            "acr_value": "http://idmanagement.gov/ns/assurance/ial/1",
         },
         "client_registration": {
             "client_id": ("urn:gov:cisa:openidconnect.profiles:sp:sso:cisa:dotgov_registrar"),


### PR DESCRIPTION
In advance of #1433, for now we want to allow people to log in using Login.gov WITHOUT being identity verified. This simple change makes that switch. People logging in to the system will need to have Login.gov accounts where they can verify control of the email address used, but they will not need to be personally identity-verified using their SSN/ID/phone/etc.

We anticipate that when #1433 and #1435 are ready, that this will be superseded, but for now this is right for our current group of domain managers.

@h-m-f-t @amcelya @michelle-rago 