### PR TITLE
ON HOLD - Issue 1489: Reduce email sends to first-time transition for the applicable transitions

### DIFF
--- a/src/registrar/models/domain_application.py
+++ b/src/registrar/models/domain_application.py
@@ -578,7 +578,8 @@ class DomainApplication(TimeStampedModel):
                 changes_dict = json.loads(entry.changes)
                 # changes_dict will look like {'status': ['withdrawn', 'submitted']},
                 # henceforth the len(changes_dict.get('status', [])) == 2
-                if len(changes_dict.get("status", [])) == 2 and changes_dict.get("status", [])[1] == status:
+                status_change = changes_dict.get("status", [])
+                if len(status_change) == 2 and status_change[1] == status:
                     return True
             except JSONDecodeError:
                 logger.warning(
@@ -656,7 +657,7 @@ class DomainApplication(TimeStampedModel):
         self.save()
 
         # Limit email notifications for this transition to the first time the request transitions to this status
-        if not self.has_previously_had_a_status_of("submitted"):
+        if not self.has_previously_had_a_status_of(DomainApplication.ApplicationStatus.SUBMITTED):
             self._send_status_update_email(
                 "submission confirmation",
                 "emails/submission_confirmation.txt",
@@ -738,7 +739,7 @@ class DomainApplication(TimeStampedModel):
         )
 
         # Limit email notifications for this transition to the first time the request transitions to this status
-        if not self.has_previously_had_a_status_of("approved"):
+        if not self.has_previously_had_a_status_of(DomainApplication.ApplicationStatus.APPROVED):
             self._send_status_update_email(
                 "application approved",
                 "emails/status_change_approved.txt",
@@ -755,7 +756,7 @@ class DomainApplication(TimeStampedModel):
         """Withdraw an application that has been submitted."""
 
         # Limit email notifications for this transition to the first time the request transitions to this status
-        if not self.has_previously_had_a_status_of("withdrawn"):
+        if not self.has_previously_had_a_status_of(DomainApplication.ApplicationStatus.WITHDRAWN):
             self._send_status_update_email(
                 "withdraw",
                 "emails/domain_request_withdrawn.txt",
@@ -787,7 +788,7 @@ class DomainApplication(TimeStampedModel):
                 logger.error("Can't query an approved domain while attempting a DA reject()")
 
         # Limit email notifications for this transition to the first time the request transitions to this status
-        if not self.has_previously_had_a_status_of("rejected"):
+        if not self.has_previously_had_a_status_of(DomainApplication.ApplicationStatus.REJECTED):
             self._send_status_update_email(
                 "action needed",
                 "emails/status_change_rejected.txt",

--- a/src/registrar/models/domain_application.py
+++ b/src/registrar/models/domain_application.py
@@ -576,14 +576,14 @@ class DomainApplication(TimeStampedModel):
         for entry in log_entries:
             try:
                 changes_dict = json.loads(entry.changes)
-                logger.info(changes_dict)
                 # changes_dict will look like {'status': ['withdrawn', 'submitted']},
                 # henceforth the len(changes_dict.get('status', [])) == 2
                 if len(changes_dict.get("status", [])) == 2 and changes_dict.get("status", [])[1] == status:
-                    logger.info(f"found one instance where it had a status of {status}")
                     return True
             except JSONDecodeError:
-                pass
+                logger.warning(
+                    "JSON decode error while parsing logs for domain requests in has_previously_had_a_status_of"
+                )
 
         return False
 

--- a/src/registrar/tests/test_models.py
+++ b/src/registrar/tests/test_models.py
@@ -1,6 +1,6 @@
 from django.test import TestCase
 from django.db.utils import IntegrityError
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from registrar.models import (
     Contact,
@@ -154,17 +154,34 @@ class TestDomainApplication(TestCase):
                 application.submit()
         self.assertEqual(application.status, application.ApplicationStatus.SUBMITTED)
 
+    @patch("auditlog.models.LogEntry.objects.get_for_object")
+    def test_has_previously_had_a_status_of_returns_true(self, mock_get_for_object):
+        """Set up mock LogEntry.objects.get_for_object to return a log entry with the desired status"""
+
+        log_entry_with_status = MagicMock(changes='{"status": ["previous_status", "desired_status"]}')
+        mock_get_for_object.return_value = [log_entry_with_status]
+
+        result = self.started_application.has_previously_had_a_status_of("desired_status")
+
+        self.assertTrue(result)
+
+    @patch("auditlog.models.LogEntry.objects.get_for_object")
+    def test_has_previously_had_a_status_of_returns_false(self, mock_get_for_object):
+        """Set up mock LogEntry.objects.get_for_object to return a log entry
+        with a different status than the desired status"""
+
+        log_entry_with_status = MagicMock(changes='{"status": ["previous_status", "different_status"]}')
+        mock_get_for_object.return_value = [log_entry_with_status]
+
+        result = self.started_application.has_previously_had_a_status_of("desired_status")
+
+        self.assertFalse(result)
+
     def test_submit_sends_email(self):
         """Create an application and submit it and see if email was sent."""
-        user, _ = User.objects.get_or_create(username="testy")
-        contact = Contact.objects.create(email="test@test.gov")
-        domain, _ = DraftDomain.objects.get_or_create(name="igorville.gov")
-        application = DomainApplication.objects.create(
-            creator=user,
-            requested_domain=domain,
-            submitter=contact,
-        )
-        application.save()
+
+        # submitter's email is mayor@igorville.gov
+        application = completed_application()
 
         with boto3_mocking.clients.handler_for("sesv2", self.mock_client):
             with less_console_noise():
@@ -176,7 +193,185 @@ class TestDomainApplication(TestCase):
                 [
                     email
                     for email in MockSESClient.EMAILS_SENT
-                    if "test@test.gov" in email["kwargs"]["Destination"]["ToAddresses"]
+                    if "mayor@igorville.gov" in email["kwargs"]["Destination"]["ToAddresses"]
+                ]
+            ),
+            0,
+        )
+
+    @patch("auditlog.models.LogEntry.objects.get_for_object")
+    def test_submit_does_not_send_email_if_submitted_previously(self, mock_get_for_object):
+        """Create an application, make it so it was submitted previously, submit it,
+        and see that an email was not sent."""
+
+        # submitter's email is mayor@igorville.gov
+        application = completed_application()
+
+        # Mock the logs
+        log_entry_with_status = MagicMock(changes='{"status": ["started", "submitted"]}')
+        mock_get_for_object.return_value = [log_entry_with_status]
+
+        with boto3_mocking.clients.handler_for("sesv2", self.mock_client):
+            with less_console_noise():
+                application.submit()
+
+        # check to see if an email was sent
+        self.assertEqual(
+            len(
+                [
+                    email
+                    for email in MockSESClient.EMAILS_SENT
+                    if "mayor@igorville.gov" in email["kwargs"]["Destination"]["ToAddresses"]
+                ]
+            ),
+            0,
+        )
+
+    def test_approve_sends_email(self):
+        """Create an application and approve it and see if email was sent."""
+
+        # submitter's email is mayor@igorville.gov
+        application = completed_application(status=DomainApplication.ApplicationStatus.IN_REVIEW)
+
+        with boto3_mocking.clients.handler_for("sesv2", self.mock_client):
+            with less_console_noise():
+                application.approve()
+
+        # check to see if an email was sent
+        self.assertGreater(
+            len(
+                [
+                    email
+                    for email in MockSESClient.EMAILS_SENT
+                    if "mayor@igorville.gov" in email["kwargs"]["Destination"]["ToAddresses"]
+                ]
+            ),
+            0,
+        )
+
+    @patch("auditlog.models.LogEntry.objects.get_for_object")
+    def test_approve_does_not_send_email_if_approved_previously(self, mock_get_for_object):
+        """Create an application, make it so it was approved previously, approve it,
+        and see that an email was not sent."""
+
+        # submitter's email is mayor@igorville.gov
+        application = completed_application(status=DomainApplication.ApplicationStatus.IN_REVIEW)
+
+        # Mock the logs
+        log_entry_with_status = MagicMock(changes='{"status": ["submitted", "approved"]}')
+        mock_get_for_object.return_value = [log_entry_with_status]
+
+        with boto3_mocking.clients.handler_for("sesv2", self.mock_client):
+            with less_console_noise():
+                application.approve()
+
+        # check to see if an email was sent
+        self.assertEqual(
+            len(
+                [
+                    email
+                    for email in MockSESClient.EMAILS_SENT
+                    if "mayor@igorville.gov" in email["kwargs"]["Destination"]["ToAddresses"]
+                ]
+            ),
+            0,
+        )
+
+    def test_withdraw_sends_email(self):
+        """Create an application and withdraw it and see if email was sent."""
+
+        # submitter's email is mayor@igorville.gov
+        application = completed_application(status=DomainApplication.ApplicationStatus.IN_REVIEW)
+
+        with boto3_mocking.clients.handler_for("sesv2", self.mock_client):
+            with less_console_noise():
+                application.withdraw()
+
+        # check to see if an email was sent
+        self.assertGreater(
+            len(
+                [
+                    email
+                    for email in MockSESClient.EMAILS_SENT
+                    if "mayor@igorville.gov" in email["kwargs"]["Destination"]["ToAddresses"]
+                ]
+            ),
+            0,
+        )
+
+    @patch("auditlog.models.LogEntry.objects.get_for_object")
+    def test_withdraw_does_not_send_email_if_withdrawn_previously(self, mock_get_for_object):
+        """Create an application, make it so it was withdrawn previously, withdraw it,
+        and see that an email was not sent."""
+
+        # submitter's email is mayor@igorville.gov
+        application = completed_application(status=DomainApplication.ApplicationStatus.IN_REVIEW)
+
+        # Mock the logs
+        log_entry_with_status = MagicMock(changes='{"status": ["submitted", "withdrawn"]}')
+        mock_get_for_object.return_value = [log_entry_with_status]
+
+        with boto3_mocking.clients.handler_for("sesv2", self.mock_client):
+            with less_console_noise():
+                application.withdraw()
+
+        # check to see if an email was sent
+        self.assertEqual(
+            len(
+                [
+                    email
+                    for email in MockSESClient.EMAILS_SENT
+                    if "mayor@igorville.gov" in email["kwargs"]["Destination"]["ToAddresses"]
+                ]
+            ),
+            0,
+        )
+
+    def test_reject_sends_email(self):
+        """Create an application and reject it and see if email was sent."""
+
+        # submitter's email is mayor@igorville.gov
+        application = completed_application(status=DomainApplication.ApplicationStatus.APPROVED)
+
+        with boto3_mocking.clients.handler_for("sesv2", self.mock_client):
+            with less_console_noise():
+                application.reject()
+
+        # check to see if an email was sent
+        self.assertGreater(
+            len(
+                [
+                    email
+                    for email in MockSESClient.EMAILS_SENT
+                    if "mayor@igorville.gov" in email["kwargs"]["Destination"]["ToAddresses"]
+                ]
+            ),
+            0,
+        )
+
+    @patch("auditlog.models.LogEntry.objects.get_for_object")
+    def test_reject_does_not_send_email_if_rejected_previously(self, mock_get_for_object):
+        """Create an application, make it so it was rejected previously, reject it,
+        and see that an email was not sent."""
+
+        # submitter's email is mayor@igorville.gov
+        application = completed_application(status=DomainApplication.ApplicationStatus.APPROVED)
+
+        # Mock the logs
+        log_entry_with_status = MagicMock(changes='{"status": ["submitted", "rejected"]}')
+        mock_get_for_object.return_value = [log_entry_with_status]
+
+        with boto3_mocking.clients.handler_for("sesv2", self.mock_client):
+            with less_console_noise():
+                application.reject()
+
+        # check to see if an email was sent
+        self.assertEqual(
+            len(
+                [
+                    email
+                    for email in MockSESClient.EMAILS_SENT
+                    if "mayor@igorville.gov" in email["kwargs"]["Destination"]["ToAddresses"]
                 ]
             ),
             0,


### PR DESCRIPTION
…tions

## Ticket

Resolves #1489 
<!--Reminder, when a code change is made that is user facing, beyond content updates, then the following are required:
- a developer approves the PR
- a designer approves the PR or checks off all relevant items in this checklist.

All other changes require just a single approving review.-->

## Changes

<!-- What was added, updated, or removed in this PR. -->
- Query the logs to determine whether a request has ever been in a given previous state
- For the applicable FSM transitions, skip the email send if the above condition is true
- Unit tests on models and from the DjA perspective (different approaches that test the same thing)

<!--
    Please add/remove/edit any of the template below to fit the needs
    of this specific PR.
--->

## Context for reviewers

<!--Background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers.  -->

The model tests can be streamlined. I might revisit tomorrow.

## Setup

<!--  Add any steps or code to run in this section to help others run your code.
    
    Example 1:
    ```sh
    echo "Code goes here"
    ``` 
    
    Example 2: If the PR was to add a new link with a redirect, this section could simply be:
    -go to /path/to/start/page
    -click the blue link in the <insert location>
    -notice user is redirected to <proper end location>
-->

Create an application and go to town transitioning back an forth through the allowable transitions. You should only get the submitted, approved, withdrawn and rejected emails ONCE each, on first time transitioning to those states.

## Code Review Verification Steps

### As the original developer, I have

#### Satisfied acceptance criteria and met development standards

- [x] Met the acceptance criteria, or will meet them in a subsequent PR
- [x] Created/modified automated tests
- [x] Added at least 2 developers as PR reviewers (only 1 will need to approve)
- [x] Messaged on Slack or in standup to notify the team that a PR is ready for review
- [ ] Changes to “how we do things” are documented in READMEs and or onboarding guide
- [ ] If any model was updated to modify/add/delete columns, makemigrations was ran and the assoicated migrations file has been commited.

#### Ensured code standards are met (Original Developer)

- [x] All new functions and methods are commented using plain language
- [ ] Did dependency updates in Pipfile also get changed in requirements.txt?
- [x] Interactions with external systems are wrapped in try/except
- [x] Error handling exists for unusual or missing values

#### Validated user-facing changes (if applicable)

- [ ] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Checked keyboard navigability
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)
- [ ] Add at least 1 designer as PR reviewer

### As a code reviewer, I have

#### Reviewed, tested, and left feedback about the changes

- [ ] Pulled this branch locally and tested it
- [ ] Reviewed this code and left comments
- [ ] Checked that all code is adequately covered by tests
- [ ] Made it clear which comments need to be addressed before this work is merged
- [ ] If any model was updated to modify/add/delete columns, makemigrations was ran and the assoicated migrations file has been commited.

#### Ensured code standards are met (Code reviewer)

- [ ] All new functions and methods are commented using plain language
- [ ] Interactions with external systems are wrapped in try/except
- [ ] Error handling exists for unusual or missing values
- [ ] (Rarely needed) Did dependency updates in Pipfile also get changed in requirements.txt?

#### Validated user-facing changes as a developer

- [ ] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Checked keyboard navigability
- [ ] Meets all designs and user flows provided by design/product
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)

- [ ] Tested with multiple browsers, the suggestion is to use ones that the developer didn't (check off which ones were used)
  - [ ] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari

- [ ] (Rarely needed) Tested as both an analyst and applicant user

**Note:** Multiple code reviewers can share the checklists above, a second reviewers should not make a duplicate checklist

### As a designer reviewer, I have

#### Verified that the changes match the design intention

- [ ] Checked that the design translated visually
- [ ] Checked behavior
- [ ] Checked different states (empty, one, some, error)
- [ ] Checked for landmarks, page heading structure, and links
- [ ] Tried to break the intended flow

#### Validated user-facing changes as a designer

- [ ] Checked keyboard navigability
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)

- [ ] Tested with multiple browsers (check off which ones were used)
  - [ ] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari

- [ ] (Rarely needed) Tested as both an analyst and applicant user

## Screenshots

<!-- If this PR makes visible interface changes, an image of the finished interface can help reviewers
and casual observers understand the context of the changes.
A before image is optional and can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow.
You may want to use [GIPHY Capture](https://giphy.com/apps/giphycapture) for this! 📸

_Please frame images to show useful context but also highlight the affected regions._
--->
