### PR TITLE
Add PRA burden link to application intro

### DIFF
--- a/src/registrar/templates/application_intro.html
+++ b/src/registrar/templates/application_intro.html
@@ -15,7 +15,7 @@
         <p>If you have <a href="{% public_site_url 'domains/before/#information-you%E2%80%99ll-need-to-complete-the-domain-request-form' %}" target="_blank" class="usa-link">all the information you need</a>,
            completing your domain request might take around 15 minutes. <a href="{% public_site_url 'contact/' %}" target="_blank" rel="noopener noreferrer" class="usa-link">Contact us if you need help with your request</a>.</p>
         
-        <p>Read our <a href="{% public_site_url 'privacy-policy#pra' %}" target="_blank" rel="noopener noreferrer" class="usa-link">Paperwork Reduction Act statement</a> (OMB Control 1670-0049).</p>
+        <p>Read our <a href="{% public_site_url 'privacy-policy#pra' %}" target="_blank" rel="noopener noreferrer" class="usa-link">Paperwork Reduction Act statement</a> (OMB Control Number: 1670-0049, expiration date: 10/31/2026).</p>
 
 {% block form_buttons %}
         <div class="stepnav">

--- a/src/registrar/templates/application_intro.html
+++ b/src/registrar/templates/application_intro.html
@@ -15,7 +15,7 @@
         <p>If you have <a href="{% public_site_url 'domains/before/#information-you%E2%80%99ll-need-to-complete-the-domain-request-form' %}" target="_blank" class="usa-link">all the information you need</a>,
            completing your domain request might take around 15 minutes. <a href="{% public_site_url 'contact/' %}" target="_blank" rel="noopener noreferrer" class="usa-link">Contact us</a> if you need help.</p>
         
-        <p>Read our <a href="{% public_site_url 'privacy-policy#pra' %}" target="_blank" rel="noopener noreferrer" class="usa-link">Paperwork Reduction Act statement</a> (OMB Control Number: 1670-0049, expiration date: 10/31/2026).</p>
+        <p>Read our <a href="{% public_site_url 'privacy-policy#pra' %}" target="_blank" rel="noopener noreferrer" class="usa-link">Paperwork Reduction Act statement</a> (OMB control number: 1670-0049; expiration date: 10/31/2026).</p>
 
 {% block form_buttons %}
         <div class="stepnav">

--- a/src/registrar/templates/application_intro.html
+++ b/src/registrar/templates/application_intro.html
@@ -29,7 +29,7 @@
 
         </form>
 
-   <div class="caption margin-top-3"><a href="{% public_site_url 'privacy-policy#pra' %}" target="_blank" rel="noopener noreferrer" class="usa-link">Paperwork Reduction Act statement</a> (OMB control number: 1670-0049; expiration date: 10/31/2026)</div>
+   <div class="caption margin-top-5"><a href="{% public_site_url 'privacy-policy#pra' %}" target="_blank" rel="noopener noreferrer" class="usa-link">Paperwork Reduction Act statement</a> (OMB control number: 1670-0049; expiration date: 10/31/2026)</div>
   </div>
 </main>
 {% endblock %}

--- a/src/registrar/templates/application_intro.html
+++ b/src/registrar/templates/application_intro.html
@@ -29,7 +29,7 @@
 
         </form>
 
-   <p class="font-sans-sm"><a href="{% public_site_url 'privacy-policy#pra' %}" target="_blank" rel="noopener noreferrer" class="usa-link">Paperwork Reduction Act statement</a> (OMB control number: 1670-0049; expiration date: 10/31/2026)</p>
+   <p class="font-sans-xs"><a href="{% public_site_url 'privacy-policy#pra' %}" target="_blank" rel="noopener noreferrer" class="usa-link">Paperwork Reduction Act statement</a> (OMB control number: 1670-0049; expiration date: 10/31/2026)</p>
   </div>
 </main>
 {% endblock %}

--- a/src/registrar/templates/application_intro.html
+++ b/src/registrar/templates/application_intro.html
@@ -29,7 +29,7 @@
 
         </form>
 
-   <p><a href="{% public_site_url 'privacy-policy#pra' %}" target="_blank" rel="noopener noreferrer" class="usa-link">Paperwork Reduction Act statement</a> (OMB control number: 1670-0049; expiration date: 10/31/2026)</p>
+   <p class="caption"><a href="{% public_site_url 'privacy-policy#pra' %}" target="_blank" rel="noopener noreferrer" class="usa-link">Paperwork Reduction Act statement</a> (OMB control number: 1670-0049; expiration date: 10/31/2026)</p>
   </div>
 </main>
 {% endblock %}

--- a/src/registrar/templates/application_intro.html
+++ b/src/registrar/templates/application_intro.html
@@ -29,7 +29,7 @@
 
         </form>
 
-   <p class="caption"><a href="{% public_site_url 'privacy-policy#pra' %}" target="_blank" rel="noopener noreferrer" class="usa-link">Paperwork Reduction Act statement</a> (OMB control number: 1670-0049; expiration date: 10/31/2026)</p>
+   <div class="caption"><a href="{% public_site_url 'privacy-policy#pra' %}" target="_blank" rel="noopener noreferrer" class="usa-link">Paperwork Reduction Act statement</a> (OMB control number: 1670-0049; expiration date: 10/31/2026)</div>
   </div>
 </main>
 {% endblock %}

--- a/src/registrar/templates/application_intro.html
+++ b/src/registrar/templates/application_intro.html
@@ -14,9 +14,10 @@
         <h2>Time to complete the form</h2>
         <p>If you have <a href="{% public_site_url 'domains/before/#information-you%E2%80%99ll-need-to-complete-the-domain-request-form' %}" target="_blank" class="usa-link">all the information you need</a>,
            completing your domain request might take around 15 minutes.</p>
+        
         <p><a href="{% public_site_url 'contact/' %}" target="_blank" rel="noopener noreferrer" class="usa-link">Contact us if you need help with your request</a>.</p>
         
-        <p>Read our <a href="{% public_site_url 'tbd' %}" target="_blank" rel="noopener noreferrer" class="usa-link">Paperwork Reduction Act statement</a> (OMB Control 1670-0049).</p>
+        <p>Read our <a href="{% public_site_url 'privacy-policy#pra' %}" target="_blank" rel="noopener noreferrer" class="usa-link">Paperwork Reduction Act statement</a> (OMB Control 1670-0049).</p>
 
 {% block form_buttons %}
         <div class="stepnav">

--- a/src/registrar/templates/application_intro.html
+++ b/src/registrar/templates/application_intro.html
@@ -29,7 +29,7 @@
 
         </form>
 
-   <p class="font-sans-xs"><a href="{% public_site_url 'privacy-policy#pra' %}" target="_blank" rel="noopener noreferrer" class="usa-link">Paperwork Reduction Act statement</a> (OMB control number: 1670-0049; expiration date: 10/31/2026)</p>
+   <p><a href="{% public_site_url 'privacy-policy#pra' %}" target="_blank" rel="noopener noreferrer" class="usa-link">Paperwork Reduction Act statement</a> (OMB control number: 1670-0049; expiration date: 10/31/2026)</p>
   </div>
 </main>
 {% endblock %}

--- a/src/registrar/templates/application_intro.html
+++ b/src/registrar/templates/application_intro.html
@@ -13,7 +13,7 @@
         <p>We’ll use the information you provide to verify your organization’s eligibility for a .gov domain. We’ll also verify that the domain you request meets our guidelines.</p>
         <h2>Time to complete the form</h2>
         <p>If you have <a href="{% public_site_url 'domains/before/#information-you%E2%80%99ll-need-to-complete-the-domain-request-form' %}" target="_blank" class="usa-link">all the information you need</a>,
-           completing your domain request might take around 15 minutes. <a href="{% public_site_url 'contact/' %}" target="_blank" rel="noopener noreferrer" class="usa-link">Contact us</a> if you need help.</p>
+           completing your domain request might take around 15 minutes.</p>
         
         <p>Read our <a href="{% public_site_url 'privacy-policy#pra' %}" target="_blank" rel="noopener noreferrer" class="usa-link">Paperwork Reduction Act statement</a> (OMB control number: 1670-0049; expiration date: 10/31/2026).</p>
 

--- a/src/registrar/templates/application_intro.html
+++ b/src/registrar/templates/application_intro.html
@@ -28,7 +28,7 @@
 {% endblock %}
 
         </form>
-
+<br/>
    <div class="caption"><a href="{% public_site_url 'privacy-policy#pra' %}" target="_blank" rel="noopener noreferrer" class="usa-link">Paperwork Reduction Act statement</a> (OMB control number: 1670-0049; expiration date: 10/31/2026)</div>
   </div>
 </main>

--- a/src/registrar/templates/application_intro.html
+++ b/src/registrar/templates/application_intro.html
@@ -13,9 +13,7 @@
         <p>We’ll use the information you provide to verify your organization’s eligibility for a .gov domain. We’ll also verify that the domain you request meets our guidelines.</p>
         <h2>Time to complete the form</h2>
         <p>If you have <a href="{% public_site_url 'domains/before/#information-you%E2%80%99ll-need-to-complete-the-domain-request-form' %}" target="_blank" class="usa-link">all the information you need</a>,
-           completing your domain request might take around 15 minutes.</p>
-        
-        <p><a href="{% public_site_url 'contact/' %}" target="_blank" rel="noopener noreferrer" class="usa-link">Contact us if you need help with your request</a>.</p>
+           completing your domain request might take around 15 minutes. <a href="{% public_site_url 'contact/' %}" target="_blank" rel="noopener noreferrer" class="usa-link">Contact us if you need help with your request</a>.</p>
         
         <p>Read our <a href="{% public_site_url 'privacy-policy#pra' %}" target="_blank" rel="noopener noreferrer" class="usa-link">Paperwork Reduction Act statement</a> (OMB Control 1670-0049).</p>
 

--- a/src/registrar/templates/application_intro.html
+++ b/src/registrar/templates/application_intro.html
@@ -13,7 +13,7 @@
         <p>We’ll use the information you provide to verify your organization’s eligibility for a .gov domain. We’ll also verify that the domain you request meets our guidelines.</p>
         <h2>Time to complete the form</h2>
         <p>If you have <a href="{% public_site_url 'domains/before/#information-you%E2%80%99ll-need-to-complete-the-domain-request-form' %}" target="_blank" class="usa-link">all the information you need</a>,
-           completing your domain request might take around 15 minutes.</p>
+           completing your domain request might take around 15 minutes. Read our <a href="{% public_site_url 'tbd' %}" target="_blank" rel="noopener noreferrer" class="usa-link">Paperwork Reduction Act burden statement (OMB Control 1670-0049)</a>.</p>
         <p><a href="{% public_site_url 'contact/' %}" target="_blank" rel="noopener noreferrer" class="usa-link">Contact us if you need help with your request</a>.</p>
 
 {% block form_buttons %}

--- a/src/registrar/templates/application_intro.html
+++ b/src/registrar/templates/application_intro.html
@@ -13,7 +13,7 @@
         <p>We’ll use the information you provide to verify your organization’s eligibility for a .gov domain. We’ll also verify that the domain you request meets our guidelines.</p>
         <h2>Time to complete the form</h2>
         <p>If you have <a href="{% public_site_url 'domains/before/#information-you%E2%80%99ll-need-to-complete-the-domain-request-form' %}" target="_blank" class="usa-link">all the information you need</a>,
-           completing your domain request might take around 15 minutes. <a href="{% public_site_url 'contact/' %}" target="_blank" rel="noopener noreferrer" class="usa-link">Contact us if you need help with your request</a>.</p>
+           completing your domain request might take around 15 minutes. <a href="{% public_site_url 'contact/' %}" target="_blank" rel="noopener noreferrer" class="usa-link">Contact us</a> if you need help.</p>
         
         <p>Read our <a href="{% public_site_url 'privacy-policy#pra' %}" target="_blank" rel="noopener noreferrer" class="usa-link">Paperwork Reduction Act statement</a> (OMB Control Number: 1670-0049, expiration date: 10/31/2026).</p>
 

--- a/src/registrar/templates/application_intro.html
+++ b/src/registrar/templates/application_intro.html
@@ -29,7 +29,7 @@
 
         </form>
 
-    <h5><a href="{% public_site_url 'privacy-policy#pra' %}" target="_blank" rel="noopener noreferrer" class="usa-link">Paperwork Reduction Act statement</a> (OMB control number: 1670-0049; expiration date: 10/31/2026)</h5>
+   <p class="font-sans-sm"><a href="{% public_site_url 'privacy-policy#pra' %}" target="_blank" rel="noopener noreferrer" class="usa-link">Paperwork Reduction Act statement</a> (OMB control number: 1670-0049; expiration date: 10/31/2026)</p>
   </div>
 </main>
 {% endblock %}

--- a/src/registrar/templates/application_intro.html
+++ b/src/registrar/templates/application_intro.html
@@ -13,8 +13,10 @@
         <p>We’ll use the information you provide to verify your organization’s eligibility for a .gov domain. We’ll also verify that the domain you request meets our guidelines.</p>
         <h2>Time to complete the form</h2>
         <p>If you have <a href="{% public_site_url 'domains/before/#information-you%E2%80%99ll-need-to-complete-the-domain-request-form' %}" target="_blank" class="usa-link">all the information you need</a>,
-           completing your domain request might take around 15 minutes. Read our <a href="{% public_site_url 'tbd' %}" target="_blank" rel="noopener noreferrer" class="usa-link">Paperwork Reduction Act burden statement (OMB Control 1670-0049)</a>.</p>
+           completing your domain request might take around 15 minutes.</p>
         <p><a href="{% public_site_url 'contact/' %}" target="_blank" rel="noopener noreferrer" class="usa-link">Contact us if you need help with your request</a>.</p>
+        
+        <p>Read our <a href="{% public_site_url 'tbd' %}" target="_blank" rel="noopener noreferrer" class="usa-link">Paperwork Reduction Act statement</a> (OMB Control 1670-0049).</p>
 
 {% block form_buttons %}
         <div class="stepnav">

--- a/src/registrar/templates/application_intro.html
+++ b/src/registrar/templates/application_intro.html
@@ -28,8 +28,8 @@
 {% endblock %}
 
         </form>
-<br/>
-   <div class="caption"><a href="{% public_site_url 'privacy-policy#pra' %}" target="_blank" rel="noopener noreferrer" class="usa-link">Paperwork Reduction Act statement</a> (OMB control number: 1670-0049; expiration date: 10/31/2026)</div>
+
+   <div class="caption margin-top-3"><a href="{% public_site_url 'privacy-policy#pra' %}" target="_blank" rel="noopener noreferrer" class="usa-link">Paperwork Reduction Act statement</a> (OMB control number: 1670-0049; expiration date: 10/31/2026)</div>
   </div>
 </main>
 {% endblock %}

--- a/src/registrar/templates/application_intro.html
+++ b/src/registrar/templates/application_intro.html
@@ -15,7 +15,6 @@
         <p>If you have <a href="{% public_site_url 'domains/before/#information-you%E2%80%99ll-need-to-complete-the-domain-request-form' %}" target="_blank" class="usa-link">all the information you need</a>,
            completing your domain request might take around 15 minutes.</p>
         
-        <p>Read our <a href="{% public_site_url 'privacy-policy#pra' %}" target="_blank" rel="noopener noreferrer" class="usa-link">Paperwork Reduction Act statement</a> (OMB control number: 1670-0049; expiration date: 10/31/2026).</p>
 
 {% block form_buttons %}
         <div class="stepnav">
@@ -30,6 +29,7 @@
 
         </form>
 
+    <h5><a href="{% public_site_url 'privacy-policy#pra' %}" target="_blank" rel="noopener noreferrer" class="usa-link">Paperwork Reduction Act statement</a> (OMB control number: 1670-0049; expiration date: 10/31/2026)</h5>
   </div>
 </main>
 {% endblock %}


### PR DESCRIPTION
## Ticket https://github.com/cisagov/manage.get.gov/issues/1498

## Changes

<!-- What was added, updated, or removed in this PR. -->
- Added required PRA language to the application intro below the "Continue" button. 

- For now, the link goes to the privacy policy. We can add a new section to that page (pending @h-m-f-t 's approval).

<!--
    Please add/remove/edit any of the template below to fit the needs
    of this specific PR.
--->

## Screenshot 
![image](https://github.com/cisagov/manage.get.gov/assets/60157596/f0d55300-7a05-4bdb-8133-247e12120b12)

## Context for reviewers

<!--Background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers.  -->

### As a designer reviewer, I have

#### Verified that the changes match the design intention

- [ ] Checked that the design translated visually
- [ ] Checked behavior
- [ ] Checked different states (empty, one, some, error)
- [ ] Checked for landmarks, page heading structure, and links
- [ ] Tried to break the intended flow

#### Validated user-facing changes as a designer

- [ ] Checked keyboard navigability
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)

- [ ] Tested with multiple browsers (check off which ones were used)
  - [ ] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari

