### PR TITLE
Issue 1412: Trigger a modal on domain request submission

### DIFF
--- a/src/.pa11yci
+++ b/src/.pa11yci
@@ -19,7 +19,6 @@
         "http://localhost:8080/register/other_contacts/",
         "http://localhost:8080/register/anything_else/",
         "http://localhost:8080/register/requirements/",
-        "http://localhost:8080/register/review/",
         "http://localhost:8080/register/finished/"
     ]
 }

--- a/src/registrar/templates/application_form.html
+++ b/src/registrar/templates/application_form.html
@@ -103,6 +103,7 @@
           id="toggle-submit-domain-request"
           aria-labelledby="Are you sure you want to continue?"
           aria-describedby="Your DNSSEC records will be deleted from the registry."
+          data-force-action
         >
             {% include 'includes/modal.html' with modal_heading="You are about to submit a domain request for yourcity.gov." modal_description="Once you submit this request, you won’t be able to make further edits until it’s reviewed by our staff. You’ll only be able to withdraw your request." modal_button=modal_button|safe %}
         </div>

--- a/src/registrar/templates/application_form.html
+++ b/src/registrar/templates/application_form.html
@@ -85,15 +85,27 @@
               class="usa-button usa-button--outline"
             >Save and return to manage your domains</button>
             {% else %}
-            <button
-              type="submit"
+            <a
+              href="#toggle-submit-domain-request"
               class="usa-button usa-button--big dotgov-button--green"
-            >Submit your domain request</button>
+              aria-controls="toggle-submit-domain-request"
+              data-open-modal
+              >Submit your domain request</a
+            >
             {% endif %}
           </div>
 {% endblock %}
 
         </form>
+
+        <div
+          class="usa-modal"
+          id="toggle-submit-domain-request"
+          aria-labelledby="Are you sure you want to continue?"
+          aria-describedby="Your DNSSEC records will be deleted from the registry."
+        >
+            {% include 'includes/modal.html' with modal_heading="You are about to submit a domain request for yourcity.gov." modal_description="Once you submit this request, you won’t be able to make further edits until it’s reviewed by our staff. You’ll only be able to withdraw your request." modal_button=modal_button|safe %}
+        </div>
 
 {% block after_form_content %}{% endblock %}
 

--- a/src/registrar/templates/application_form.html
+++ b/src/registrar/templates/application_form.html
@@ -101,11 +101,11 @@
         <div
           class="usa-modal"
           id="toggle-submit-domain-request"
-          aria-labelledby="Are you sure you want to continue?"
-          aria-describedby="Your DNSSEC records will be deleted from the registry."
+          aria-labelledby="Are you sure you want to submit a domain request?"
+          aria-describedby="Are you sure you want to submit a domain request?"
           data-force-action
         >
-            {% include 'includes/modal.html' with modal_heading="You are about to submit a domain request for yourcity.gov." modal_description="Once you submit this request, you won’t be able to make further edits until it’s reviewed by our staff. You’ll only be able to withdraw your request." modal_button=modal_button|safe %}
+            {% include 'includes/modal.html' with modal_heading=modal_heading|safe modal_description="Once you submit this request, you won’t be able to make further edits until it’s reviewed by our staff. You’ll only be able to withdraw your request." modal_button=modal_button|safe %}
         </div>
 
 {% block after_form_content %}{% endblock %}

--- a/src/registrar/tests/test_copy_names_from_contacts_to_users.py
+++ b/src/registrar/tests/test_copy_names_from_contacts_to_users.py
@@ -18,8 +18,8 @@ class TestDataUpdates(TestCase):
         self.user2 = User.objects.create(username="user2")
         self.user3 = User.objects.create(username="user3")
         self.user4 = User.objects.create(username="user4")
-        # The last user created triggers the creation of a contact and attaches itself to it. @Neil wth is going on?
-        # This bs_user defuses that situation so we can test the code.
+        # The last user created triggers the creation of a contact and attaches itself to it. See signals.
+        # This bs_user defuses that situation (unwanted user-contact pairing) so we can test the code.
         self.bs_user = User.objects.create()
 
         self.contact1 = Contact.objects.create(

--- a/src/registrar/tests/test_copy_names_from_contacts_to_users.py
+++ b/src/registrar/tests/test_copy_names_from_contacts_to_users.py
@@ -19,7 +19,7 @@ class TestDataUpdates(TestCase):
         self.user3 = User.objects.create(username="user3")
         self.user4 = User.objects.create(username="user4")
         # The last user created triggers the creation of a contact and attaches itself to it. See signals.
-        # This bs_user defuses that situation (unwanted user-contact pairing) so we can test the code.
+        # This bs_user defuses that situation.
         self.bs_user = User.objects.create()
 
         self.contact1 = Contact.objects.create(

--- a/src/registrar/tests/test_views.py
+++ b/src/registrar/tests/test_views.py
@@ -141,7 +141,7 @@ class DomainApplicationTests(TestWithUser, WebTest):
         # 302 redirect to the first form
         page = self.app.get(reverse("application:")).follow()
         # submitting should get back the same page if the required field is empty
-        result = page.form.submit()
+        result = page.forms[0].submit()
         self.assertIn("What kind of U.S.-based government organization do you represent?", result)
 
     def test_application_multiple_applications_exist(self):
@@ -178,11 +178,11 @@ class DomainApplicationTests(TestWithUser, WebTest):
         session_id = self.app.cookies[settings.SESSION_COOKIE_NAME]
 
         # ---- TYPE PAGE  ----
-        type_form = type_page.form
+        type_form = type_page.forms[0]
         type_form["organization_type-organization_type"] = "federal"
         # test next button and validate data
         self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
-        type_result = type_page.form.submit()
+        type_result = type_form.submit()
         # should see results in db
         application = DomainApplication.objects.get()  # there's only one
         self.assertEqual(application.organization_type, "federal")
@@ -197,7 +197,7 @@ class DomainApplicationTests(TestWithUser, WebTest):
         self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
 
         federal_page = type_result.follow()
-        federal_form = federal_page.form
+        federal_form = federal_page.forms[0]
         federal_form["organization_federal-federal_type"] = "executive"
 
         # test next button
@@ -216,7 +216,7 @@ class DomainApplicationTests(TestWithUser, WebTest):
         # Follow the redirect to the next form page
         self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
         org_contact_page = federal_result.follow()
-        org_contact_form = org_contact_page.form
+        org_contact_form = org_contact_page.forms[0]
         # federal agency so we have to fill in federal_agency
         org_contact_form["organization_contact-federal_agency"] = "General Services Administration"
         org_contact_form["organization_contact-organization_name"] = "Testorg"
@@ -249,7 +249,7 @@ class DomainApplicationTests(TestWithUser, WebTest):
         # Follow the redirect to the next form page
         self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
         ao_page = org_contact_result.follow()
-        ao_form = ao_page.form
+        ao_form = ao_page.forms[0]
         ao_form["authorizing_official-first_name"] = "Testy ATO"
         ao_form["authorizing_official-last_name"] = "Tester ATO"
         ao_form["authorizing_official-title"] = "Chief Tester"
@@ -276,7 +276,7 @@ class DomainApplicationTests(TestWithUser, WebTest):
         # Follow the redirect to the next form page
         self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
         current_sites_page = ao_result.follow()
-        current_sites_form = current_sites_page.form
+        current_sites_form = current_sites_page.forms[0]
         current_sites_form["current_sites-0-website"] = "www.city.com"
 
         # test next button
@@ -298,7 +298,7 @@ class DomainApplicationTests(TestWithUser, WebTest):
         # Follow the redirect to the next form page
         self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
         dotgov_page = current_sites_result.follow()
-        dotgov_form = dotgov_page.form
+        dotgov_form = dotgov_page.forms[0]
         dotgov_form["dotgov_domain-requested_domain"] = "city"
         dotgov_form["dotgov_domain-0-alternative_domain"] = "city1"
 
@@ -318,7 +318,7 @@ class DomainApplicationTests(TestWithUser, WebTest):
         # Follow the redirect to the next form page
         self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
         purpose_page = dotgov_result.follow()
-        purpose_form = purpose_page.form
+        purpose_form = purpose_page.forms[0]
         purpose_form["purpose-purpose"] = "For all kinds of things."
 
         # test next button
@@ -337,7 +337,7 @@ class DomainApplicationTests(TestWithUser, WebTest):
         # Follow the redirect to the next form page
         self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
         your_contact_page = purpose_result.follow()
-        your_contact_form = your_contact_page.form
+        your_contact_form = your_contact_page.forms[0]
 
         your_contact_form["your_contact-first_name"] = "Testy you"
         your_contact_form["your_contact-last_name"] = "Tester you"
@@ -365,7 +365,7 @@ class DomainApplicationTests(TestWithUser, WebTest):
         # Follow the redirect to the next form page
         self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
         other_contacts_page = your_contact_result.follow()
-        other_contacts_form = other_contacts_page.form
+        other_contacts_form = other_contacts_page.forms[0]
 
         other_contacts_form["other_contacts-0-first_name"] = "Testy2"
         other_contacts_form["other_contacts-0-last_name"] = "Tester2"
@@ -398,7 +398,7 @@ class DomainApplicationTests(TestWithUser, WebTest):
         # Follow the redirect to the next form page
         self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
         anything_else_page = other_contacts_result.follow()
-        anything_else_form = anything_else_page.form
+        anything_else_form = anything_else_page.forms[0]
 
         anything_else_form["anything_else-anything_else"] = "Nothing else."
 
@@ -418,7 +418,7 @@ class DomainApplicationTests(TestWithUser, WebTest):
         # Follow the redirect to the next form page
         self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
         requirements_page = anything_else_result.follow()
-        requirements_form = requirements_page.form
+        requirements_form = requirements_page.forms[0]
 
         requirements_form["requirements-is_policy_acknowledged"] = True
 
@@ -438,7 +438,7 @@ class DomainApplicationTests(TestWithUser, WebTest):
         # Follow the redirect to the next form page
         self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
         review_page = requirements_result.follow()
-        review_form = review_page.form
+        review_form = review_page.forms[0]
 
         # Review page contains all the previously entered data
         # Let's make sure the long org name is displayed
@@ -540,7 +540,7 @@ class DomainApplicationTests(TestWithUser, WebTest):
         # the conditional step titles shouldn't appear initially
         self.assertNotContains(type_page, self.TITLES["organization_federal"])
         self.assertNotContains(type_page, self.TITLES["organization_election"])
-        type_form = type_page.form
+        type_form = type_page.forms[0]
         type_form["organization_type-organization_type"] = "federal"
 
         # set the session ID before .submit()
@@ -561,9 +561,9 @@ class DomainApplicationTests(TestWithUser, WebTest):
 
         # continuing on in the flow we need to see top-level agency on the
         # contact page
-        federal_page.form["organization_federal-federal_type"] = "executive"
+        federal_page.forms[0]["organization_federal-federal_type"] = "executive"
         self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
-        federal_result = federal_page.form.submit()
+        federal_result = federal_page.forms[0].submit()
         # the post request should return a redirect to the contact
         # question
         self.assertEqual(federal_result.status_code, 302)
@@ -586,7 +586,7 @@ class DomainApplicationTests(TestWithUser, WebTest):
         # the conditional step titles shouldn't appear initially
         self.assertNotContains(type_page, self.TITLES["organization_federal"])
         self.assertNotContains(type_page, self.TITLES["organization_election"])
-        type_form = type_page.form
+        type_form = type_page.forms[0]
         type_form["organization_type-organization_type"] = "county"
 
         # set the session ID before .submit()
@@ -606,9 +606,9 @@ class DomainApplicationTests(TestWithUser, WebTest):
 
         # continuing on in the flow we need to NOT see top-level agency on the
         # contact page
-        election_page.form["organization_election-is_election_board"] = "True"
+        election_page.forms[0]["organization_election-is_election_board"] = "True"
         self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
-        election_result = election_page.form.submit()
+        election_result = election_page.forms[0].submit()
         # the post request should return a redirect to the contact
         # question
         self.assertEqual(election_result.status_code, 302)
@@ -626,10 +626,10 @@ class DomainApplicationTests(TestWithUser, WebTest):
         # and then setting the cookie on each request.
         session_id = self.app.cookies[settings.SESSION_COOKIE_NAME]
 
-        type_form = type_page.form
+        type_form = type_page.forms[0]
         type_form["organization_type-organization_type"] = "federal"
         self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
-        type_result = type_page.form.submit()
+        type_result = type_form.submit()
 
         # follow first redirect
         self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
@@ -654,15 +654,15 @@ class DomainApplicationTests(TestWithUser, WebTest):
         # and then setting the cookie on each request.
         session_id = self.app.cookies[settings.SESSION_COOKIE_NAME]
 
-        type_form = type_page.form
+        type_form = type_page.forms[0]
         type_form["organization_type-organization_type"] = DomainApplication.OrganizationChoices.INTERSTATE
         self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
-        type_result = type_page.form.submit()
+        type_result = type_form.submit()
 
         # follow first redirect
         self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
         contact_page = type_result.follow()
-        org_contact_form = contact_page.form
+        org_contact_form = contact_page.forms[0]
 
         self.assertNotIn("federal_agency", org_contact_form.fields)
 
@@ -690,10 +690,10 @@ class DomainApplicationTests(TestWithUser, WebTest):
         # and then setting the cookie on each request.
         session_id = self.app.cookies[settings.SESSION_COOKIE_NAME]
 
-        type_form = type_page.form
+        type_form = type_page.forms[0]
         type_form["organization_type-organization_type"] = DomainApplication.OrganizationChoices.SPECIAL_DISTRICT
         self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
-        type_result = type_page.form.submit()
+        type_result = type_page.forms[0].submit()
         # follow first redirect
         self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
         contact_page = type_result.follow()
@@ -710,7 +710,7 @@ class DomainApplicationTests(TestWithUser, WebTest):
         session_id = self.app.cookies[settings.SESSION_COOKIE_NAME]
 
         self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
-        result = contacts_page.form.submit()
+        result = contacts_page.forms[0].submit()
         # follow first redirect
         self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
         no_contacts_page = result.follow()
@@ -727,10 +727,10 @@ class DomainApplicationTests(TestWithUser, WebTest):
         # and then setting the cookie on each request.
         session_id = self.app.cookies[settings.SESSION_COOKIE_NAME]
 
-        type_form = type_page.form
+        type_form = type_page.forms[0]
         type_form["organization_type-organization_type"] = DomainApplication.OrganizationChoices.INTERSTATE
         self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
-        type_result = type_page.form.submit()
+        type_result = type_form.submit()
         # follow first redirect
         self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
         contact_page = type_result.follow()
@@ -745,10 +745,10 @@ class DomainApplicationTests(TestWithUser, WebTest):
         # of a "session". We are going to do it manually, saving the session ID here
         # and then setting the cookie on each request.
         session_id = self.app.cookies[settings.SESSION_COOKIE_NAME]
-        type_form = type_page.form
+        type_form = type_page.forms[0]
         type_form["organization_type-organization_type"] = DomainApplication.OrganizationChoices.TRIBAL
         self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
-        type_result = type_page.form.submit()
+        type_result = type_form.submit()
         # the tribal government page comes immediately afterwards
         self.assertIn("/tribal_government", type_result.headers["Location"])
         # follow first redirect
@@ -767,18 +767,18 @@ class DomainApplicationTests(TestWithUser, WebTest):
         session_id = self.app.cookies[settings.SESSION_COOKIE_NAME]
 
         # ---- TYPE PAGE  ----
-        type_form = type_page.form
+        type_form = type_page.forms[0]
         type_form["organization_type-organization_type"] = "federal"
 
         # test next button
         self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
-        type_result = type_page.form.submit()
+        type_result = type_form.submit()
 
         # ---- FEDERAL BRANCH PAGE  ----
         # Follow the redirect to the next form page
         self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
         federal_page = type_result.follow()
-        federal_form = federal_page.form
+        federal_form = federal_page.forms[0]
         federal_form["organization_federal-federal_type"] = "executive"
         self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
         federal_result = federal_form.submit()
@@ -787,7 +787,7 @@ class DomainApplicationTests(TestWithUser, WebTest):
         # Follow the redirect to the next form page
         self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
         org_contact_page = federal_result.follow()
-        org_contact_form = org_contact_page.form
+        org_contact_form = org_contact_page.forms[0]
         # federal agency so we have to fill in federal_agency
         org_contact_form["organization_contact-federal_agency"] = "General Services Administration"
         org_contact_form["organization_contact-organization_name"] = "Testorg"
@@ -828,18 +828,18 @@ class DomainApplicationTests(TestWithUser, WebTest):
         # and then setting the cookie on each request.
         session_id = self.app.cookies[settings.SESSION_COOKIE_NAME]
         # ---- TYPE PAGE  ----
-        type_form = type_page.form
+        type_form = type_page.forms[0]
         type_form["organization_type-organization_type"] = "federal"
 
         # test next button
         self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
-        type_result = type_page.form.submit()
+        type_result = type_form.submit()
 
         # ---- FEDERAL BRANCH PAGE  ----
         # Follow the redirect to the next form page
         self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
         federal_page = type_result.follow()
-        federal_form = federal_page.form
+        federal_form = federal_page.forms[0]
         federal_form["organization_federal-federal_type"] = "executive"
         self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
         federal_result = federal_form.submit()
@@ -848,7 +848,7 @@ class DomainApplicationTests(TestWithUser, WebTest):
         # Follow the redirect to the next form page
         self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
         org_contact_page = federal_result.follow()
-        org_contact_form = org_contact_page.form
+        org_contact_form = org_contact_page.forms[0]
         # federal agency so we have to fill in federal_agency
         org_contact_form["organization_contact-federal_agency"] = "General Services Administration"
         org_contact_form["organization_contact-organization_name"] = "Testorg"
@@ -870,7 +870,7 @@ class DomainApplicationTests(TestWithUser, WebTest):
         # Follow the redirect to the next form page
         self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
         ao_page = org_contact_result.follow()
-        ao_form = ao_page.form
+        ao_form = ao_page.forms[0]
         ao_form["authorizing_official-first_name"] = "Testy ATO"
         ao_form["authorizing_official-last_name"] = "Tester ATO"
         ao_form["authorizing_official-title"] = "Chief Tester"
@@ -884,7 +884,7 @@ class DomainApplicationTests(TestWithUser, WebTest):
         # Follow the redirect to the next form page
         self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
         current_sites_page = ao_result.follow()
-        current_sites_form = current_sites_page.form
+        current_sites_form = current_sites_page.forms[0]
         current_sites_form["current_sites-0-website"] = "www.city.com"
 
         # test saving the page
@@ -917,7 +917,7 @@ class DomainApplicationTests(TestWithUser, WebTest):
         current_sites_page = self.app.get(reverse("application:current_sites"))
         session_id = self.app.cookies[settings.SESSION_COOKIE_NAME]
         # fill in the form field
-        current_sites_form = current_sites_page.form
+        current_sites_form = current_sites_page.forms[0]
         self.assertIn("current_sites-0-website", current_sites_form.fields)
         self.assertNotIn("current_sites-1-website", current_sites_form.fields)
         current_sites_form["current_sites-0-website"] = "https://example.com"
@@ -926,7 +926,7 @@ class DomainApplicationTests(TestWithUser, WebTest):
         self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
         current_sites_result = current_sites_form.submit("submit_button", value="save")
         self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
-        current_sites_form = current_sites_result.follow().form
+        current_sites_form = current_sites_result.follow().forms[0]
 
         # verify that there are two form fields
         value = current_sites_form["current_sites-0-website"].value
@@ -1085,6 +1085,16 @@ class DomainApplicationTests(TestWithUser, WebTest):
         # click the "Edit" link
         detail_page = home_page.click("Manage", index=0)
         self.assertContains(detail_page, "Federal: an agency of the U.S. government")
+
+    def test_submit_modal(self):
+        """When user clicks on submit your domain request, a modal pops up."""
+        completed_application()
+        review_page = self.app.get(reverse("application:review"))
+        # We can't test the modal itself as it relies on JS for init and triggering,
+        # but we can test for the existence of its trigger:
+        self.assertContains(review_page, "toggle-submit-domain-request")
+        # And the existence of the modal's data parked and ready for the js init:
+        self.assertContains(review_page, "You are about to submit a domain request")
 
 
 class TestWithDomainPermissions(TestWithUser):

--- a/src/registrar/tests/test_views.py
+++ b/src/registrar/tests/test_views.py
@@ -1088,13 +1088,14 @@ class DomainApplicationTests(TestWithUser, WebTest):
 
     def test_submit_modal(self):
         """When user clicks on submit your domain request, a modal pops up."""
-        completed_application()
+        # completed_application(name="cats.gov")
         review_page = self.app.get(reverse("application:review"))
         # We can't test the modal itself as it relies on JS for init and triggering,
         # but we can test for the existence of its trigger:
         self.assertContains(review_page, "toggle-submit-domain-request")
         # And the existence of the modal's data parked and ready for the js init:
-        self.assertContains(review_page, "You are about to submit a domain request")
+        print(review_page)
+        self.assertContains(review_page, "You are about to submit")
 
 
 class TestWithDomainPermissions(TestWithUser):

--- a/src/registrar/tests/test_views.py
+++ b/src/registrar/tests/test_views.py
@@ -164,6 +164,9 @@ class DomainApplicationTests(TestWithUser, WebTest):
         this test work.
 
         This test also looks for the long organization name on the summary page.
+
+        This also tests for the presence of a modal trigger and the dynamic test
+        in the modal header on the submit page.
         """
         num_pages_tested = 0
         # elections, type_of_work, tribal_government, no_other_contacts
@@ -471,6 +474,14 @@ class DomainApplicationTests(TestWithUser, WebTest):
         self.assertContains(review_page, "testy2@town.com")
         self.assertContains(review_page, "(201) 555-5557")
         self.assertContains(review_page, "Nothing else.")
+
+        # We can't test the modal itself as it relies on JS for init and triggering,
+        # but we can test for the existence of its trigger:
+        self.assertContains(review_page, "toggle-submit-domain-request")
+        # And the existence of the modal's data parked and ready for the js init.
+        # The next assert also tests for the passed requested domain context from
+        # the view > application_form > modal
+        self.assertContains(review_page, "You are about to submit a domain request for city.gov")
 
         # final submission results in a redirect to the "finished" URL
         self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
@@ -1086,16 +1097,17 @@ class DomainApplicationTests(TestWithUser, WebTest):
         detail_page = home_page.click("Manage", index=0)
         self.assertContains(detail_page, "Federal: an agency of the U.S. government")
 
-    def test_submit_modal(self):
-        """When user clicks on submit your domain request, a modal pops up."""
-        # completed_application(name="cats.gov")
+    def test_submit_modal_no_domain_text_fallback(self):
+        """When user clicks on submit your domain request and the requested domain
+        is null (possible through url direct access to the review page), present
+        fallback copy in the modal's header.
+
+        NOTE: This may be a moot point if we implement a more solid pattern in the
+        future, like not a submit action at all on the review page."""
+
         review_page = self.app.get(reverse("application:review"))
-        # We can't test the modal itself as it relies on JS for init and triggering,
-        # but we can test for the existence of its trigger:
         self.assertContains(review_page, "toggle-submit-domain-request")
-        # And the existence of the modal's data parked and ready for the js init:
-        print(review_page)
-        self.assertContains(review_page, "You are about to submit")
+        self.assertContains(review_page, "You are about to submit an incomplete request")
 
 
 class TestWithDomainPermissions(TestWithUser):

--- a/src/registrar/views/application.py
+++ b/src/registrar/views/application.py
@@ -321,12 +321,19 @@ class ApplicationWizard(ApplicationWizardPermissionView, TemplateView):
 
     def get_context_data(self):
         """Define context for access on all wizard pages."""
-        # Create HTML for the submit button:
         # The on-page submit button is just a trigger for the modal;
         # the submit button we're adding to context will get passed to
         # the modal and is the button that triggers the actual domain
         # application submission (via post -> goto_next_step -> done).
         modal_button = '<button type="submit" ' 'class="usa-button" ' ">Submit request</button>"
+        # We'll concatenate the modal header here for passing along to the
+        # modal include. NOTE: We are able to 'fast-forward' a domain application
+        # by tyoing in review in the URL. The submit button still shows, hence
+        # the if/else.
+        if self.application.requested_domain:
+            modal_heading = 'You are about to submit a domain request for ' + str(self.application.requested_domain)
+        else:
+            modal_heading = 'You are about to submit an incomplete request'
         return {
             "form_titles": self.TITLES,
             "steps": self.steps,
@@ -334,6 +341,7 @@ class ApplicationWizard(ApplicationWizardPermissionView, TemplateView):
             "visited": self.storage.get("step_history", []),
             "is_federal": self.application.is_federal(),
             "modal_button": modal_button,
+            "modal_heading": modal_heading,
         }
 
     def get_step_list(self) -> list:

--- a/src/registrar/views/application.py
+++ b/src/registrar/views/application.py
@@ -331,9 +331,9 @@ class ApplicationWizard(ApplicationWizardPermissionView, TemplateView):
         # by tyoing in review in the URL. The submit button still shows, hence
         # the if/else.
         if self.application.requested_domain:
-            modal_heading = 'You are about to submit a domain request for ' + str(self.application.requested_domain)
+            modal_heading = "You are about to submit a domain request for " + str(self.application.requested_domain)
         else:
-            modal_heading = 'You are about to submit an incomplete request'
+            modal_heading = "You are about to submit an incomplete request"
         return {
             "form_titles": self.TITLES,
             "steps": self.steps,

--- a/src/registrar/views/application.py
+++ b/src/registrar/views/application.py
@@ -321,12 +321,19 @@ class ApplicationWizard(ApplicationWizardPermissionView, TemplateView):
 
     def get_context_data(self):
         """Define context for access on all wizard pages."""
+        # Create HTML for the submit button:
+        # The on-page submit button is just a trigger for the modal;
+        # the submit button we're adding to context will get passed to
+        # the modal and is the button that triggers the actual domain
+        # application submission (via post -> goto_next_step -> done).
+        modal_button = '<button type="submit" ' 'class="usa-button" ' ">Submit request</button>"
         return {
             "form_titles": self.TITLES,
             "steps": self.steps,
             # Add information about which steps should be unlocked
             "visited": self.storage.get("step_history", []),
             "is_federal": self.application.is_federal(),
+            "modal_button": modal_button,
         }
 
     def get_step_list(self) -> list:

--- a/src/registrar/views/application.py
+++ b/src/registrar/views/application.py
@@ -321,15 +321,9 @@ class ApplicationWizard(ApplicationWizardPermissionView, TemplateView):
 
     def get_context_data(self):
         """Define context for access on all wizard pages."""
-        # The on-page submit button is just a trigger for the modal;
-        # the submit button we're adding to context will get passed to
-        # the modal and is the button that triggers the actual domain
-        # application submission (via post -> goto_next_step -> done).
+        # Build the submit button that we'll pass to the modal.
         modal_button = '<button type="submit" ' 'class="usa-button" ' ">Submit request</button>"
-        # We'll concatenate the modal header here for passing along to the
-        # modal include. NOTE: We are able to 'fast-forward' a domain application
-        # by tyoing in review in the URL. The submit button still shows, hence
-        # the if/else.
+        # Concatenate the modal header that we'll pass to the modal.
         if self.application.requested_domain:
             modal_heading = "You are about to submit a domain request for " + str(self.application.requested_domain)
         else:


### PR DESCRIPTION
## Ticket

Resolves #1412 
<!--Reminder, when a code change is made that is user facing, beyond content updates, then the following are required:
- a developer approves the PR
- a designer approves the PR or checks off all relevant items in this checklist.

All other changes require just a single approving review.-->

## Changes

<!-- What was added, updated, or removed in this PR. -->
- Implement a forced action modal between domain request submit and form submit button,
- Unit test that looks for the modal trigger and modal data,
-  Fixes for existing DA unit tests that query and trigger the previously unique form.

<!--
    Please add/remove/edit any of the template below to fit the needs
    of this specific PR.
--->

## Context for reviewers

<!--Background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers.  -->

This ticket made me wonder whether it's worth adding Selenium to our tech stack.

## Setup

<!--  Add any steps or code to run in this section to help others run your code.
    
    Example 1:
    ```sh
    echo "Code goes here"
    ``` 
    
    Example 2: If the PR was to add a new link with a redirect, this section could simply be:
    -go to /path/to/start/page
    -click the blue link in the <insert location>
    -notice user is redirected to <proper end location>
-->

If you want to test locally (or just have a better experience going through a pre-populates domain request), click on a request then change the last part of the URL to review: http://localhost:8080/register/review/

## Code Review Verification Steps

### As the original developer, I have

#### Satisfied acceptance criteria and met development standards

- [x] Met the acceptance criteria, or will meet them in a subsequent PR
- [x] Created/modified automated tests
- [x] Added at least 2 developers as PR reviewers (only 1 will need to approve)
- [x] Messaged on Slack or in standup to notify the team that a PR is ready for review
- [ ] Changes to “how we do things” are documented in READMEs and or onboarding guide
- [ ] If any model was updated to modify/add/delete columns, makemigrations was ran and the assoicated migrations file has been commited.

#### Ensured code standards are met (Original Developer)

- [x] All new functions and methods are commented using plain language
- [ ] Did dependency updates in Pipfile also get changed in requirements.txt?
- [ ] Interactions with external systems are wrapped in try/except
- [ ] Error handling exists for unusual or missing values

#### Validated user-facing changes (if applicable)

- [ ] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [x] Checked keyboard navigability
- [x] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)
- [x] Add at least 1 designer as PR reviewer

### As a code reviewer, I have

#### Reviewed, tested, and left feedback about the changes

- [ ] Pulled this branch locally and tested it
- [ ] Reviewed this code and left comments
- [ ] Checked that all code is adequately covered by tests
- [ ] Made it clear which comments need to be addressed before this work is merged
- [ ] If any model was updated to modify/add/delete columns, makemigrations was ran and the assoicated migrations file has been commited.

#### Ensured code standards are met (Code reviewer)

- [ ] All new functions and methods are commented using plain language
- [ ] Interactions with external systems are wrapped in try/except
- [ ] Error handling exists for unusual or missing values
- [ ] (Rarely needed) Did dependency updates in Pipfile also get changed in requirements.txt?

#### Validated user-facing changes as a developer

- [ ] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Checked keyboard navigability
- [ ] Meets all designs and user flows provided by design/product
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)

- [ ] Tested with multiple browsers, the suggestion is to use ones that the developer didn't (check off which ones were used)
  - [ ] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari

- [ ] (Rarely needed) Tested as both an analyst and applicant user

**Note:** Multiple code reviewers can share the checklists above, a second reviewers should not make a duplicate checklist

### As a designer reviewer, I have

#### Verified that the changes match the design intention

- [ ] Checked that the design translated visually
- [ ] Checked behavior
- [ ] Checked different states (empty, one, some, error)
- [ ] Checked for landmarks, page heading structure, and links
- [ ] Tried to break the intended flow

#### Validated user-facing changes as a designer

- [x] Checked keyboard navigability
- [x] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)

- [ ] Tested with multiple browsers (check off which ones were used)
  - [x] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari

- [ ] (Rarely needed) Tested as both an analyst and applicant user

## Screenshots

<!-- If this PR makes visible interface changes, an image of the finished interface can help reviewers
and casual observers understand the context of the changes.
A before image is optional and can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow.
You may want to use [GIPHY Capture](https://giphy.com/apps/giphycapture) for this! 📸

_Please frame images to show useful context but also highlight the affected regions._
--->
