### PR TITLE
ISSUE #1837: Update from created_at to submission_date

### DIFF
--- a/src/registrar/admin.py
+++ b/src/registrar/admin.py
@@ -942,7 +942,7 @@ class DomainApplicationAdmin(ListHeaderAdmin):
         "custom_election_board",
         "city",
         "state_territory",
-        "submission_date", #this is the right change
+        "submission_date",
         "submitter",
         "investigator",
     ]

--- a/src/registrar/admin.py
+++ b/src/registrar/admin.py
@@ -942,7 +942,7 @@ class DomainApplicationAdmin(ListHeaderAdmin):
         "custom_election_board",
         "city",
         "state_territory",
-        "created_at",
+        "submission_date", #this is the right change
         "submitter",
         "investigator",
     ]


### PR DESCRIPTION
## Ticket

Resolves #1837


## Changes

* Created At column is now updated to Submission Date -- see screenshots as well

## Context for reviewers

* Previously, for Domain Applications we had the column of "created at", but not all created Domain Applications finish and so we want the field of "submission date" instead for Domain Applications that are submitted

## Setup

1. Go to my sandbox
2. Go to `/admin`
3. Click on `Domain Application`
4. Look through the columns -- you should now see "submission date" instead of "created at"
## Code Review Verification Steps

### As the original developer, I have

#### Satisfied acceptance criteria and met development standards

- [ ] Met the acceptance criteria, or will meet them in a subsequent PR
- [ ] Created/modified automated tests
- [ ] Added at least 2 developers as PR reviewers (only 1 will need to approve)
- [ ] Messaged on Slack or in standup to notify the team that a PR is ready for review
- [ ] Changes to “how we do things” are documented in READMEs and or onboarding guide
- [ ] If any model was updated to modify/add/delete columns, makemigrations was ran and the associated migrations file has been commited.

#### Ensured code standards are met (Original Developer)

- [ ] All new functions and methods are commented using plain language
- [ ] Did dependency updates in Pipfile also get changed in requirements.txt?
- [ ] Interactions with external systems are wrapped in try/except
- [ ] Error handling exists for unusual or missing values

#### Validated user-facing changes (if applicable)

- [ ] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Checked keyboard navigability
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)
- [ ] Add at least 1 designer as PR reviewer

### As a code reviewer, I have

#### Reviewed, tested, and left feedback about the changes

- [x] Pulled this branch locally and tested it
- [x] Reviewed this code and left comments
- [x] Checked that all code is adequately covered by tests
- [ ] Made it clear which comments need to be addressed before this work is merged
- [ ] If any model was updated to modify/add/delete columns, makemigrations was ran and the associated migrations file has been commited.

#### Ensured code standards are met (Code reviewer)

- [ ] All new functions and methods are commented using plain language
- [ ] Interactions with external systems are wrapped in try/except
- [ ] Error handling exists for unusual or missing values
- [ ] (Rarely needed) Did dependency updates in Pipfile also get changed in requirements.txt?

#### Validated user-facing changes as a developer

- [ ] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Checked keyboard navigability
- [ ] Meets all designs and user flows provided by design/product
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)

- [ ] Tested with multiple browsers, the suggestion is to use ones that the developer didn't (check off which ones were used)
  - [ ] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari

- [ ] (Rarely needed) Tested as both an analyst and applicant user

**Note:** Multiple code reviewers can share the checklists above, a second reviewers should not make a duplicate checklist

### As a designer reviewer, I have

#### Verified that the changes match the design intention

- [ ] Checked that the design translated visually
- [ ] Checked behavior
- [ ] Checked different states (empty, one, some, error)
- [ ] Checked for landmarks, page heading structure, and links
- [ ] Tried to break the intended flow

#### Validated user-facing changes as a designer

- [ ] Checked keyboard navigability
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)

- [ ] Tested with multiple browsers (check off which ones were used)
  - [ ] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari

- [ ] (Rarely needed) Tested as both an analyst and applicant user

## Screenshots
**Previous state:**
<img width="1098" alt="Screenshot 2024-03-08 at 11 52 33 AM" src="https://github.com/cisagov/manage.get.gov/assets/13954664/fa450f5e-6847-4927-be9b-b30c6683cd47">
**Current state:**
<img width="1083" alt="Screenshot 2024-03-08 at 11 54 10 AM" src="https://github.com/cisagov/manage.get.gov/assets/13954664/1cb50306-5c81-44f8-b10e-f58bb51afd4d">
