### PR TITLE
Issue #1458 - lowercase emails on add user to domain; case insensitive match

### DIFF
--- a/src/registrar/forms/domain.py
+++ b/src/registrar/forms/domain.py
@@ -28,6 +28,17 @@ class DomainAddUserForm(forms.Form):
 
     email = forms.EmailField(label="Email")
 
+    def clean(self):
+        """clean form data by lowercasing email"""
+        cleaned_data = super().clean()
+
+        # Lowercase the value of the 'email' field
+        email_value = cleaned_data.get("email")
+        if email_value:
+            cleaned_data["email"] = email_value.lower()
+
+        return cleaned_data
+
 
 class DomainNameserverForm(forms.Form):
     """Form for changing nameservers."""

--- a/src/registrar/models/user.py
+++ b/src/registrar/models/user.py
@@ -101,7 +101,7 @@ class User(AbstractUser):
         """When a user first arrives on the site, we need to retrieve any domain
         invitations that match their email address."""
         for invitation in DomainInvitation.objects.filter(
-            email=self.email, status=DomainInvitation.DomainInvitationStatus.INVITED
+            email__iexact=self.email, status=DomainInvitation.DomainInvitationStatus.INVITED
         ):
             try:
                 invitation.retrieve()

--- a/src/registrar/tests/test_models.py
+++ b/src/registrar/tests/test_models.py
@@ -654,3 +654,17 @@ class TestUser(TestCase):
         """A new user who's neither transitioned nor invited should
         return True when tested with class method needs_identity_verification"""
         self.assertTrue(User.needs_identity_verification(self.user.email, self.user.username))
+
+    def test_check_domain_invitations_on_login_caps_email(self):
+        """A DomainInvitation with an email address with capital letters should match
+        a User record whose email address is not in caps"""
+        # create DomainInvitation with CAPS email that matches User email
+        # on a case-insensitive match
+        CAPS_EMAIL = "MAYOR@igorville.gov"
+        # mock the domain invitation save routine
+        with patch("registrar.models.DomainInvitation.save") as save_mock:
+            DomainInvitation.objects.get_or_create(email=CAPS_EMAIL, domain=self.domain)
+            self.user.check_domain_invitations_on_login()
+            # if check_domain_invitations_on_login properly matches exactly one
+            # Domain Invitation, then save routine should be called exactly once
+            save_mock.assert_called_once

--- a/src/registrar/tests/test_models.py
+++ b/src/registrar/tests/test_models.py
@@ -660,11 +660,11 @@ class TestUser(TestCase):
         a User record whose email address is not in caps"""
         # create DomainInvitation with CAPS email that matches User email
         # on a case-insensitive match
-        CAPS_EMAIL = "MAYOR@igorville.gov"
+        caps_email = "MAYOR@igorville.gov"
         # mock the domain invitation save routine
         with patch("registrar.models.DomainInvitation.save") as save_mock:
-            DomainInvitation.objects.get_or_create(email=CAPS_EMAIL, domain=self.domain)
+            DomainInvitation.objects.get_or_create(email=caps_email, domain=self.domain)
             self.user.check_domain_invitations_on_login()
             # if check_domain_invitations_on_login properly matches exactly one
             # Domain Invitation, then save routine should be called exactly once
-            save_mock.assert_called_once
+            save_mock.assert_called_once()

--- a/src/registrar/tests/test_views.py
+++ b/src/registrar/tests/test_views.py
@@ -1355,22 +1355,22 @@ class TestDomainManagers(TestDomainOverview):
         out the boto3 SES email sending here.
         """
         # make sure there is no user with this email
-        EMAIL = "mayor@igorville.gov"
-        User.objects.filter(email=EMAIL).delete()
+        email_address = "mayor@igorville.gov"
+        User.objects.filter(email=email_address).delete()
 
         self.domain_information, _ = DomainInformation.objects.get_or_create(creator=self.user, domain=self.domain)
 
         add_page = self.app.get(reverse("domain-users-add", kwargs={"pk": self.domain.id}))
         session_id = self.app.cookies[settings.SESSION_COOKIE_NAME]
-        add_page.form["email"] = EMAIL
+        add_page.form["email"] = email_address
         self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
         success_result = add_page.form.submit()
         self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
         success_page = success_result.follow()
 
-        self.assertContains(success_page, EMAIL)
+        self.assertContains(success_page, email_address)
         self.assertContains(success_page, "Cancel")  # link to cancel invitation
-        self.assertTrue(DomainInvitation.objects.filter(email=EMAIL).exists())
+        self.assertTrue(DomainInvitation.objects.filter(email=email_address).exists())
 
     @boto3_mocking.patching
     def test_domain_invitation_created_for_caps_email(self):
@@ -1380,30 +1380,30 @@ class TestDomainManagers(TestDomainOverview):
         out the boto3 SES email sending here.
         """
         # make sure there is no user with this email
-        EMAIL = "mayor@igorville.gov"
-        CAPS_EMAIL = "MAYOR@igorville.gov"
-        User.objects.filter(email=EMAIL).delete()
+        email_address = "mayor@igorville.gov"
+        caps_email_address = "MAYOR@igorville.gov"
+        User.objects.filter(email=email_address).delete()
 
         self.domain_information, _ = DomainInformation.objects.get_or_create(creator=self.user, domain=self.domain)
 
         add_page = self.app.get(reverse("domain-users-add", kwargs={"pk": self.domain.id}))
         session_id = self.app.cookies[settings.SESSION_COOKIE_NAME]
-        add_page.form["email"] = CAPS_EMAIL
+        add_page.form["email"] = caps_email_address
         self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
         success_result = add_page.form.submit()
         self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
         success_page = success_result.follow()
 
-        self.assertContains(success_page, EMAIL)
+        self.assertContains(success_page, email_address)
         self.assertContains(success_page, "Cancel")  # link to cancel invitation
-        self.assertTrue(DomainInvitation.objects.filter(email=EMAIL).exists())
+        self.assertTrue(DomainInvitation.objects.filter(email=email_address).exists())
 
     @boto3_mocking.patching
     def test_domain_invitation_email_sent(self):
         """Inviting a non-existent user sends them an email."""
         # make sure there is no user with this email
-        EMAIL = "mayor@igorville.gov"
-        User.objects.filter(email=EMAIL).delete()
+        email_address = "mayor@igorville.gov"
+        User.objects.filter(email=email_address).delete()
 
         self.domain_information, _ = DomainInformation.objects.get_or_create(creator=self.user, domain=self.domain)
 
@@ -1412,28 +1412,28 @@ class TestDomainManagers(TestDomainOverview):
         with boto3_mocking.clients.handler_for("sesv2", mock_client):
             add_page = self.app.get(reverse("domain-users-add", kwargs={"pk": self.domain.id}))
             session_id = self.app.cookies[settings.SESSION_COOKIE_NAME]
-            add_page.form["email"] = EMAIL
+            add_page.form["email"] = email_address
             self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
             add_page.form.submit()
         # check the mock instance to see if `send_email` was called right
         mock_client_instance.send_email.assert_called_once_with(
             FromEmailAddress=settings.DEFAULT_FROM_EMAIL,
-            Destination={"ToAddresses": [EMAIL]},
+            Destination={"ToAddresses": [email_address]},
             Content=ANY,
         )
 
     def test_domain_invitation_cancel(self):
         """Posting to the delete view deletes an invitation."""
-        EMAIL = "mayor@igorville.gov"
-        invitation, _ = DomainInvitation.objects.get_or_create(domain=self.domain, email=EMAIL)
+        email_address = "mayor@igorville.gov"
+        invitation, _ = DomainInvitation.objects.get_or_create(domain=self.domain, email=email_address)
         self.client.post(reverse("invitation-delete", kwargs={"pk": invitation.id}))
         with self.assertRaises(DomainInvitation.DoesNotExist):
             DomainInvitation.objects.get(id=invitation.id)
 
     def test_domain_invitation_cancel_no_permissions(self):
         """Posting to the delete view as a different user should fail."""
-        EMAIL = "mayor@igorville.gov"
-        invitation, _ = DomainInvitation.objects.get_or_create(domain=self.domain, email=EMAIL)
+        email_address = "mayor@igorville.gov"
+        invitation, _ = DomainInvitation.objects.get_or_create(domain=self.domain, email=email_address)
 
         other_user = User()
         other_user.save()
@@ -1445,20 +1445,20 @@ class TestDomainManagers(TestDomainOverview):
     @boto3_mocking.patching
     def test_domain_invitation_flow(self):
         """Send an invitation to a new user, log in and load the dashboard."""
-        EMAIL = "mayor@igorville.gov"
-        User.objects.filter(email=EMAIL).delete()
+        email_address = "mayor@igorville.gov"
+        User.objects.filter(email=email_address).delete()
 
         add_page = self.app.get(reverse("domain-users-add", kwargs={"pk": self.domain.id}))
 
         self.domain_information, _ = DomainInformation.objects.get_or_create(creator=self.user, domain=self.domain)
 
         session_id = self.app.cookies[settings.SESSION_COOKIE_NAME]
-        add_page.form["email"] = EMAIL
+        add_page.form["email"] = email_address
         self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
         add_page.form.submit()
 
         # user was invited, create them
-        new_user = User.objects.create(username=EMAIL, email=EMAIL)
+        new_user = User.objects.create(username=email_address, email=email_address)
         # log them in to `self.app`
         self.app.set_user(new_user.username)
         # and manually call the on each login callback


### PR DESCRIPTION
## Ticket

Resolves #1458 
<!--Reminder, when a code change is made that is user facing, beyond content updates, then the following are required:
- a developer approves the PR
- a designer approves the PR or checks off all relevant items in this checklist.

All other changes require just a single approving review.-->

## Changes

<!-- What was added, updated, or removed in this PR. -->
- Email addresses are lowercased on Add User form in Domain management
- Domain Invitation matching on login is case insensitive on email address

<!--
    Please add/remove/edit any of the template below to fit the needs
    of this specific PR.
--->

## Context for reviewers

There are two parts to test on this PR.

In order to test that email addresses are lowercased, go to a domain that you manage and add a user to it through 'Add a domain manager' in domain management.  When adding the email address, enter the email address with capital letters in it.  You will see when the Invitation is created that the domain invitation has all lowercase values.

Now, to test that a user from login,gov's email address will match a Domain Invitation with capital letters in the email address, it may be easiest to use two different login accounts.  Log into account A first.  Go to a domain managed by account A, and add a domain manager for account B with account B's email address.  The first fix will lowercase the email address, but you can make it uppercase in Django admin.  Next go to django admin and find the domain invitation you just created.  Make the email address upper case and make sure it case-insensitive matches account B's email address.  Now log out.  And log back in as account B.  You should now be matched up as a domain manager for the domain.

<!--Background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers.  -->

## Setup

<!--  Add any steps or code to run in this section to help others run your code.
    
    Example 1:
    ```sh
    echo "Code goes here"
    ``` 
    
    Example 2: If the PR was to add a new link with a redirect, this section could simply be:
    -go to /path/to/start/page
    -click the blue link in the <insert location>
    -notice user is redirected to <proper end location>
-->

## Code Review Verification Steps

### As the original developer, I have

#### Satisfied acceptance criteria and met development standards

- [ ] Met the acceptance criteria, or will meet them in a subsequent PR
- [ ] Created/modified automated tests
- [ ] Added at least 2 developers as PR reviewers (only 1 will need to approve)
- [ ] Messaged on Slack or in standup to notify the team that a PR is ready for review
- [ ] Changes to “how we do things” are documented in READMEs and or onboarding guide
- [ ] If any model was updated to modify/add/delete columns, makemigrations was ran and the assoicated migrations file has been commited.

#### Ensured code standards are met (Original Developer)

- [ ] All new functions and methods are commented using plain language
- [ ] Did dependency updates in Pipfile also get changed in requirements.txt?
- [ ] Interactions with external systems are wrapped in try/except
- [ ] Error handling exists for unusual or missing values

#### Validated user-facing changes (if applicable)

- [ ] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Checked keyboard navigability
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)
- [ ] Add at least 1 designer as PR reviewer

### As a code reviewer, I have

#### Reviewed, tested, and left feedback about the changes

- [ ] Pulled this branch locally and tested it
- [ ] Reviewed this code and left comments
- [ ] Checked that all code is adequately covered by tests
- [ ] Made it clear which comments need to be addressed before this work is merged
- [ ] If any model was updated to modify/add/delete columns, makemigrations was ran and the assoicated migrations file has been commited.

#### Ensured code standards are met (Code reviewer)

- [ ] All new functions and methods are commented using plain language
- [ ] Interactions with external systems are wrapped in try/except
- [ ] Error handling exists for unusual or missing values
- [ ] (Rarely needed) Did dependency updates in Pipfile also get changed in requirements.txt?

#### Validated user-facing changes as a developer

- [ ] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Checked keyboard navigability
- [ ] Meets all designs and user flows provided by design/product
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)

- [ ] Tested with multiple browsers, the suggestion is to use ones that the developer didn't (check off which ones were used)
  - [ ] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari

- [ ] (Rarely needed) Tested as both an analyst and applicant user

**Note:** Multiple code reviewers can share the checklists above, a second reviewers should not make a duplicate checklist

### As a designer reviewer, I have

#### Verified that the changes match the design intention

- [ ] Checked that the design translated visually
- [ ] Checked behavior
- [ ] Checked different states (empty, one, some, error)
- [ ] Checked for landmarks, page heading structure, and links
- [ ] Tried to break the intended flow

#### Validated user-facing changes as a designer

- [ ] Checked keyboard navigability
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)

- [ ] Tested with multiple browsers (check off which ones were used)
  - [ ] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari

- [ ] (Rarely needed) Tested as both an analyst and applicant user

## Screenshots

<!-- If this PR makes visible interface changes, an image of the finished interface can help reviewers
and casual observers understand the context of the changes.
A before image is optional and can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow.
You may want to use [GIPHY Capture](https://giphy.com/apps/giphycapture) for this! 📸

_Please frame images to show useful context but also highlight the affected regions._
--->
