### PR TITLE
Ticket #1643 - Remove stale form errors on the check availablity page

### DIFF
--- a/src/registrar/assets/js/get-gov.js
+++ b/src/registrar/assets/js/get-gov.js
@@ -245,13 +245,10 @@ function handleValidationClick(e) {
   const alternateDomainsInputs = document.querySelectorAll('[auto-validate]');
   if (alternateDomainsInputs) {
     for (const domainInput of alternateDomainsInputs){
-      // Only apply this logic to alternate domains input
-      if (domainInput.classList.contains('alternate-domain-input')){
-          domainInput.addEventListener('input', function() {
-              removeFormErrors(domainInput, true);
-            }
-          );
-      }
+      domainInput.addEventListener('input', function() {
+          removeFormErrors(domainInput, true);
+        }
+      );
     }
     }
 })();

--- a/src/registrar/assets/js/get-gov.js
+++ b/src/registrar/assets/js/get-gov.js
@@ -264,7 +264,6 @@ function removeFormErrors(input){
   let errorMessage = document.getElementById(`${input.id}__error-message`);
   if (errorMessage) {
     errorMessage.remove();
-    console.log("Error message removed")
   }else{
     return
   }
@@ -274,6 +273,7 @@ function removeFormErrors(input){
     input.classList.remove('usa-input--error');
   }
 
+  // Get the form label
   let label = document.querySelector(`label[for="${input.id}"]`);
   if (label) {
     label.classList.remove('usa-label--error');

--- a/src/registrar/assets/js/get-gov.js
+++ b/src/registrar/assets/js/get-gov.js
@@ -286,7 +286,7 @@ function removeFormErrors(input, removeStaleAlerts=false){
   }
 
   if (removeStaleAlerts){
-    let staleAlerts = document.getElementsByClassName("usa-alert--error")
+    let staleAlerts = Array.from(document.getElementsByClassName("usa-alert--error"))
     for (let alert of staleAlerts){
       // Don't remove the error associated with the input
       if (alert.id !== `${input.id}--toast`) {

--- a/src/registrar/assets/js/get-gov.js
+++ b/src/registrar/assets/js/get-gov.js
@@ -286,7 +286,7 @@ function removeFormErrors(input, removeStaleAlerts=false){
   }
 
   if (removeStaleAlerts){
-    let staleAlerts = Array.from(document.getElementsByClassName("usa-alert--error"))
+    let staleAlerts = document.querySelectorAll(".usa-alert--error")
     for (let alert of staleAlerts){
       // Don't remove the error associated with the input
       if (alert.id !== `${input.id}--toast`) {

--- a/src/registrar/assets/js/get-gov.js
+++ b/src/registrar/assets/js/get-gov.js
@@ -260,7 +260,6 @@ function handleValidationClick(e) {
  * Removes form errors surrounding a form input
  */
 function removeFormErrors(input){
-  console.log("in the function...")
   // Remove error message
   let errorMessage = document.getElementById(`${input.id}__error-message`);
   if (errorMessage) {

--- a/src/registrar/assets/js/get-gov.js
+++ b/src/registrar/assets/js/get-gov.js
@@ -236,7 +236,7 @@ function handleValidationClick(e) {
     const checkAvailabilityInput = document.getElementById(targetId);
     checkAvailabilityButton.addEventListener('click',
       function() { 
-        removeFormErrors(checkAvailabilityInput)
+        removeFormErrors(checkAvailabilityInput, true);
       }
     );
   }
@@ -248,7 +248,7 @@ function handleValidationClick(e) {
       // Only apply this logic to alternate domains input
       if (domainInput.classList.contains('alternate-domain-input')){
           domainInput.addEventListener('input', function() {
-              removeFormErrors(domainInput);
+              removeFormErrors(domainInput, true);
             }
           );
       }
@@ -259,7 +259,7 @@ function handleValidationClick(e) {
 /**
  * Removes form errors surrounding a form input
  */
-function removeFormErrors(input){
+function removeFormErrors(input, removeStaleAlerts=false){
   // Remove error message
   let errorMessage = document.getElementById(`${input.id}__error-message`);
   if (errorMessage) {
@@ -282,6 +282,16 @@ function removeFormErrors(input){
     let parentDiv = label.parentElement;
     if (parentDiv) {
       parentDiv.classList.remove('usa-form-group--error');
+    }
+  }
+
+  if (removeStaleAlerts){
+    let staleAlerts = document.getElementsByClassName("usa-alert--error")
+    for (let alert of staleAlerts){
+      // Don't remove the error associated with the input
+      if (alert.id !== `${input.id}--toast`) {
+        alert.remove()
+      }
     }
   }
 }

--- a/src/registrar/assets/js/get-gov.js
+++ b/src/registrar/assets/js/get-gov.js
@@ -227,10 +227,69 @@ function handleValidationClick(e) {
   for(const button of activatesValidation) {
     button.addEventListener('click', handleValidationClick);
   }
+
+  
+  // Add event listener to the "Check availability" button
+  const checkAvailabilityButton = document.getElementById('check-availability-button');
+  if (checkAvailabilityButton) {
+    const targetId = checkAvailabilityButton.getAttribute('validate-for');
+    const checkAvailabilityInput = document.getElementById(targetId);
+    checkAvailabilityButton.addEventListener('click',
+      function() { 
+        removeFormErrors(checkAvailabilityInput)
+      }
+    );
+  }
+
+  // Add event listener to the alternate domains input
+  const alternateDomainsInputs = document.querySelectorAll('[auto-validate]');
+  if (alternateDomainsInputs) {
+    for (const domainInput of alternateDomainsInputs){
+      // Only apply this logic to alternate domains input
+      if (domainInput.classList.contains('alternate-domain-input')){
+          domainInput.addEventListener('input', function() {
+              removeFormErrors(domainInput);
+            }
+          );
+      }
+    }
+    }
 })();
 
 /**
- * Delete method for formsets that diff in the view and delete in the model (Nameservers, DS Data)
+ * Removes form errors surrounding a form input
+ */
+function removeFormErrors(input){
+  console.log("in the function...")
+  // Remove error message
+  let errorMessage = document.getElementById(`${input.id}__error-message`);
+  if (errorMessage) {
+    errorMessage.remove();
+    console.log("Error message removed")
+  }else{
+    return
+  }
+
+  // Remove error classes
+  if (input.classList.contains('usa-input--error')) {
+    input.classList.remove('usa-input--error');
+  }
+
+  let label = document.querySelector(`label[for="${input.id}"]`);
+  if (label) {
+    label.classList.remove('usa-label--error');
+
+    // Remove error classes from parent div
+    let parentDiv = label.parentElement;
+    if (parentDiv) {
+      parentDiv.classList.remove('usa-form-group--error');
+    }
+  }
+}
+
+/**
+ * Prepare the namerservers and DS data forms delete buttons
+ * We will call this on the forms init, and also every time we add a form
  * 
  */
 function removeForm(e, formLabel, isNameserversForm, addButton, formIdentifier){

--- a/src/registrar/templates/application_dotgov_domain.html
+++ b/src/registrar/templates/application_dotgov_domain.html
@@ -53,6 +53,7 @@
       {% endwith %}
     {% endwith %}
     <button
+      id="check-availability-button"
       type="button"
       class="usa-button"
       validate-for="{{ forms.0.requested_domain.auto_id }}"
@@ -79,7 +80,7 @@
       {% endwith %}
     {% endwith %}
 
-    <button id="check-availability-button" type="submit" name="submit_button" value="save" class="usa-button usa-button--unstyled">
+    <button type="submit" name="submit_button" value="save" class="usa-button usa-button--unstyled">
       <svg class="usa-icon" aria-hidden="true" focusable="false" role="img" width="24" height="24">
         <use xlink:href="{%static 'img/sprite.svg'%}#add_circle"></use>
       </svg><span class="margin-left-05">Add another alternative</span>

--- a/src/registrar/templates/application_dotgov_domain.html
+++ b/src/registrar/templates/application_dotgov_domain.html
@@ -79,7 +79,7 @@
       {% endwith %}
     {% endwith %}
 
-    <button type="submit" name="submit_button" value="save" class="usa-button usa-button--unstyled">
+    <button id="check-availability-button" type="submit" name="submit_button" value="save" class="usa-button usa-button--unstyled">
       <svg class="usa-icon" aria-hidden="true" focusable="false" role="img" width="24" height="24">
         <use xlink:href="{%static 'img/sprite.svg'%}#add_circle"></use>
       </svg><span class="margin-left-05">Add another alternative</span>


### PR DESCRIPTION
## Ticket

Resolves #1643
<!--Reminder, when a code change is made that is user facing, beyond content updates, then the following are required:
- a developer approves the PR
- a designer approves the PR or checks off all relevant items in this checklist.

All other changes require just a single approving review.-->

## Changes

<!-- What was added, updated, or removed in this PR. -->
- Modifies the `get-gov.js` file to remove stale form level error messages when a text change occurs

<!--
    Please add/remove/edit any of the template below to fit the needs
    of this specific PR.
--->

## Context for reviewers
An edge-case was found where the form error and the fail message could drift out of sync because the form error only gets updated when the form is submitted, vs the check availability button (and api call) which update on a user event.

This PR simply removes stale form errors that are no longer in sync with the new content changes.
<!--Background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers.  -->

## Setup
1. Start a new domain request, and go to dotgov_domain
2. Enter an invalid value, like "-", for domain and alternate domain. Click the check availability button for good measure
3. Click "Save and continue"
4. Enter a dot for domain and alternate domain. Click the check availability button. As you do so, the form errors should disappear, but the error message should be retained
5. Try to save again. The form should return a valid error
<!--  Add any steps or code to run in this section to help others run your code.
    
    Example 1:
    ```sh
    echo "Code goes here"
    ``` 
    
    Example 2: If the PR was to add a new link with a redirect, this section could simply be:
    -go to /path/to/start/page
    -click the blue link in the <insert location>
    -notice user is redirected to <proper end location>
-->

## Code Review Verification Steps

### As the original developer, I have

#### Satisfied acceptance criteria and met development standards

- [ ] Met the acceptance criteria, or will meet them in a subsequent PR
- [ ] Created/modified automated tests
- [ ] Added at least 2 developers as PR reviewers (only 1 will need to approve)
- [ ] Messaged on Slack or in standup to notify the team that a PR is ready for review
- [ ] Changes to “how we do things” are documented in READMEs and or onboarding guide
- [ ] If any model was updated to modify/add/delete columns, makemigrations was ran and the assoicated migrations file has been commited.

#### Ensured code standards are met (Original Developer)

- [ ] All new functions and methods are commented using plain language
- [ ] Did dependency updates in Pipfile also get changed in requirements.txt?
- [ ] Interactions with external systems are wrapped in try/except
- [ ] Error handling exists for unusual or missing values

#### Validated user-facing changes (if applicable)

- [ ] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Checked keyboard navigability
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)
- [ ] Add at least 1 designer as PR reviewer

### As a code reviewer, I have

#### Reviewed, tested, and left feedback about the changes

- [ ] Pulled this branch locally and tested it
- [ ] Reviewed this code and left comments
- [ ] Checked that all code is adequately covered by tests
- [ ] Made it clear which comments need to be addressed before this work is merged
- [ ] If any model was updated to modify/add/delete columns, makemigrations was ran and the assoicated migrations file has been commited.

#### Ensured code standards are met (Code reviewer)

- [ ] All new functions and methods are commented using plain language
- [ ] Interactions with external systems are wrapped in try/except
- [ ] Error handling exists for unusual or missing values
- [ ] (Rarely needed) Did dependency updates in Pipfile also get changed in requirements.txt?

#### Validated user-facing changes as a developer

- [ ] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Checked keyboard navigability
- [ ] Meets all designs and user flows provided by design/product
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)

- [ ] Tested with multiple browsers, the suggestion is to use ones that the developer didn't (check off which ones were used)
  - [ ] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari

- [ ] (Rarely needed) Tested as both an analyst and applicant user

**Note:** Multiple code reviewers can share the checklists above, a second reviewers should not make a duplicate checklist

### As a designer reviewer, I have

#### Verified that the changes match the design intention

- [ ] Checked that the design translated visually
- [ ] Checked behavior
- [ ] Checked different states (empty, one, some, error)
- [ ] Checked for landmarks, page heading structure, and links
- [ ] Tried to break the intended flow

#### Validated user-facing changes as a designer

- [ ] Checked keyboard navigability
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)

- [ ] Tested with multiple browsers (check off which ones were used)
  - [ ] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari

- [ ] (Rarely needed) Tested as both an analyst and applicant user

## Screenshots

<!-- If this PR makes visible interface changes, an image of the finished interface can help reviewers
and casual observers understand the context of the changes.
A before image is optional and can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow.
You may want to use [GIPHY Capture](https://giphy.com/apps/giphycapture) for this! 📸

_Please frame images to show useful context but also highlight the affected regions._
--->
