### PR TITLE
Issue #1652: Domain invitation 'cancel' link does not display on retrieved invitations

### DIFF
--- a/src/registrar/templates/domain_users.html
+++ b/src/registrar/templates/domain_users.html
@@ -133,9 +133,11 @@
           <td data-sort-value="{{ invitation.created_at|date:"U" }}" data-label="Date created">{{ invitation.created_at|date }} </td>
           <td data-label="Status">{{ invitation.status|title }}</td>
           <td>
+            {% if invitation.status == invitation.DomainInvitationStatus.INVITED %}
             <form method="POST" action="{% url "invitation-delete" pk=invitation.id %}">
               {% csrf_token %}<input type="submit" class="usa-button--unstyled text-no-underline" value="Cancel">
             </form>
+            {% endif %}
           </td>
         </tr>
         {% endfor %}

--- a/src/registrar/tests/test_views_domain.py
+++ b/src/registrar/tests/test_views_domain.py
@@ -668,7 +668,9 @@ class TestDomainManagers(TestDomainOverview):
     def test_domain_invitation_cancel_retrieved_invitation(self):
         """Posting to the delete view when invitation retrieved returns an error message"""
         email_address = "mayor@igorville.gov"
-        invitation, _ = DomainInvitation.objects.get_or_create(domain=self.domain, email=email_address, status=DomainInvitation.DomainInvitationStatus.RETRIEVED)
+        invitation, _ = DomainInvitation.objects.get_or_create(
+            domain=self.domain, email=email_address, status=DomainInvitation.DomainInvitationStatus.RETRIEVED
+        )
         with less_console_noise():
             response = self.client.post(reverse("invitation-delete", kwargs={"pk": invitation.id}), follow=True)
             # Assert that an error message is displayed to the user
@@ -678,7 +680,7 @@ class TestDomainManagers(TestDomainOverview):
         # Assert that the DomainInvitation is not deleted
         self.assertTrue(DomainInvitation.objects.filter(id=invitation.id).exists())
         DomainInvitation.objects.filter(email=email_address).delete()
-    
+
     def test_domain_invitation_cancel_no_permissions(self):
         """Posting to the delete view as a different user should fail."""
         email_address = "mayor@igorville.gov"

--- a/src/registrar/tests/test_views_domain.py
+++ b/src/registrar/tests/test_views_domain.py
@@ -665,6 +665,20 @@ class TestDomainManagers(TestDomainOverview):
         with self.assertRaises(DomainInvitation.DoesNotExist):
             DomainInvitation.objects.get(id=invitation.id)
 
+    def test_domain_invitation_cancel_retrieved_invitation(self):
+        """Posting to the delete view when invitation retrieved returns an error message"""
+        email_address = "mayor@igorville.gov"
+        invitation, _ = DomainInvitation.objects.get_or_create(domain=self.domain, email=email_address, status=DomainInvitation.DomainInvitationStatus.RETRIEVED)
+        with less_console_noise():
+            response = self.client.post(reverse("invitation-delete", kwargs={"pk": invitation.id}), follow=True)
+            # Assert that an error message is displayed to the user
+            self.assertContains(response, f"Invitation to {email_address} has already been retrieved.")
+            # Assert that the Cancel link is not displayed
+            self.assertNotContains(response, "Cancel")
+        # Assert that the DomainInvitation is not deleted
+        self.assertTrue(DomainInvitation.objects.filter(id=invitation.id).exists())
+        DomainInvitation.objects.filter(email=email_address).delete()
+    
     def test_domain_invitation_cancel_no_permissions(self):
         """Posting to the delete view as a different user should fail."""
         email_address = "mayor@igorville.gov"

--- a/src/registrar/views/domain.py
+++ b/src/registrar/views/domain.py
@@ -822,6 +822,18 @@ class DomainAddUserView(DomainFormBaseView):
 class DomainInvitationDeleteView(SuccessMessageMixin, DomainInvitationPermissionDeleteView):
     object: DomainInvitation  # workaround for type mismatch in DeleteView
 
+    def post(self, request, *args, **kwargs):
+        """Override post method in order to error in the case when the
+        domain invitation status is RETRIEVED"""
+        self.object = self.get_object()
+        form = self.get_form()
+        if form.is_valid() and self.object.status == self.object.DomainInvitationStatus.INVITED:
+            return self.form_valid(form)
+        else:
+            # Produce an error message if the domain invatation status is RETRIEVED
+            messages.error(request, f"Invitation to {self.object.email} has already been retrieved")
+            return HttpResponseRedirect(self.get_success_url())
+
     def get_success_url(self):
         return reverse("domain-users", kwargs={"pk": self.object.domain.id})
 

--- a/src/registrar/views/domain.py
+++ b/src/registrar/views/domain.py
@@ -831,7 +831,7 @@ class DomainInvitationDeleteView(SuccessMessageMixin, DomainInvitationPermission
             return self.form_valid(form)
         else:
             # Produce an error message if the domain invatation status is RETRIEVED
-            messages.error(request, f"Invitation to {self.object.email} has already been retrieved")
+            messages.error(request, f"Invitation to {self.object.email} has already been retrieved.")
             return HttpResponseRedirect(self.get_success_url())
 
     def get_success_url(self):


### PR DESCRIPTION
## Ticket

Resolves #1652 
<!--Reminder, when a code change is made that is user facing, beyond content updates, then the following are required:
- a developer approves the PR
- a designer approves the PR or checks off all relevant items in this checklist.

All other changes require just a single approving review.-->

## Changes

<!-- What was added, updated, or removed in this PR. -->
- Domain Invitations that are already retrieved no longer display a 'Cancel' link
- If user posts to the path that would previously have been executed by the 'Cancel' link, the domain invitation is not deleted, and an error message, "Invitation to {email_address} has already been retrieved.", is displayed

<!--
    Please add/remove/edit any of the template below to fit the needs
    of this specific PR.
--->

## Context for reviewers

<!--Background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers.  -->

## Setup

<!--  Add any steps or code to run in this section to help others run your code.
    
    Example 1:
    ```sh
    echo "Code goes here"
    ``` 
    
    Example 2: If the PR was to add a new link with a redirect, this section could simply be:
    -go to /path/to/start/page
    -click the blue link in the <insert location>
    -notice user is redirected to <proper end location>
-->

## Code Review Verification Steps

### As the original developer, I have

#### Satisfied acceptance criteria and met development standards

- [ ] Met the acceptance criteria, or will meet them in a subsequent PR
- [ ] Created/modified automated tests
- [ ] Added at least 2 developers as PR reviewers (only 1 will need to approve)
- [ ] Messaged on Slack or in standup to notify the team that a PR is ready for review
- [ ] Changes to “how we do things” are documented in READMEs and or onboarding guide
- [ ] If any model was updated to modify/add/delete columns, makemigrations was ran and the associated migrations file has been commited.

#### Ensured code standards are met (Original Developer)

- [ ] All new functions and methods are commented using plain language
- [ ] Did dependency updates in Pipfile also get changed in requirements.txt?
- [ ] Interactions with external systems are wrapped in try/except
- [ ] Error handling exists for unusual or missing values

#### Validated user-facing changes (if applicable)

- [ ] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Checked keyboard navigability
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)
- [ ] Add at least 1 designer as PR reviewer

### As a code reviewer, I have

#### Reviewed, tested, and left feedback about the changes

- [ ] Pulled this branch locally and tested it
- [ ] Reviewed this code and left comments
- [ ] Checked that all code is adequately covered by tests
- [ ] Made it clear which comments need to be addressed before this work is merged
- [ ] If any model was updated to modify/add/delete columns, makemigrations was ran and the associated migrations file has been commited.

#### Ensured code standards are met (Code reviewer)

- [ ] All new functions and methods are commented using plain language
- [ ] Interactions with external systems are wrapped in try/except
- [ ] Error handling exists for unusual or missing values
- [ ] (Rarely needed) Did dependency updates in Pipfile also get changed in requirements.txt?

#### Validated user-facing changes as a developer

- [ ] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Checked keyboard navigability
- [ ] Meets all designs and user flows provided by design/product
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)

- [ ] Tested with multiple browsers, the suggestion is to use ones that the developer didn't (check off which ones were used)
  - [ ] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari

- [ ] (Rarely needed) Tested as both an analyst and applicant user

**Note:** Multiple code reviewers can share the checklists above, a second reviewers should not make a duplicate checklist

### As a designer reviewer, I have

#### Verified that the changes match the design intention

- [ ] Checked that the design translated visually
- [ ] Checked behavior
- [ ] Checked different states (empty, one, some, error)
- [ ] Checked for landmarks, page heading structure, and links
- [ ] Tried to break the intended flow

#### Validated user-facing changes as a designer

- [ ] Checked keyboard navigability
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)

- [ ] Tested with multiple browsers (check off which ones were used)
  - [ ] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari

- [ ] (Rarely needed) Tested as both an analyst and applicant user

## Screenshots

<!-- If this PR makes visible interface changes, an image of the finished interface can help reviewers
and casual observers understand the context of the changes.
A before image is optional and can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow.
You may want to use [GIPHY Capture](https://giphy.com/apps/giphycapture) for this! 📸

_Please frame images to show useful context but also highlight the affected regions._
--->
