### PR TITLE
Redirect to get.gov after logout

### DIFF
--- a/src/registrar/config/settings.py
+++ b/src/registrar/config/settings.py
@@ -519,7 +519,7 @@ LOGIN_REQUIRED_IGNORE_PATHS = [
 ]
 
 # where to go after logging out
-LOGOUT_REDIRECT_URL = "home"
+LOGOUT_REDIRECT_URL = "https://get.gov/"
 
 # disable dynamic client registration,
 # only the OP inside OIDC_PROVIDERS will be available

--- a/src/zap.conf
+++ b/src/zap.conf
@@ -67,6 +67,7 @@
 10038	OUTOFSCOPE	http://app:8080/dns/nameservers
 10038	OUTOFSCOPE	http://app:8080/dns/dnssec
 10038	OUTOFSCOPE	http://app:8080/dns/dnssec/dsdata
+10038	OUTOFSCOPE	http://app:8080/org-name-address
 # This URL always returns 404, so include it as well.
 10038	OUTOFSCOPE	http://app:8080/todo
 # OIDC isn't configured in the test environment and DEBUG=True so this gives a 500 without CSP headers


### PR DESCRIPTION
# 489. Redirect to get.gov after logout from manage.get.gov

Resolves #489

## Changes

After logging out, redirect to https://get.gov using Django's LOGOUT_REDIRECT_URL setting.

## Context for reviewers

This prevents the surprising experience we have now of logging out of manage.get.gov and ending up back at Login.gov because we redirected to a page that requires users to be logged in.

## Setup

Run this locally or on a sandbox, log in and then click "Sign out" in the top right and you should end up at get.gov.

## Code Review Verification Steps

### As the original developer, I have

#### Satisfied acceptance criteria and met development standards

- [X] Met the acceptance criteria, or will meet them in a subsequent PR
- [X] Added at least 2 developers as PR reviewers (only 1 will need to approve)
- [X] Messaged on Slack or in standup to notify the team that a PR is ready for review

#### Validated user-facing changes (if applicable)

- [X] Add at least 1 designer as PR reviewer

### As a code reviewer, I have

#### Reviewed, tested, and left feedback about the changes

- [ ] Pulled this branch locally and tested it
- [ ] Reviewed this code and left comments
- [ ] Checked that all code is adequately covered by tests
- [ ] Made it clear which comments need to be addressed before this work is merged
- [ ] If any model was updated to modify/add/delete columns, makemigrations was ran and the assoicated migrations file has been commited.

#### Ensured code standards are met (Code reviewer)

- [ ] All new functions and methods are commented using plain language
- [ ] Interactions with external systems are wrapped in try/except
- [ ] Error handling exists for unusual or missing values
- [ ] (Rarely needed) Did dependency updates in Pipfile also get changed in requirements.txt?

#### Validated user-facing changes as a developer

- [ ] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Checked keyboard navigability
- [ ] Meets all designs and user flows provided by design/product
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)

- [ ] Tested with multiple browsers, the suggestion is to use ones that the developer didn't (check off which ones were used)
  - [ ] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari

- [ ] (Rarely needed) Tested as both an analyst and applicant user

**Note:** Multiple code reviewers can share the checklists above, a second reviewers should not make a duplicate checklist

### As a designer reviewer, I have

#### Verified that the changes match the design intention

- [ ] Checked that the design translated visually
- [ ] Checked behavior
- [ ] Checked different states (empty, one, some, error)
- [ ] Checked for landmarks, page heading structure, and links
- [ ] Tried to break the intended flow

#### Validated user-facing changes as a designer

- [ ] Checked keyboard navigability
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)

- [ ] Tested with multiple browsers (check off which ones were used)
  - [ ] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari

- [ ] (Rarely needed) Tested as both an analyst and applicant user

## Screenshots

<!-- If this PR makes visible interface changes, an image of the finished interface can help reviewers
and casual observers understand the context of the changes.
A before image is optional and can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow.
You may want to use [GIPHY Capture](https://giphy.com/apps/giphycapture) for this! 📸

_Please frame images to show useful context but also highlight the affected regions._
--->
