### PR TITLE
Add language to say that an available domain is not guaranteed

### DIFF
--- a/src/api/views.py
+++ b/src/api/views.py
@@ -34,7 +34,7 @@ DOMAIN_API_MESSAGES = {
     "invalid": "Enter a domain using only letters, numbers, or hyphens (though we don't recommend using hyphens).",
     "success": "That domain is available! We’ll try to give you the domain you want, "
                "but it's not guaranteed. After you complete this form, we’ll "
-                "evaluate whether your request meets our requirements.",
+               "evaluate whether your request meets our requirements.",
     "error": GenericError.get_error_message(GenericErrorCodes.CANNOT_CONTACT_REGISTRY),
 }
 

--- a/src/api/views.py
+++ b/src/api/views.py
@@ -33,8 +33,8 @@ DOMAIN_API_MESSAGES = {
     ),
     "invalid": "Enter a domain using only letters, numbers, or hyphens (though we don't recommend using hyphens).",
     "success": "That domain is available! We’ll try to give you the domain you want, " 
-               "but it's not guaranteed. After you complete this form, we’ll evaluate whether your " 
-               "request meets our requirements.",
+               "but it's not guaranteed. After you complete this form, we’ll "
+                "evaluate whether your request meets our requirements.",
     "error": GenericError.get_error_message(GenericErrorCodes.CANNOT_CONTACT_REGISTRY),
 }
 

--- a/src/api/views.py
+++ b/src/api/views.py
@@ -32,7 +32,7 @@ DOMAIN_API_MESSAGES = {
         "Read more about choosing your .gov domain.</a>".format(public_site_url("domains/choosing"))
     ),
     "invalid": "Enter a domain using only letters, numbers, or hyphens (though we don't recommend using hyphens).",
-    "success": "That domain is available! We’ll try to give you the domain you want, " 
+    "success": "That domain is available! We’ll try to give you the domain you want, "
                "but it's not guaranteed. After you complete this form, we’ll "
                 "evaluate whether your request meets our requirements.",
     "error": GenericError.get_error_message(GenericErrorCodes.CANNOT_CONTACT_REGISTRY),

--- a/src/api/views.py
+++ b/src/api/views.py
@@ -32,9 +32,9 @@ DOMAIN_API_MESSAGES = {
         "Read more about choosing your .gov domain.</a>".format(public_site_url("domains/choosing"))
     ),
     "invalid": "Enter a domain using only letters, numbers, or hyphens (though we don't recommend using hyphens).",
-    "success": "That domain is available! We’ll try to give you the domain you want, "
-               "but it's not guaranteed. After you complete this form, we’ll "
-               "evaluate whether your request meets our requirements.",
+    "success": "That domain is available! We’ll try to give you the domain you want, \
+               but it's not guaranteed. After you complete this form, we’ll \
+               evaluate whether your request meets our requirements.",
     "error": GenericError.get_error_message(GenericErrorCodes.CANNOT_CONTACT_REGISTRY),
 }
 

--- a/src/api/views.py
+++ b/src/api/views.py
@@ -32,7 +32,9 @@ DOMAIN_API_MESSAGES = {
         "Read more about choosing your .gov domain.</a>".format(public_site_url("domains/choosing"))
     ),
     "invalid": "Enter a domain using only letters, numbers, or hyphens (though we don't recommend using hyphens).",
-    "success": "That domain is available!",
+    "success": "That domain is available! We’ll try to give you the domain you want, " 
+               "but it's not guaranteed. After you complete this form, we’ll evaluate whether your " 
+               "request meets our requirements.",
     "error": GenericError.get_error_message(GenericErrorCodes.CANNOT_CONTACT_REGISTRY),
 }
 


### PR DESCRIPTION
## Ticket

Resolves #781 


## Changes

<!-- What was added, updated, or removed in this PR. -->
- Added language to let a user know, more explicitly, that an available domain isn't automatically theirs


<!--
    Please add/remove/edit any of the template below to fit the needs
    of this specific PR.
--->

## Context for reviewers

<!--Background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers.  -->

## Setup

<!--  Add any steps or code to run in this section to help others run your code.
    
    Example 1:
    ```sh
    echo "Code goes here"
    ``` 
    
    Example 2: If the PR was to add a new link with a redirect, this section could simply be:
    -go to /path/to/start/page
    -click the blue link in the <insert location>
    -notice user is redirected to <proper end location>
-->

## Code Review Verification Steps




**Note:** Multiple code reviewers can share the checklists above, a second reviewers should not make a duplicate checklist

### As a designer reviewer, I have

#### Verified that the changes match the design intention

- [ ] Checked that the design translated visually
- [ ] Checked behavior
- [ ] Checked different states (empty, one, some, error)
- [ ] Checked for landmarks, page heading structure, and links
- [ ] Tried to break the intended flow

#### Validated user-facing changes as a designer

- [ ] Checked keyboard navigability
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)

- [ ] Tested with multiple browsers (check off which ones were used)
  - [ ] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari

- [ ] (Rarely needed) Tested as both an analyst and applicant user

## Screenshots

<!-- If this PR makes visible interface changes, an image of the finished interface can help reviewers
and casual observers understand the context of the changes.
A before image is optional and can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow.
You may want to use [GIPHY Capture](https://giphy.com/apps/giphycapture) for this! 📸

_Please frame images to show useful context but also highlight the affected regions._
--->
![image](https://github.com/cisagov/manage.get.gov/assets/60157596/d022253f-f0df-40c9-ba5b-59c8ab5b0800)

