### PR TITLE
Dashboard: adjust placeholder messaging

### DIFF
--- a/src/registrar/templates/home.html
+++ b/src/registrar/templates/home.html
@@ -138,7 +138,7 @@
       aria-live="polite"
     ></div>
     {% else %}
-    <p>You don't have any active domain requests right now</p>
+    <p>You don't have any domain requests yet</p>
     <!-- <p><a href="{% url 'application:' %}" class="usa-button">Start a new domain request</a></p> -->
     {% endif %}
   </section>

--- a/src/registrar/templates/home.html
+++ b/src/registrar/templates/home.html
@@ -87,7 +87,7 @@
       aria-live="polite"
     ></div>
     {% else %}
-    <p>You don't have any registered domains yet</p>
+    <p>You don't have any registered domains.</p>
     {% endif %}
   </section>
 
@@ -95,7 +95,7 @@
     <h2>Domain requests</h2>
     {% if domain_applications %}
     <table class="usa-table usa-table--borderless usa-table--stacked dotgov-table dotgov-table--stacked">
-      <caption class="sr-only">Your domain applications</caption>
+      <caption class="sr-only">Your domain requests</caption>
       <thead>
         <tr>
           <th data-sortable scope="col" role="columnheader">Domain name</th>
@@ -138,7 +138,7 @@
       aria-live="polite"
     ></div>
     {% else %}
-    <p>You don't have any domain requests yet</p>
+    <p>You haven't requested any domains.</p>
     <!-- <p><a href="{% url 'application:' %}" class="usa-button">Start a new domain request</a></p> -->
     {% endif %}
   </section>


### PR DESCRIPTION
## Ticket

The placeholder messaging for "domain requests" didn't match the wording for "domains." It also mentioned "active," but the table will display rejected and withdrawn requests, as well. 

Updated the placeholder messaging within the "domain requests" table when no requests have been created yet.