### PR TITLE
(not on my sandbox) Fix User/Contact bug overwriting test data

### DIFF
--- a/src/registrar/models/contact.py
+++ b/src/registrar/models/contact.py
@@ -59,12 +59,12 @@ class Contact(TimeStampedModel):
         names = [n for n in [self.first_name, self.middle_name, self.last_name] if n]
         return " ".join(names) if names else "Unknown"
 
-    def save(self, *args, **kwargs):
+    def save(self, enable_custom_save=True, *args, **kwargs):
         # Call the parent class's save method to perform the actual save
         super().save(*args, **kwargs)
 
         # Update the related User object's first_name and last_name
-        if self.user:
+        if self.user and enable_custom_save:
             self.user.first_name = self.first_name
             self.user.last_name = self.last_name
             self.user.save()

--- a/src/registrar/models/contact.py
+++ b/src/registrar/models/contact.py
@@ -64,7 +64,7 @@ class Contact(TimeStampedModel):
         super().save(*args, **kwargs)
 
         # Update the related User object's first_name and last_name
-        if self.user and not self.user.first_name or not self.user.last_name:
+        if self.user and (not self.user.first_name or not self.user.last_name):
             self.user.first_name = self.first_name
             self.user.last_name = self.last_name
             self.user.save()

--- a/src/registrar/models/contact.py
+++ b/src/registrar/models/contact.py
@@ -64,7 +64,7 @@ class Contact(TimeStampedModel):
         super().save(*args, **kwargs)
 
         # Update the related User object's first_name and last_name
-        if self.user:
+        if self.user and not self.user.first_name or not self.user.last_name:
             self.user.first_name = self.first_name
             self.user.last_name = self.last_name
             self.user.save()

--- a/src/registrar/models/contact.py
+++ b/src/registrar/models/contact.py
@@ -59,12 +59,12 @@ class Contact(TimeStampedModel):
         names = [n for n in [self.first_name, self.middle_name, self.last_name] if n]
         return " ".join(names) if names else "Unknown"
 
-    def save(self, enable_custom_save=True, *args, **kwargs):
+    def save(self, *args, **kwargs):
         # Call the parent class's save method to perform the actual save
         super().save(*args, **kwargs)
 
         # Update the related User object's first_name and last_name
-        if self.user and enable_custom_save:
+        if self.user:
             self.user.first_name = self.first_name
             self.user.last_name = self.last_name
             self.user.save()

--- a/src/registrar/signals.py
+++ b/src/registrar/signals.py
@@ -46,7 +46,7 @@ def handle_profile(sender, instance, **kwargs):
 
     if len(contacts) >= 1 and is_new_user:  # a matching contact
         contacts[0].user = instance
-        contacts[0].save()
+        contacts[0].save(enable_custom_save=False)
 
         if len(contacts) > 1:  # multiple matches
             logger.warning(

--- a/src/registrar/signals.py
+++ b/src/registrar/signals.py
@@ -46,7 +46,7 @@ def handle_profile(sender, instance, **kwargs):
 
     if len(contacts) >= 1 and is_new_user:  # a matching contact
         contacts[0].user = instance
-        contacts[0].save(enable_custom_save=False)
+        contacts[0].save()
 
         if len(contacts) > 1:  # multiple matches
             logger.warning(

--- a/src/registrar/tests/test_admin.py
+++ b/src/registrar/tests/test_admin.py
@@ -1110,8 +1110,8 @@ class AuditedAdminTest(TestCase):
         tested_fields = [
             DomainApplication.authorizing_official.field,
             DomainApplication.submitter.field,
-            # DomainApplication.investigator.field,
-            # DomainApplication.creator.field,
+            DomainApplication.investigator.field,
+            DomainApplication.creator.field,
             DomainApplication.requested_domain.field,
         ]
 
@@ -1163,10 +1163,11 @@ class AuditedAdminTest(TestCase):
             )
 
     def test_alphabetically_sorted_fk_fields_domain_information(self):
+        self.maxDiff = None
         tested_fields = [
             DomainInformation.authorizing_official.field,
             DomainInformation.submitter.field,
-            # DomainInformation.creator.field,
+            #DomainInformation.creator.field,
             (DomainInformation.domain.field, ["name"]),
             (DomainInformation.domain_application.field, ["requested_domain__name"]),
         ]

--- a/src/registrar/tests/test_admin.py
+++ b/src/registrar/tests/test_admin.py
@@ -1163,7 +1163,6 @@ class AuditedAdminTest(TestCase):
             )
 
     def test_alphabetically_sorted_fk_fields_domain_information(self):
-        self.maxDiff = None
         tested_fields = [
             DomainInformation.authorizing_official.field,
             DomainInformation.submitter.field,

--- a/src/registrar/tests/test_admin.py
+++ b/src/registrar/tests/test_admin.py
@@ -1167,7 +1167,7 @@ class AuditedAdminTest(TestCase):
         tested_fields = [
             DomainInformation.authorizing_official.field,
             DomainInformation.submitter.field,
-            #DomainInformation.creator.field,
+            # DomainInformation.creator.field,
             (DomainInformation.domain.field, ["name"]),
             (DomainInformation.domain_application.field, ["requested_domain__name"]),
         ]

--- a/src/registrar/tests/test_models.py
+++ b/src/registrar/tests/test_models.py
@@ -674,7 +674,8 @@ class TestContact(TestCase):
     def setUp(self):
         self.email_for_invalid = "intern@igorville.gov"
         self.invalid_user, _ = User.objects.get_or_create(
-            username=self.email_for_invalid, email=self.email_for_invalid, first_name="", last_name="")
+            username=self.email_for_invalid, email=self.email_for_invalid, first_name="", last_name=""
+        )
         self.invalid_contact, _ = Contact.objects.get_or_create(user=self.invalid_user)
 
         self.email = "mayor@igorville.gov"
@@ -695,7 +696,7 @@ class TestContact(TestCase):
         self.assertEqual(self.invalid_contact.last_name, "")
         self.assertEqual(self.invalid_user.first_name, "")
         self.assertEqual(self.invalid_user.last_name, "")
-        
+
         # Manually update the contact - mimicking production (pre-existing data)
         self.invalid_contact.first_name = "Joey"
         self.invalid_contact.last_name = "Baloney"
@@ -709,7 +710,7 @@ class TestContact(TestCase):
         self.assertEqual(self.invalid_contact.last_name, "Baloney")
         self.assertEqual(self.invalid_user.first_name, "Joey")
         self.assertEqual(self.invalid_user.last_name, "Baloney")
-    
+
     def test_saving_contact_does_not_update_user_first_last_names(self):
         """When a contact is updated, we avoid propagating the changes to the linked user if it already has a value"""
 
@@ -743,7 +744,7 @@ class TestContact(TestCase):
         # Updating the contact's email does not propagate
         self.assertEqual(self.contact.email, "joey.baloney@diaperville.com")
         self.assertEqual(self.user.email, "mayor@igorville.gov")
-    
+
     def test_saving_contact_does_not_update_user_email_when_none(self):
         """When a contact's email is updated, the change is not propagated to the lined user."""
         self.invalid_contact.email = "joey.baloney@diaperville.com"

--- a/src/registrar/tests/test_models.py
+++ b/src/registrar/tests/test_models.py
@@ -734,7 +734,7 @@ class TestContact(TestCase):
         self.assertEqual(self.user.last_name, "Lebowski")
 
     def test_saving_contact_does_not_update_user_email(self):
-        """When a contact's email is updated, the change is not propagated to the lined user."""
+        """When a contact's email is updated, the change is not propagated to the user."""
         self.contact.email = "joey.baloney@diaperville.com"
         self.contact.save()
 
@@ -746,7 +746,8 @@ class TestContact(TestCase):
         self.assertEqual(self.user.email, "mayor@igorville.gov")
 
     def test_saving_contact_does_not_update_user_email_when_none(self):
-        """When a contact's email is updated, the change is not propagated to the lined user."""
+        """When a contact's email is updated, and the first/last name is none,
+        the change is not propagated to the user."""
         self.invalid_contact.email = "joey.baloney@diaperville.com"
         self.invalid_contact.save()
 

--- a/src/registrar/tests/test_models.py
+++ b/src/registrar/tests/test_models.py
@@ -678,8 +678,8 @@ class TestContact(TestCase):
         self.invalid_contact, _ = Contact.objects.get_or_create(user=self.invalid_user)
 
         self.email = "mayor@igorville.gov"
-        self.existing_user, _ = User.objects.get_or_create(email=self.email, first_name="Jeff", last_name="Lebowski")
-        self.existing_contact, _ = Contact.objects.get_or_create(user=self.existing_user)
+        self.user, _ = User.objects.get_or_create(email=self.email, first_name="Jeff", last_name="Lebowski")
+        self.contact, _ = Contact.objects.get_or_create(user=self.user)
 
     def tearDown(self):
         super().tearDown()
@@ -689,13 +689,14 @@ class TestContact(TestCase):
     def test_saving_contact_updates_user_first_last_names(self):
         """When a contact is updated, we propagate the changes to the linked user if it exists."""
 
-        # User and Contact are created and linked as expected
+        # User and Contact are created and linked as expected.
+        # An empty User object should create an empty contact.
         self.assertEqual(self.invalid_contact.first_name, "")
         self.assertEqual(self.invalid_contact.last_name, "")
         self.assertEqual(self.invalid_user.first_name, "")
         self.assertEqual(self.invalid_user.last_name, "")
         
-        # Manually update the contact - mimicking production
+        # Manually update the contact - mimicking production (pre-existing data)
         self.invalid_contact.first_name = "Joey"
         self.invalid_contact.last_name = "Baloney"
         self.invalid_contact.save()
@@ -713,35 +714,35 @@ class TestContact(TestCase):
         """When a contact is updated, we avoid propagating the changes to the linked user if it already has a value"""
 
         # User and Contact are created and linked as expected
-        self.assertEqual(self.existing_contact.first_name, "Jeff")
-        self.assertEqual(self.existing_contact.last_name, "Lebowski")
-        self.assertEqual(self.existing_user.first_name, "Jeff")
-        self.assertEqual(self.existing_user.last_name, "Lebowski")
+        self.assertEqual(self.contact.first_name, "Jeff")
+        self.assertEqual(self.contact.last_name, "Lebowski")
+        self.assertEqual(self.user.first_name, "Jeff")
+        self.assertEqual(self.user.last_name, "Lebowski")
 
-        self.existing_contact.first_name = "Joey"
-        self.existing_contact.last_name = "Baloney"
-        self.existing_contact.save()
+        self.contact.first_name = "Joey"
+        self.contact.last_name = "Baloney"
+        self.contact.save()
 
         # Refresh the user object to reflect the changes made in the database
-        self.existing_user.refresh_from_db()
+        self.user.refresh_from_db()
 
         # Updating the contact's first and last names propagate to the user
-        self.assertEqual(self.existing_contact.first_name, "Joey")
-        self.assertEqual(self.existing_contact.last_name, "Baloney")
-        self.assertEqual(self.existing_user.first_name, "Jeff")
-        self.assertEqual(self.existing_user.last_name, "Lebowski")
+        self.assertEqual(self.contact.first_name, "Joey")
+        self.assertEqual(self.contact.last_name, "Baloney")
+        self.assertEqual(self.user.first_name, "Jeff")
+        self.assertEqual(self.user.last_name, "Lebowski")
 
     def test_saving_contact_does_not_update_user_email(self):
         """When a contact's email is updated, the change is not propagated to the lined user."""
-        self.existing_contact.email = "joey.baloney@diaperville.com"
-        self.existing_contact.save()
+        self.contact.email = "joey.baloney@diaperville.com"
+        self.contact.save()
 
         # Refresh the user object to reflect the changes made in the database
-        self.existing_user.refresh_from_db()
+        self.user.refresh_from_db()
 
         # Updating the contact's email does not propagate
-        self.assertEqual(self.existing_contact.email, "joey.baloney@diaperville.com")
-        self.assertEqual(self.existing_user.email, "mayor@igorville.gov")
+        self.assertEqual(self.contact.email, "joey.baloney@diaperville.com")
+        self.assertEqual(self.user.email, "mayor@igorville.gov")
     
     def test_saving_contact_does_not_update_user_email_when_none(self):
         """When a contact's email is updated, the change is not propagated to the lined user."""

--- a/src/registrar/tests/test_models.py
+++ b/src/registrar/tests/test_models.py
@@ -753,4 +753,4 @@ class TestContact(TestCase):
 
         # Updating the contact's email does not propagate
         self.assertEqual(self.invalid_contact.email, "joey.baloney@diaperville.com")
-        self.assertEqual(self.invalid_user.email, "mayor@igorville.gov")
+        self.assertEqual(self.invalid_user.email, "intern@igorville.gov")

--- a/src/registrar/tests/test_models_domain.py
+++ b/src/registrar/tests/test_models_domain.py
@@ -761,7 +761,6 @@ class TestRegistrantContacts(MockEppLib):
             self.assertEqual(expected_contact.email, actual_contact.email)
 
     def test_convert_public_contact_to_epp(self):
-        self.maxDiff = None
         domain, _ = Domain.objects.get_or_create(name="freeman.gov")
         dummy_contact = domain.get_default_security_contact()
         test_disclose = self._convertPublicContactToEpp(dummy_contact, disclose_email=True).__dict__

--- a/src/registrar/tests/test_reports.py
+++ b/src/registrar/tests/test_reports.py
@@ -152,7 +152,6 @@ class CsvReportsTest(TestCase):
     @boto3_mocking.patching
     def test_load_federal_report(self):
         """Tests the get_current_federal api endpoint"""
-        self.maxDiff = None
         mock_client = MagicMock()
         mock_client_instance = mock_client.return_value
 


### PR DESCRIPTION
## Ticket

Resolves #1547 
<!--Reminder, when a code change is made that is user facing, beyond content updates, then the following are required:
- a developer approves the PR
- a designer approves the PR or checks off all relevant items in this checklist.

All other changes require just a single approving review.-->

## Changes

<!-- What was added, updated, or removed in this PR. -->
- Modify `contact.py` such that the save will also do an additional check for if the first_name/last_name is empty. If it is, we want to modify it. If it isn't, we simply don't.
- Fix some test cases and add some additional ones

<!--
    Please add/remove/edit any of the template below to fit the needs
    of this specific PR.
--->

## Context for reviewers
The original implementation of #1547 introduced a bug where signals was, in essence, overwriting data incorrectly when invoking User.objects.create manually. This caused issues with our test cases, as that is frequently used there. 

This fix narrows the scope of _where_ we are doing that overwriting such that we now only do it when the first name or the last name is empty.
<!--Background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers.  -->

## Setup
1. Login with your analyst account
2. Navigate to /admin, ensure that all your user object looks correct
3. Logout (while keeping the app open)
4. Login with your admin account
5. Edit the first/last name of the analyst user (Do not empty out the fields, just change it to another name). These modifications should not result in any changes to the first/last name of the user
6. Delete the user object for your analyst account
7. Logout of your admin account
8. Login with your analyst account
9. Repeat step 2, then perform step 5 while logged in with your analyst account
<!--  Add any steps or code to run in this section to help others run your code.
    
    Example 1:
    ```sh
    echo "Code goes here"
    ``` 
    
    Example 2: If the PR was to add a new link with a redirect, this section could simply be:
    -go to /path/to/start/page
    -click the blue link in the <insert location>
    -notice user is redirected to <proper end location>
-->

## Code Review Verification Steps

### As the original developer, I have

#### Satisfied acceptance criteria and met development standards

- [ ] Met the acceptance criteria, or will meet them in a subsequent PR
- [ ] Created/modified automated tests
- [ ] Added at least 2 developers as PR reviewers (only 1 will need to approve)
- [ ] Messaged on Slack or in standup to notify the team that a PR is ready for review
- [ ] Changes to “how we do things” are documented in READMEs and or onboarding guide
- [ ] If any model was updated to modify/add/delete columns, makemigrations was ran and the assoicated migrations file has been commited.

#### Ensured code standards are met (Original Developer)

- [ ] All new functions and methods are commented using plain language
- [ ] Did dependency updates in Pipfile also get changed in requirements.txt?
- [ ] Interactions with external systems are wrapped in try/except
- [ ] Error handling exists for unusual or missing values

#### Validated user-facing changes (if applicable)

- [ ] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Checked keyboard navigability
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)
- [ ] Add at least 1 designer as PR reviewer

### As a code reviewer, I have

#### Reviewed, tested, and left feedback about the changes

- [ ] Pulled this branch locally and tested it
- [ ] Reviewed this code and left comments
- [ ] Checked that all code is adequately covered by tests
- [ ] Made it clear which comments need to be addressed before this work is merged
- [ ] If any model was updated to modify/add/delete columns, makemigrations was ran and the assoicated migrations file has been commited.

#### Ensured code standards are met (Code reviewer)

- [ ] All new functions and methods are commented using plain language
- [ ] Interactions with external systems are wrapped in try/except
- [ ] Error handling exists for unusual or missing values
- [ ] (Rarely needed) Did dependency updates in Pipfile also get changed in requirements.txt?

#### Validated user-facing changes as a developer

- [ ] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Checked keyboard navigability
- [ ] Meets all designs and user flows provided by design/product
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)

- [ ] Tested with multiple browsers, the suggestion is to use ones that the developer didn't (check off which ones were used)
  - [ ] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari

- [ ] (Rarely needed) Tested as both an analyst and applicant user

**Note:** Multiple code reviewers can share the checklists above, a second reviewers should not make a duplicate checklist

### As a designer reviewer, I have

#### Verified that the changes match the design intention

- [ ] Checked that the design translated visually
- [ ] Checked behavior
- [ ] Checked different states (empty, one, some, error)
- [ ] Checked for landmarks, page heading structure, and links
- [ ] Tried to break the intended flow

#### Validated user-facing changes as a designer

- [ ] Checked keyboard navigability
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)

- [ ] Tested with multiple browsers (check off which ones were used)
  - [ ] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari

- [ ] (Rarely needed) Tested as both an analyst and applicant user

## Screenshots

<!-- If this PR makes visible interface changes, an image of the finished interface can help reviewers
and casual observers understand the context of the changes.
A before image is optional and can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow.
You may want to use [GIPHY Capture](https://giphy.com/apps/giphycapture) for this! 📸

_Please frame images to show useful context but also highlight the affected regions._
--->
