### PR TITLE
Add missing usa-list class to a ul

### DIFF
--- a/src/registrar/templates/domain_dns.html
+++ b/src/registrar/templates/domain_dns.html
@@ -12,7 +12,7 @@
   <p>You can enter your name servers, as well as other DNS-related information, in the following sections:</p>
 
   {% url 'domain-dns-nameservers' pk=domain.id as url %}
-<ul>  
+<ul class="usa-list">
 <li><a href="{{ url }}">Name servers</a></li>
 
   {% url 'domain-dns-dnssec' pk=domain.id as url %}


### PR DESCRIPTION
## Ticket

Resolves #1527 

## Changes

Add a missing `class="usa-list"` to a `ul` element.

## Context for reviewers

Very quick fix. Easy to review on `/domain/<id>/dns` if I can get it merged to a sandbox.

![Screenshot 2023-12-18 at 1 06 11 PM](https://github.com/cisagov/manage.get.gov/assets/443389/2ebfd607-7641-4b2b-b8a7-51e664f3ca61)
