### PR TITLE
handle 500 error with empty string for alternative domain

### DIFF
--- a/src/registrar/models/utility/domain_helper.py
+++ b/src/registrar/models/utility/domain_helper.py
@@ -33,11 +33,12 @@ class DomainHelper:
         # Split into pieces for the linter
         domain = cls._validate_domain_string(domain, blank_ok)
 
-        try:
-            if not check_domain_available(domain):
-                raise errors.DomainUnavailableError()
-        except RegistryError as err:
-            raise errors.RegistrySystemError() from err
+        if domain != "":
+            try:
+                if not check_domain_available(domain):
+                    raise errors.DomainUnavailableError()
+            except RegistryError as err:
+                raise errors.RegistrySystemError() from err
         return domain
 
     @staticmethod

--- a/src/registrar/tests/test_models_domain.py
+++ b/src/registrar/tests/test_models_domain.py
@@ -20,7 +20,7 @@ from registrar.models.user import User
 from registrar.utility.errors import ActionNotAllowed, NameserverError
 
 from registrar.models.utility.contact_error import ContactError, ContactErrorCodes
-
+from registrar.utility import errors
 
 from django_fsm import TransitionNotAllowed  # type: ignore
 from epplibwrapper import (
@@ -502,15 +502,25 @@ class TestDomainAvailable(MockEppLib):
         self.assertFalse(available)
         patcher.stop()
 
-    def test_domain_available_with_value_error(self):
+    def test_domain_available_with_invalid_error(self):
         """
         Scenario: Testing whether an invalid domain is available
-            Should throw ValueError
+            Should throw InvalidDomainError
 
-            Validate ValueError is raised
+            Validate InvalidDomainError is raised
         """
-        with self.assertRaises(ValueError):
+        with self.assertRaises(errors.InvalidDomainError()):
             Domain.available("invalid-string")
+
+    def test_domain_available_with_empty_string(self):
+        """
+        Scenario: Testing whether an empty string domain name is available
+            Should throw InvalidDomainError
+
+            Validate InvalidDomainError is raised
+        """
+        with self.assertRaises(errors.InvalidDomainError()):
+            Domain.available("")
 
     def test_domain_available_unsuccessful(self):
         """

--- a/src/registrar/tests/test_models_domain.py
+++ b/src/registrar/tests/test_models_domain.py
@@ -509,7 +509,7 @@ class TestDomainAvailable(MockEppLib):
 
             Validate InvalidDomainError is raised
         """
-        with self.assertRaises(errors.InvalidDomainError()):
+        with self.assertRaises(errors.InvalidDomainError):
             Domain.available("invalid-string")
 
     def test_domain_available_with_empty_string(self):
@@ -519,7 +519,7 @@ class TestDomainAvailable(MockEppLib):
 
             Validate InvalidDomainError is raised
         """
-        with self.assertRaises(errors.InvalidDomainError()):
+        with self.assertRaises(errors.InvalidDomainError):
             Domain.available("")
 
     def test_domain_available_unsuccessful(self):


### PR DESCRIPTION
## Ticket

Resolves #1812 
<!--Reminder, when a code change is made that is user facing, beyond content updates, then the following are required:
- a developer approves the PR
- a designer approves the PR or checks off all relevant items in this checklist.

All other changes require just a single approving review.-->

## Changes

<!-- What was added, updated, or removed in this PR. -->
-don't throw ValueError on domain.available which will cause the site to throw a 500
-don't check domain availability on empty alternative domain values (which will auto delete)

<!--
    Please add/remove/edit any of the template below to fit the needs
    of this specific PR.
--->

## Context for reviewers
- the error was being thrown because an alternative domain can be blank and if it is originally " " it passes the front end checks and fails the models/domain.py avaliability check. It shouldnt have sent an " " value  to domain.available at all and should have instead just ignored that alternative domain. Also, domain.available caused the 500 due to poor error handling. Domain.available takes " " and sees that it is not a valid domain name but it was throwing ValueError which is not caught in the validate function. Even just having this as an InvalidDomainError would have given the user a human readable error instead of a 500 error. Hence, I made both changes here 
<!--Background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers.  -->

## Setup

<!--  Add any steps or code to run in this section to help others run your code.
    
    Example 1:
    ```sh
    echo "Code goes here"
    ``` 
    
    Example 2: If the PR was to add a new link with a redirect, this section could simply be:
    -go to /path/to/start/page
    -click the blue link in the <insert location>
    -notice user is redirected to <proper end location>
-->
on [getgov-ab]( https://getgov-ab.app.cloud.gov)

1. go to the domain page in a request ( https://getgov-ab.app.cloud.gov/request/dotgov_domain/)
2. add an empty space on the alternative domain
3. see that you can submit the domain with no 500 error

## Code Review Verification Steps
### As the original developer, I have

#### Satisfied acceptance criteria and met development standards

- [ ] Met the acceptance criteria, or will meet them in a subsequent PR
- [ ] Created/modified automated tests
- [ ] Added at least 2 developers as PR reviewers (only 1 will need to approve)
- [ ] Messaged on Slack or in standup to notify the team that a PR is ready for review
- [ ] Changes to “how we do things” are documented in READMEs and or onboarding guide
- [ ] If any model was updated to modify/add/delete columns, makemigrations was ran and the associated migrations file has been commited.

#### Ensured code standards are met (Original Developer)

- [ ] All new functions and methods are commented using plain language
- [ ] Did dependency updates in Pipfile also get changed in requirements.txt?
- [ ] Interactions with external systems are wrapped in try/except
- [ ] Error handling exists for unusual or missing values

#### Validated user-facing changes (if applicable)

- [ ] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Checked keyboard navigability
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)
- [ ] Add at least 1 designer as PR reviewer

### As a code reviewer, I have

#### Reviewed, tested, and left feedback about the changes

- [ ] Pulled this branch locally and tested it
- [ ] Reviewed this code and left comments
- [ ] Checked that all code is adequately covered by tests
- [ ] Made it clear which comments need to be addressed before this work is merged
- [ ] If any model was updated to modify/add/delete columns, makemigrations was ran and the associated migrations file has been commited.

#### Ensured code standards are met (Code reviewer)

- [ ] All new functions and methods are commented using plain language
- [ ] Interactions with external systems are wrapped in try/except
- [ ] Error handling exists for unusual or missing values
- [ ] (Rarely needed) Did dependency updates in Pipfile also get changed in requirements.txt?

#### Validated user-facing changes as a developer

- [ ] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Checked keyboard navigability
- [ ] Meets all designs and user flows provided by design/product
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)

- [ ] Tested with multiple browsers, the suggestion is to use ones that the developer didn't (check off which ones were used)
  - [ ] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari

- [ ] (Rarely needed) Tested as both an analyst and applicant user

**Note:** Multiple code reviewers can share the checklists above, a second reviewers should not make a duplicate checklist

### As a designer reviewer, I have

#### Verified that the changes match the design intention

- [ ] Checked that the design translated visually
- [ ] Checked behavior
- [ ] Checked different states (empty, one, some, error)
- [ ] Checked for landmarks, page heading structure, and links
- [ ] Tried to break the intended flow

#### Validated user-facing changes as a designer

- [ ] Checked keyboard navigability
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)

- [ ] Tested with multiple browsers (check off which ones were used)
  - [ ] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari

- [ ] (Rarely needed) Tested as both an analyst and applicant user

## Screenshots

<!-- If this PR makes visible interface changes, an image of the finished interface can help reviewers
and casual observers understand the context of the changes.
A before image is optional and can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow.
You may want to use [GIPHY Capture](https://giphy.com/apps/giphycapture) for this! 📸

_Please frame images to show useful context but also highlight the affected regions._
--->
