### PR TITLE
Issue 1674: Add FSM rules for the new transitions from approv

### DIFF
--- a/src/registrar/admin.py
+++ b/src/registrar/admin.py
@@ -882,14 +882,11 @@ class DomainApplicationAdmin(ListHeaderAdmin):
                 if (
                     obj
                     and original_obj.status == models.DomainApplication.ApplicationStatus.APPROVED
-                    and (
-                        obj.status == models.DomainApplication.ApplicationStatus.REJECTED
-                        or obj.status == models.DomainApplication.ApplicationStatus.INELIGIBLE
-                    )
+                    and obj.status != models.DomainApplication.ApplicationStatus.APPROVED
                     and not obj.domain_is_not_active()
                 ):
                     # If an admin tried to set an approved application to
-                    # rejected or ineligible and the related domain is already
+                    # another status and the related domain is already
                     # active, shortcut the action and throw a friendly
                     # error message. This action would still not go through
                     # shortcut or not as the rules are duplicated on the model,

--- a/src/registrar/tests/test_admin.py
+++ b/src/registrar/tests/test_admin.py
@@ -707,41 +707,13 @@ class TestDomainApplicationAdmin(MockEppLib):
                 "Cannot edit an application with a restricted creator.",
             )
 
-    @boto3_mocking.patching
-    def test_error_when_saving_approved_to_rejected_and_domain_is_active(self):
-        # Create an instance of the model
-        application = completed_application(status=DomainApplication.ApplicationStatus.APPROVED)
-        domain = Domain.objects.create(name=application.requested_domain.name)
-        application.approved_domain = domain
-        application.save()
+    def trigger_saving_approved_to_another_state(self, domain_is_active, another_state):
+        """Helper method that triggers domain request state changes from approved to another state,
+        with an associated domain that can be either active (READY) or not.
 
-        # Create a request object with a superuser
-        request = self.factory.post("/admin/registrar/domainapplication/{}/change/".format(application.pk))
-        request.user = self.superuser
+        Used to test errors when saving a change with an active domain, also used to test side effects
+        when saving a change goes through."""
 
-        # Define a custom implementation for is_active
-        def custom_is_active(self):
-            return True  # Override to return True
-
-        # Use ExitStack to combine patch contexts
-        with ExitStack() as stack:
-            # Patch Domain.is_active and django.contrib.messages.error simultaneously
-            stack.enter_context(patch.object(Domain, "is_active", custom_is_active))
-            stack.enter_context(patch.object(messages, "error"))
-
-            with boto3_mocking.clients.handler_for("sesv2", self.mock_client):
-                with less_console_noise():
-                    # Simulate saving the model
-                    application.status = DomainApplication.ApplicationStatus.REJECTED
-                    self.admin.save_model(request, application, None, True)
-
-            # Assert that the error message was called with the correct argument
-            messages.error.assert_called_once_with(
-                request,
-                "This action is not permitted. The domain " + "is already active.",
-            )
-
-    def test_side_effects_when_saving_approved_to_rejected(self):
         # Create an instance of the model
         application = completed_application(status=DomainApplication.ApplicationStatus.APPROVED)
         domain = Domain.objects.create(name=application.requested_domain.name)
@@ -755,101 +727,60 @@ class TestDomainApplicationAdmin(MockEppLib):
 
         # Define a custom implementation for is_active
         def custom_is_active(self):
-            return False  # Override to return False
+            return domain_is_active  # Override to return True
 
         # Use ExitStack to combine patch contexts
         with ExitStack() as stack:
             # Patch Domain.is_active and django.contrib.messages.error simultaneously
             stack.enter_context(patch.object(Domain, "is_active", custom_is_active))
             stack.enter_context(patch.object(messages, "error"))
-            with boto3_mocking.clients.handler_for("sesv2", self.mock_client):
-                with less_console_noise():
-                    # Simulate saving the model
-                    application.status = DomainApplication.ApplicationStatus.REJECTED
-                    self.admin.save_model(request, application, None, True)
 
-            # Assert that the error message was never called
-            messages.error.assert_not_called()
+            application.status = another_state
+            self.admin.save_model(request, application, None, True)
 
-        self.assertEqual(application.approved_domain, None)
+            # Assert that the error message was called with the correct argument
+            if domain_is_active:
+                messages.error.assert_called_once_with(
+                    request,
+                    "This action is not permitted. The domain " + "is already active.",
+                )
+            else:
+                # Assert that the error message was never called
+                messages.error.assert_not_called()
 
-        # Assert that Domain got Deleted
-        with self.assertRaises(Domain.DoesNotExist):
-            domain.refresh_from_db()
+                self.assertEqual(application.approved_domain, None)
 
-        # Assert that DomainInformation got Deleted
-        with self.assertRaises(DomainInformation.DoesNotExist):
-            domain_information.refresh_from_db()
+                # Assert that Domain got Deleted
+                with self.assertRaises(Domain.DoesNotExist):
+                    domain.refresh_from_db()
+
+                # Assert that DomainInformation got Deleted
+                with self.assertRaises(DomainInformation.DoesNotExist):
+                    domain_information.refresh_from_db()
+
+    def test_error_when_saving_approved_to_in_review_and_domain_is_active(self):
+        self.trigger_saving_approved_to_another_state(True, DomainApplication.ApplicationStatus.IN_REVIEW)
+
+    def test_error_when_saving_approved_to_action_needed_and_domain_is_active(self):
+        self.trigger_saving_approved_to_another_state(True, DomainApplication.ApplicationStatus.ACTION_NEEDED)
+
+    def test_error_when_saving_approved_to_rejected_and_domain_is_active(self):
+        self.trigger_saving_approved_to_another_state(True, DomainApplication.ApplicationStatus.REJECTED)
 
     def test_error_when_saving_approved_to_ineligible_and_domain_is_active(self):
-        # Create an instance of the model
-        application = completed_application(status=DomainApplication.ApplicationStatus.APPROVED)
-        domain = Domain.objects.create(name=application.requested_domain.name)
-        application.approved_domain = domain
-        application.save()
+        self.trigger_saving_approved_to_another_state(True, DomainApplication.ApplicationStatus.INELIGIBLE)
 
-        # Create a request object with a superuser
-        request = self.factory.post("/admin/registrar/domainapplication/{}/change/".format(application.pk))
-        request.user = self.superuser
+    def test_side_effects_when_saving_approved_to_in_review(self):
+        self.trigger_saving_approved_to_another_state(False, DomainApplication.ApplicationStatus.IN_REVIEW)
 
-        # Define a custom implementation for is_active
-        def custom_is_active(self):
-            return True  # Override to return True
+    def test_side_effects_when_saving_approved_to_action_needed(self):
+        self.trigger_saving_approved_to_another_state(False, DomainApplication.ApplicationStatus.ACTION_NEEDED)
 
-        # Use ExitStack to combine patch contexts
-        with ExitStack() as stack:
-            # Patch Domain.is_active and django.contrib.messages.error simultaneously
-            stack.enter_context(patch.object(Domain, "is_active", custom_is_active))
-            stack.enter_context(patch.object(messages, "error"))
-
-            # Simulate saving the model
-            application.status = DomainApplication.ApplicationStatus.INELIGIBLE
-            self.admin.save_model(request, application, None, True)
-
-            # Assert that the error message was called with the correct argument
-            messages.error.assert_called_once_with(
-                request,
-                "This action is not permitted. The domain " + "is already active.",
-            )
+    def test_side_effects_when_saving_approved_to_rejected(self):
+        self.trigger_saving_approved_to_another_state(False, DomainApplication.ApplicationStatus.REJECTED)
 
     def test_side_effects_when_saving_approved_to_ineligible(self):
-        # Create an instance of the model
-        application = completed_application(status=DomainApplication.ApplicationStatus.APPROVED)
-        domain = Domain.objects.create(name=application.requested_domain.name)
-        domain_information = DomainInformation.objects.create(creator=self.superuser, domain=domain)
-        application.approved_domain = domain
-        application.save()
-
-        # Create a request object with a superuser
-        request = self.factory.post("/admin/registrar/domainapplication/{}/change/".format(application.pk))
-        request.user = self.superuser
-
-        # Define a custom implementation for is_active
-        def custom_is_active(self):
-            return False  # Override to return False
-
-        # Use ExitStack to combine patch contexts
-        with ExitStack() as stack:
-            # Patch Domain.is_active and django.contrib.messages.error simultaneously
-            stack.enter_context(patch.object(Domain, "is_active", custom_is_active))
-            stack.enter_context(patch.object(messages, "error"))
-
-            # Simulate saving the model
-            application.status = DomainApplication.ApplicationStatus.INELIGIBLE
-            self.admin.save_model(request, application, None, True)
-
-            # Assert that the error message was never called
-            messages.error.assert_not_called()
-
-        self.assertEqual(application.approved_domain, None)
-
-        # Assert that Domain got Deleted
-        with self.assertRaises(Domain.DoesNotExist):
-            domain.refresh_from_db()
-
-        # Assert that DomainInformation got Deleted
-        with self.assertRaises(DomainInformation.DoesNotExist):
-            domain_information.refresh_from_db()
+        self.trigger_saving_approved_to_another_state(False, DomainApplication.ApplicationStatus.INELIGIBLE)
 
     def test_has_correct_filters(self):
         """


### PR DESCRIPTION
## Ticket

Resolves #1674 
<!--Reminder, when a code change is made that is user facing, beyond content updates, then the following are required:
- a developer approves the PR
- a designer approves the PR or checks off all relevant items in this checklist.

All other changes require just a single approving review.-->

## Changes

<!-- What was added, updated, or removed in this PR. -->
- New rules for approved -> in-review and approved -> action_needed transitions: domain must not be ready
- On successful transitions, delete the non-ready domain and the DI
- Error handling in DjA to shortcut a yellow error screen - NOTE: this is a 3rd redundancy. The code that makes sure only allowable FSM transitions show up in the dropdown will already hide the in_review, action_needed, reject, reject_with_prejudice options. We probably need a notification under the select input to let the analysts know that an active domain is present and is blocking transitions @cisagov/gov-designers 
- Tests in test_admin and tests_models

<!--
    Please add/remove/edit any of the template below to fit the needs
    of this specific PR.
--->

## Context for reviewers

<!--Background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers.  -->

## Setup

<!--  Add any steps or code to run in this section to help others run your code.
    
    Example 1:
    ```sh
    echo "Code goes here"
    ``` 
    
    Example 2: If the PR was to add a new link with a redirect, this section could simply be:
    -go to /path/to/start/page
    -click the blue link in the <insert location>
    -notice user is redirected to <proper end location>
-->

In DjA, change an application to approved. Change it back to in_review, check that the domain and domain information have been deleted. Check that you can change it back to approved.

In DjA, change an application to approved. Change it to action_needed, check that the domain and domain information have been deleted. Check that you can change it back to approved.

In DjA, change an application to approved. Change the domain to READY (add nameservers). Check that you can't change the request back to in_review or action_needed (or rejected or denied)

## Code Review Verification Steps

### As the original developer, I have

#### Satisfied acceptance criteria and met development standards

- [x] Met the acceptance criteria, or will meet them in a subsequent PR
- [x] Created/modified automated tests
- [x] Added at least 2 developers as PR reviewers (only 1 will need to approve)
- [x] Messaged on Slack or in standup to notify the team that a PR is ready for review
- [ ] Changes to “how we do things” are documented in READMEs and or onboarding guide
- [ ] If any model was updated to modify/add/delete columns, makemigrations was ran and the assoicated migrations file has been commited.

#### Ensured code standards are met (Original Developer)

- [x] All new functions and methods are commented using plain language
- [ ] Did dependency updates in Pipfile also get changed in requirements.txt?
- [x] Interactions with external systems are wrapped in try/except
- [x] Error handling exists for unusual or missing values

#### Validated user-facing changes (if applicable)

- [ ] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Checked keyboard navigability
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)
- [ ] Add at least 1 designer as PR reviewer

### As a code reviewer, I have

#### Reviewed, tested, and left feedback about the changes

- [ ] Pulled this branch locally and tested it
- [ ] Reviewed this code and left comments
- [ ] Checked that all code is adequately covered by tests
- [ ] Made it clear which comments need to be addressed before this work is merged
- [ ] If any model was updated to modify/add/delete columns, makemigrations was ran and the assoicated migrations file has been commited.

#### Ensured code standards are met (Code reviewer)

- [ ] All new functions and methods are commented using plain language
- [ ] Interactions with external systems are wrapped in try/except
- [ ] Error handling exists for unusual or missing values
- [ ] (Rarely needed) Did dependency updates in Pipfile also get changed in requirements.txt?

#### Validated user-facing changes as a developer

- [ ] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Checked keyboard navigability
- [ ] Meets all designs and user flows provided by design/product
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)

- [ ] Tested with multiple browsers, the suggestion is to use ones that the developer didn't (check off which ones were used)
  - [ ] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari

- [ ] (Rarely needed) Tested as both an analyst and applicant user

**Note:** Multiple code reviewers can share the checklists above, a second reviewers should not make a duplicate checklist

### As a designer reviewer, I have

#### Verified that the changes match the design intention

- [ ] Checked that the design translated visually
- [ ] Checked behavior
- [ ] Checked different states (empty, one, some, error)
- [ ] Checked for landmarks, page heading structure, and links
- [ ] Tried to break the intended flow

#### Validated user-facing changes as a designer

- [ ] Checked keyboard navigability
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)

- [ ] Tested with multiple browsers (check off which ones were used)
  - [ ] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari

- [ ] (Rarely needed) Tested as both an analyst and applicant user

## Screenshots

<!-- If this PR makes visible interface changes, an image of the finished interface can help reviewers
and casual observers understand the context of the changes.
A before image is optional and can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow.
You may want to use [GIPHY Capture](https://giphy.com/apps/giphycapture) for this! 📸

_Please frame images to show useful context but also highlight the affected regions._
--->
