### PR TITLE
Update button text for adding a domain manager

### DIFF
--- a/src/registrar/templates/domain_add_user.html
+++ b/src/registrar/templates/domain_add_user.html
@@ -18,7 +18,7 @@
     <button
       type="submit"
       class="usa-button"
-    >Add a domain manager</button>
+    >Add domain manager</button>
   </form>
 
 {% endblock %}  {# domain_content #}


### PR DESCRIPTION
Changed "Add a domain manager" to "Add domain manager." The latter reflects that the user is adding a specific domain manager. 