### PR TITLE
Make "domain" singular in references to .gov operating requirements

### DIFF
--- a/src/registrar/admin.py
+++ b/src/registrar/admin.py
@@ -610,7 +610,7 @@ class DomainInformationAdmin(ListHeaderAdmin):
         ),
         ("Anything else?", {"fields": ["anything_else"]}),
         (
-            "Requirements for operating .gov domains",
+            "Requirements for operating a .gov domain",
             {"fields": ["is_policy_acknowledged"]},
         ),
     ]
@@ -779,7 +779,7 @@ class DomainApplicationAdmin(ListHeaderAdmin):
         ),
         ("Anything else?", {"fields": ["anything_else"]}),
         (
-            "Requirements for operating .gov domains",
+            "Requirements for operating a .gov domain",
             {"fields": ["is_policy_acknowledged"]},
         ),
     ]

--- a/src/registrar/forms/application_wizard.py
+++ b/src/registrar/forms/application_wizard.py
@@ -837,8 +837,8 @@ class AnythingElseForm(RegistrarForm):
 
 class RequirementsForm(RegistrarForm):
     is_policy_acknowledged = forms.BooleanField(
-        label="I read and agree to the requirements for operating .gov domains.",
+        label="I read and agree to the requirements for operating a .gov domain.",
         error_messages={
-            "required": ("Check the box if you read and agree to the requirements for operating .gov domains.")
+            "required": ("Check the box if you read and agree to the requirements for operating a .gov domain.")
         },
     )

--- a/src/registrar/templates/application_form.html
+++ b/src/registrar/templates/application_form.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 {% load static form_helpers url_helpers %}
 
-{% block title %}Apply for a .gov domain | {{form_titles|get_item:steps.current}} | {% endblock %}
+{% block title %}Request a .gov domain | {{form_titles|get_item:steps.current}} | {% endblock %}
 {% block content %}
 <div class="grid-container">
   <div class="grid-row grid-gap">

--- a/src/registrar/templates/application_requirements.html
+++ b/src/registrar/templates/application_requirements.html
@@ -2,7 +2,7 @@
 {% load field_helpers %}
 
 {% block form_instructions %}
-  <p>Please read this page. Check the box at the bottom to show that you agree to the requirements for operating .gov domains.</p>
+  <p>Please read this page. Check the box at the bottom to show that you agree to the requirements for operating a .gov domain.</p>
 <p>The .gov domain space exists to support a broad diversity of government missions. Generally, we don’t review or audit how government organizations use their registered domains. However, misuse of a .gov domain can reflect upon the integrity of the entire .gov space. There are categories of misuse that are statutorily prohibited or abusive in nature.</p>
 
 

--- a/src/registrar/templates/django/forms/label.html
+++ b/src/registrar/templates/django/forms/label.html
@@ -10,7 +10,7 @@
 
   {% if widget.attrs.required %}
   <!--Don't add asterisk to one-field forms -->
-    {% if field.label == "Is your organization an election office?" or field.label == "What .gov domain do you want?" or field.label == "I read and agree to the requirements for operating .gov domains." or field.label == "Please explain why there are no other employees from your organization we can contact to help us assess your eligibility for a .gov domain." %}
+    {% if field.label == "Is your organization an election office?" or field.label == "What .gov domain do you want?" or field.label == "I read and agree to the requirements for operating a .gov domain." or field.label == "Please explain why there are no other employees from your organization we can contact to help us assess your eligibility for a .gov domain." %}
     {% else %}
       <abbr class="usa-hint usa-hint--required" title="required">*</abbr>
     {% endif %}

--- a/src/registrar/tests/test_forms.py
+++ b/src/registrar/tests/test_forms.py
@@ -338,7 +338,7 @@ class TestFormValidation(MockEppLib):
         form = RequirementsForm(data={})
         self.assertEqual(
             form.errors["is_policy_acknowledged"],
-            ["Check the box if you read and agree to the requirements for operating .gov domains."],
+            ["Check the box if you read and agree to the requirements for operating a .gov domain."],
         )
 
     def test_requirements_form_unchecked(self):
@@ -346,7 +346,7 @@ class TestFormValidation(MockEppLib):
         form = RequirementsForm(data={"is_policy_acknowledged": False})
         self.assertEqual(
             form.errors["is_policy_acknowledged"],
-            ["Check the box if you read and agree to the requirements for operating .gov domains."],
+            ["Check the box if you read and agree to the requirements for operating a .gov domain."],
         )
 
     def test_tribal_government_unrecognized(self):

--- a/src/registrar/views/application.py
+++ b/src/registrar/views/application.py
@@ -89,7 +89,7 @@ class ApplicationWizard(ApplicationWizardPermissionView, TemplateView):
         Step.YOUR_CONTACT: _("Your contact information"),
         Step.OTHER_CONTACTS: _("Other employees from your organization"),
         Step.ANYTHING_ELSE: _("Anything else?"),
-        Step.REQUIREMENTS: _("Requirements for operating .gov domains"),
+        Step.REQUIREMENTS: _("Requirements for operating a .gov domain"),
         Step.REVIEW: _("Review and submit your domain request"),
     }
 


### PR DESCRIPTION
## Changes

<!-- What was added, updated, or removed in this PR. -->
- Make "domain" singular in references to .gov operating requirements. This aligns with the recent changes made to the beta site https://beta.get.gov/domains/requirements/. 

### As a designer reviewer, I have

#### Verified that the changes match the design intention

- [ ] Checked that the design translated visually
- [ ] Checked behavior
- [ ] Checked different states (empty, one, some, error)
- [ ] Checked for landmarks, page heading structure, and links
- [ ] Tried to break the intended flow

#### Validated user-facing changes as a designer

- [ ] Checked keyboard navigability
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)

- [ ] Tested with multiple browsers (check off which ones were used)
  - [ ] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari
