### PR TITLE
Use submission_date in application emails

### DIFF
--- a/src/registrar/templates/emails/status_change_action_needed.txt
+++ b/src/registrar/templates/emails/status_change_action_needed.txt
@@ -4,7 +4,7 @@ Hi {{ application.submitter.first_name }}.
 We've identified an action needed to complete the review of your .gov domain request.
 
 DOMAIN REQUESTED: {{ application.requested_domain.name }}
-REQUEST RECEIVED ON: {{ application.updated_at|date }}
+REQUEST RECEIVED ON: {{ application.submission_date|date }}
 REQUEST #: {{ application.id }}
 STATUS: Action needed
 

--- a/src/registrar/templates/emails/status_change_approved.txt
+++ b/src/registrar/templates/emails/status_change_approved.txt
@@ -4,7 +4,7 @@ Hi {{ application.submitter.first_name }}.
 Congratulations! Your .gov domain request has been approved.
 
 DOMAIN REQUESTED: {{ application.requested_domain.name }}
-REQUEST RECEIVED ON: {{ application.updated_at|date }}
+REQUEST RECEIVED ON: {{ application.submission_date|date }}
 REQUEST #: {{ application.id }}
 STATUS: In review
 

--- a/src/registrar/templates/emails/status_change_in_review.txt
+++ b/src/registrar/templates/emails/status_change_in_review.txt
@@ -4,7 +4,7 @@ Hi {{ application.submitter.first_name }}.
 Your .gov domain request is being reviewed.
 
 DOMAIN REQUESTED: {{ application.requested_domain.name }}
-REQUEST RECEIVED ON: {{ application.updated_at|date }}
+REQUEST RECEIVED ON: {{ application.submission_date|date }}
 REQUEST #: {{ application.id }}
 STATUS: In review
 

--- a/src/registrar/templates/emails/status_change_rejected.txt
+++ b/src/registrar/templates/emails/status_change_rejected.txt
@@ -4,7 +4,7 @@ Hi {{ application.submitter.first_name }}.
 Your .gov domain request has been rejected.
 
 DOMAIN REQUESTED: {{ application.requested_domain.name }}
-REQUEST RECEIVED ON: {{ application.updated_at|date }}
+REQUEST RECEIVED ON: {{ application.submission_date|date }}
 REQUEST #: {{ application.id }}
 STATUS: Rejected
 

--- a/src/registrar/templates/emails/submission_confirmation.txt
+++ b/src/registrar/templates/emails/submission_confirmation.txt
@@ -4,7 +4,7 @@ Hi {{ application.submitter.first_name }}.
 We received your .gov domain request.
 
 DOMAIN REQUESTED: {{ application.requested_domain.name }}
-REQUEST RECEIVED ON: {{ application.updated_at|date }}
+REQUEST RECEIVED ON: {{ application.submission_date|date }}
 REQUEST #: {{ application.id }}
 STATUS: Received
 


### PR DESCRIPTION
## Ticket

Resolves #1572

## Changes

This uses the `submission_date` field from a domain application in our emails about the application. The field was originally added for use on the dashboard page, but we neglected to hook it up to the email templates.

## Context for reviewers

This is a very tiny change, but if you'd like to test it manually, you should be able to mark a domain application in the Django admin as "in review" and then approve the application and see if the date in the email matches the one on the dashboard page.

## Setup

You should be able to test this on any environment with domain application fixtures and email sending credentials.

## Code Review Verification Steps

### As the original developer, I have

#### Satisfied acceptance criteria and met development standards

- [X] Met the acceptance criteria, or will meet them in a subsequent PR
- [X] Added at least 2 developers as PR reviewers (only 1 will need to approve)
- [X] Messaged on Slack or in standup to notify the team that a PR is ready for review

### As a code reviewer, I have

#### Reviewed, tested, and left feedback about the changes

- [x] Pulled this branch locally and tested it
- [ ] Reviewed this code and left comments
- [ ] Checked that all code is adequately covered by tests
- [ ] Made it clear which comments need to be addressed before this work is merged
- [ ] If any model was updated to modify/add/delete columns, makemigrations was ran and the assoicated migrations file has been commited.

#### Ensured code standards are met (Code reviewer)

- [ ] All new functions and methods are commented using plain language
- [ ] Interactions with external systems are wrapped in try/except
- [ ] Error handling exists for unusual or missing values
- [ ] (Rarely needed) Did dependency updates in Pipfile also get changed in requirements.txt?

#### Validated user-facing changes as a developer

- [ ] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Checked keyboard navigability
- [ ] Meets all designs and user flows provided by design/product
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)

- [ ] Tested with multiple browsers, the suggestion is to use ones that the developer didn't (check off which ones were used)
  - [ ] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari

- [ ] (Rarely needed) Tested as both an analyst and applicant user

**Note:** Multiple code reviewers can share the checklists above, a second reviewers should not make a duplicate checklist

### As a designer reviewer, I have

#### Verified that the changes match the design intention

- [ ] Checked that the design translated visually
- [ ] Checked behavior
- [ ] Checked different states (empty, one, some, error)
- [ ] Checked for landmarks, page heading structure, and links
- [ ] Tried to break the intended flow

#### Validated user-facing changes as a designer

- [ ] Checked keyboard navigability
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)

- [ ] Tested with multiple browsers (check off which ones were used)
  - [ ] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari

- [ ] (Rarely needed) Tested as both an analyst and applicant user

## Screenshots

<!-- If this PR makes visible interface changes, an image of the finished interface can help reviewers
and casual observers understand the context of the changes.
A before image is optional and can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow.
You may want to use [GIPHY Capture](https://giphy.com/apps/giphycapture) for this! 📸

_Please frame images to show useful context but also highlight the affected regions._
--->
