### PR TITLE
Post-request submission content updates

### DIFF
--- a/src/registrar/templates/403.html
+++ b/src/registrar/templates/403.html
@@ -23,7 +23,7 @@
       {% endif %}
       <p>
         You must be an authorized user and need to be signed in to view this page. 
-        Would you like to <a href="{% url 'login' %}"> try logging in again</a>?
+        <a href="{% url 'login' %}"> Try logging in again</a>.
       </p>
       <p>
         If you'd like help with this error <a class="usa-link" rel="noopener noreferrer" target="_blank" href="{% public_site_url 'contact' %}">contact us</a>.

--- a/src/registrar/templates/application_done.html
+++ b/src/registrar/templates/application_done.html
@@ -15,12 +15,12 @@
         />
     <h1>Thanks for your domain request!</h1>
   </span>
-  <p>We'll email a copy of your request to you.</p>
+  <p>We’ll email a copy of your request to you.</p>
 
   <h2>Next steps in this process</h2>
 
-  <p> We'll review your request. This usually takes 20 business days. During
-  this review we'll verify that:</p> 
+  <p> We’ll review your request. This usually takes 20 business days. During
+  this review we’ll verify that:</p> 
   <ul class="usa-list">
     <li>Your organization is eligible for a .gov domain.</li>
     <li>You work at the organization and/or can make requests on its behalf.</li> 

--- a/src/registrar/templates/application_done.html
+++ b/src/registrar/templates/application_done.html
@@ -27,8 +27,10 @@
     <li>Your requested domain meets our naming requirements.</li>
   </ul>
 
-  <p> You can <a href="{% url 'home' %}">check the status</a>
-      of your request at any time. We’ll email you if we have questions and when we complete our review. <a class="usa-link" rel="noopener noreferrer" target="_blank" href="{% public_site_url 'contact' %}">Contact us with any questions</a>.</p>
+  <p> We’ll email you if we have questions and when we complete our review. You can <a href="{% url 'home' %}">check the status</a>
+      of your request at any time on the registrar homepage.</p> 
+  
+  <p> <a class="usa-link" rel="noopener noreferrer" target="_blank" href="{% public_site_url 'contact' %}">Contact us if you need help during this process</a>.</p>
 
 </main>
 {% endblock %}

--- a/src/registrar/templates/application_done.html
+++ b/src/registrar/templates/application_done.html
@@ -19,11 +19,11 @@
   <h2>Next steps in this process</h2>
 
   <p> We'll review your request. This usually takes 20 business days. During
-  this review we'll verify that your:</p> 
+  this review we'll verify that:</p> 
   <ul class="usa-list">
-    <li>Organization is eligible for a .gov domain</li>
-    <li>Authorizing official approves your request</li> 
-    <li>Domain meets our naming requirements</li>
+    <li>Your organization is eligible for a .gov domain.</li>
+    <li>You work at the organization and/or can make requests on its behalf.</li> 
+    <li>Your requested domain meets our naming requirements.</li>
   </ul>
 
   <p> You can <a href="{% url 'home' %}">check the status</a>

--- a/src/registrar/templates/application_done.html
+++ b/src/registrar/templates/application_done.html
@@ -27,7 +27,7 @@
   </ul>
 
   <p> You can <a href="{% url 'home' %}">check the status</a>
-      of your request at any time. We'll email you with any questions or when we 
+      of your request at any time. We'll email you if we have questions and when we 
       complete our review.</p>
 
 </main>

--- a/src/registrar/templates/application_form.html
+++ b/src/registrar/templates/application_form.html
@@ -105,7 +105,7 @@
           aria-describedby="Are you sure you want to submit a domain request?"
           data-force-action
         >
-            {% include 'includes/modal.html' with modal_heading=modal_heading|safe modal_description="Once you submit this request, you won’t be able to make further edits until it’s reviewed by our staff. You’ll only be able to withdraw your request." modal_button=modal_button|safe %}
+            {% include 'includes/modal.html' with modal_heading=modal_heading|safe modal_description="Once you submit this request, you won’t be able to edit it until we review it. You’ll only be able to withdraw your request." modal_button=modal_button|safe %}
         </div>
 
 {% block after_form_content %}{% endblock %}

--- a/src/registrar/templates/application_no_other_contacts.html
+++ b/src/registrar/templates/application_no_other_contacts.html
@@ -2,5 +2,7 @@
 {% load static field_helpers %}
 
 {% block form_fields %}
-  {% input_with_errors forms.0.no_other_contacts_rationale %}
+  {% with attr_maxlength=1000 add_label_class="usa-sr-only" %}
+    {% input_with_errors forms.0.no_other_contacts_rationale %}
+  {% endwith %}
 {% endblock %}

--- a/src/registrar/templates/application_no_other_contacts.html
+++ b/src/registrar/templates/application_no_other_contacts.html
@@ -2,7 +2,5 @@
 {% load static field_helpers %}
 
 {% block form_fields %}
-  {% with attr_maxlength=1000 add_label_class="usa-sr-only" %}
-    {% input_with_errors forms.0.no_other_contacts_rationale %}
-  {% endwith %}
+  {% input_with_errors forms.0.no_other_contacts_rationale %}
 {% endblock %}

--- a/src/registrar/templates/includes/domain_application.html
+++ b/src/registrar/templates/includes/domain_application.html
@@ -1,7 +1,7 @@
 <h2 class="margin-top-0 margin-bottom-2 text-primary-darker text-semibold" > 
   Next steps in this process
 </h2>
-<p>We received your .gov domain request. Our next step is to review your request. This usually takes 20 business days. We’ll email you with questions or when we complete our review. <a class="usa-link" rel="noopener noreferrer" target="_blank" href="{% public_site_url 'contact' %}">Contact us with any questions</a>.</p>
+<p>We received your .gov domain request. Our next step is to review your request. This usually takes 20 business days. We’ll email you if we have questions and when we complete our review. <a class="usa-link" rel="noopener noreferrer" target="_blank" href="{% public_site_url 'contact' %}">Contact us with any questions</a>.</p>
 
 <h2 class="margin-top-0 margin-bottom-2 text-primary-darker text-semibold">
   Need to make changes?

--- a/src/registrar/templates/includes/domain_application.html
+++ b/src/registrar/templates/includes/domain_application.html
@@ -1,7 +1,7 @@
 <h2 class="margin-top-0 margin-bottom-2 text-primary-darker text-semibold" > 
-  Next steps
+  Next steps in this process
 </h2>
-<p>We received your .gov domain request. Our next step is to review your request. This usually takes two weeks. We’ll email you with questions or when we complete our review. Contact us with any questions.</p>
+<p>We received your .gov domain request. Our next step is to review your request. This usually takes 20 business days. We’ll email you with questions or when we complete our review. <a class="usa-link" rel="noopener noreferrer" target="_blank" href="{% public_site_url 'contact' %}">Contact us with any questions</a>.</p>
 
 <h2 class="margin-top-0 margin-bottom-2 text-primary-darker text-semibold">
   Need to make changes?

--- a/src/registrar/templates/includes/domain_application.html
+++ b/src/registrar/templates/includes/domain_application.html
@@ -1,3 +1,5 @@
+{% load url_helpers %}
+
 <h2 class="margin-top-0 margin-bottom-2 text-primary-darker text-semibold" > 
   Next steps in this process
 </h2>


### PR DESCRIPTION
Resolves [770](https://github.com/orgs/cisagov/projects/26/views/38?filterQuery=assignee%3A%22michelle-rago%22#:~:text=Content%3A%20Clarify%20next%20steps%20on%20Confirmation%20page), [778](https://github.com/cisagov/manage.get.gov/issues/778)


Changes
- Aligned post-request submission content re: next steps
- Simplified log in statement on 403 error page
- Tightened up pre-submission modal text