### PR TITLE
(Hot fix) Ticket #1795: DomainInformation being overwritten in some circumstances

### DIFF
--- a/src/registrar/models/domain_information.py
+++ b/src/registrar/models/domain_information.py
@@ -255,6 +255,12 @@ class DomainInformation(TimeStampedModel):
                 else:
                     da_many_to_many_dict[field] = getattr(domain_application, field).all()
 
+        # This will not happen in normal code flow, but having some redundancy doesn't hurt.
+        # da_dict should not have "id" under any circumstances.
+        if "id" in da_dict:
+            logger.warning("create_from_da() -> Found attribute 'id' when trying to create")
+            da_dict.pop("id", None)
+
         # Create a placeholder DomainInformation object
         domain_info = DomainInformation(**da_dict)
 

--- a/src/registrar/models/utility/domain_helper.py
+++ b/src/registrar/models/utility/domain_helper.py
@@ -180,8 +180,8 @@ class DomainHelper:
         """
 
         # Get a list of the existing fields on model_1 and model_2
-        model_1_fields = set(field.name for field in model_1._meta.get_fields() if field != "id")
-        model_2_fields = set(field.name for field in model_2._meta.get_fields() if field != "id")
+        model_1_fields = set(field.name for field in model_1._meta.get_fields() if field.name != "id")
+        model_2_fields = set(field.name for field in model_2._meta.get_fields() if field.name != "id")
 
         # Get the fields that exist on both DomainApplication and DomainInformation
         common_fields = model_1_fields & model_2_fields


### PR DESCRIPTION
## Ticket

Resolves #1795
<!--Reminder, when a code change is made that is user facing, beyond content updates, then the following are required:
- a developer approves the PR
- a designer approves the PR or checks off all relevant items in this checklist.

All other changes require just a single approving review.-->

## Changes

<!-- What was added, updated, or removed in this PR. -->
- Corrects a typo in domain_helper that was resulting in the inclusion of "id" in the returned kwarg dict
- Adds some redundancy in domain_information.py such that id is stripped from the dictionary if it is found (the prior 
<!--
    Please add/remove/edit any of the template below to fit the needs
    of this specific PR.
--->

## Context for reviewers
A [bug was found](https://cisa-corp.slack.com/archives/C05BGB4L5NF/p1708084192079019) on stable wherein DomainInformation records were anomalously getting overwritten on DomainApplication approval. 

This was ultimately caused by a typo which was supposed to strip out the id field, but instead retained it. This meant that .save() would update the field, rather than insert a new one. 
<!--Background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers.  -->

## Setup

This one is a little tricky to test. This bug only occurs when the id field of a DomainApplication matches the id field of a DomainInformation object. Rather than trying to get lucky, we can force this fail condition.

To do so, navigate to the model `domain_information.py`. Add `da_dict["id"] = 1` on line 263.
This will override my fix, and cause the bug to occur. 

Follow these steps to confirm it:

1. Create a new DomainApplication and submit it
2. Approve it via django admin
3. Go to the audit log, and search for the name of your application. Filter by DomainInformation. 
4. If the field says "update", this means you replicated the bug successfully.

To confirm the fix:
1. Either remove the line you added or move it before line 260 (or wherever else it makes sense)
2. Docker down then up again (starting with fresh data)
3. Repeat the same steps as before 

<!--  Add any steps or code to run in this section to help others run your code.
    
    Example 1:
    ```sh
    echo "Code goes here"
    ``` 
    
    Example 2: If the PR was to add a new link with a redirect, this section could simply be:
    -go to /path/to/start/page
    -click the blue link in the <insert location>
    -notice user is redirected to <proper end location>
-->

## Code Review Verification Steps

### As the original developer, I have

#### Satisfied acceptance criteria and met development standards

- [ ] Met the acceptance criteria, or will meet them in a subsequent PR
- [ ] Created/modified automated tests
- [ ] Added at least 2 developers as PR reviewers (only 1 will need to approve)
- [ ] Messaged on Slack or in standup to notify the team that a PR is ready for review
- [ ] Changes to “how we do things” are documented in READMEs and or onboarding guide
- [ ] If any model was updated to modify/add/delete columns, makemigrations was ran and the associated migrations file has been commited.

#### Ensured code standards are met (Original Developer)

- [ ] All new functions and methods are commented using plain language
- [ ] Did dependency updates in Pipfile also get changed in requirements.txt?
- [ ] Interactions with external systems are wrapped in try/except
- [ ] Error handling exists for unusual or missing values

#### Validated user-facing changes (if applicable)

- [ ] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Checked keyboard navigability
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)
- [ ] Add at least 1 designer as PR reviewer

### As a code reviewer, I have

#### Reviewed, tested, and left feedback about the changes

- [ ] Pulled this branch locally and tested it
- [ ] Reviewed this code and left comments
- [ ] Checked that all code is adequately covered by tests
- [ ] Made it clear which comments need to be addressed before this work is merged
- [ ] If any model was updated to modify/add/delete columns, makemigrations was ran and the associated migrations file has been commited.

#### Ensured code standards are met (Code reviewer)

- [ ] All new functions and methods are commented using plain language
- [ ] Interactions with external systems are wrapped in try/except
- [ ] Error handling exists for unusual or missing values
- [ ] (Rarely needed) Did dependency updates in Pipfile also get changed in requirements.txt?

#### Validated user-facing changes as a developer

- [ ] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Checked keyboard navigability
- [ ] Meets all designs and user flows provided by design/product
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)

- [ ] Tested with multiple browsers, the suggestion is to use ones that the developer didn't (check off which ones were used)
  - [ ] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari

- [ ] (Rarely needed) Tested as both an analyst and applicant user

**Note:** Multiple code reviewers can share the checklists above, a second reviewers should not make a duplicate checklist

### As a designer reviewer, I have

#### Verified that the changes match the design intention

- [ ] Checked that the design translated visually
- [ ] Checked behavior
- [ ] Checked different states (empty, one, some, error)
- [ ] Checked for landmarks, page heading structure, and links
- [ ] Tried to break the intended flow

#### Validated user-facing changes as a designer

- [ ] Checked keyboard navigability
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)

- [ ] Tested with multiple browsers (check off which ones were used)
  - [ ] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari

- [ ] (Rarely needed) Tested as both an analyst and applicant user

## Screenshots

<!-- If this PR makes visible interface changes, an image of the finished interface can help reviewers
and casual observers understand the context of the changes.
A before image is optional and can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow.
You may want to use [GIPHY Capture](https://giphy.com/apps/giphycapture) for this! 📸

_Please frame images to show useful context but also highlight the affected regions._
--->
