### PR TITLE
ISSUE 1979 PT 2: Unknown State Remdiation Pt 2

### DIFF
--- a/src/registrar/models/domain.py
+++ b/src/registrar/models/domain.py
@@ -1714,7 +1714,7 @@ class Domain(TimeStampedModel, DomainHelper):
         if len(cleaned.get("_contacts")) < 3:
             for contact in cleaned.get("_contacts"):
                 if contact.type == PublicContact.ContactTypeChoices.ADMINISTRATIVE:
-                    mitestssingAdmin = False
+                    missingAdmin = False
                 if contact.type == PublicContact.ContactTypeChoices.SECURITY:
                     missingSecurity = False
                 if contact.type == PublicContact.ContactTypeChoices.TECHNICAL:

--- a/src/registrar/models/domain.py
+++ b/src/registrar/models/domain.py
@@ -1951,6 +1951,7 @@ class Domain(TimeStampedModel, DomainHelper):
         # Does the item we're grabbing match
         # what we have in our DB?
         if existing_contact.email != public_contact.email or existing_contact.registry_id != public_contact.registry_id:
+            print("******* IN IF STATEMENT!!!!! ***********")
             existing_contact.delete()
             public_contact.save()
             logger.warning("Requested PublicContact is out of sync " "with DB.")

--- a/src/registrar/models/domain.py
+++ b/src/registrar/models/domain.py
@@ -1686,6 +1686,13 @@ class Domain(TimeStampedModel, DomainHelper):
                 logger.error("Error _delete_hosts_if_not_used, code was %s error was %s" % (e.code, e))
 
     def _fix_unknown_state(self, cleaned):
+        """
+        _fix_unknown_state: Calls _add_missing_contacts_if_unknown
+        to add contacts in as needed (or return an error). Otherwise
+        if we are able to add contacts and the state is out of UNKNOWN
+        and (and should be into DNS_NEEDED), we double check the
+        current state and # of nameservers and update the state from there
+        """
         try:
             self._add_missing_contacts_if_unknown(cleaned)
 
@@ -1694,7 +1701,7 @@ class Domain(TimeStampedModel, DomainHelper):
                 "%s couldn't _add_missing_contacts_if_unknown, error was %s."
                 "Domain will still be in UNKNOWN state." % (self.name, e)
             )
-        if len(self.nameservers) >= 2:
+        if len(self.nameservers) >= 2 and (self.state != self.State.READY):
             self.ready()
             self.save()
 

--- a/src/registrar/models/domain.py
+++ b/src/registrar/models/domain.py
@@ -1686,48 +1686,41 @@ class Domain(TimeStampedModel, DomainHelper):
                 logger.error("Error _delete_hosts_if_not_used, code was %s error was %s" % (e.code, e))
 
     def _fix_unknown_state(self, cleaned):
-        # print("!! GOT INTO _fix_unknown_state")
-
         try:
-            self._add_missing_contacts(cleaned)
+            self._add_missing_contacts_if_unknown(cleaned)
 
         except Exception as e:
             logger.error(
-                "%s couldn't _add_missing_contacts, error was %s."
+                "%s couldn't _add_missing_contacts_if_unknown, error was %s."
                 "Domain will still be in UNKNOWN state." % (self.name, e)
             )
         if len(self.nameservers) >= 2:
-            # print("!! GOT INTO _fix_unknown_state -> have 2 or more nameserver so ready state")
             self.ready()
             self.save()
 
     @transition(field="state", source=State.UNKNOWN, target=State.DNS_NEEDED)
-    def _add_missing_contacts(self, cleaned):
+    def _add_missing_contacts_if_unknown(self, cleaned):
         """
-        _add_missing_contacts: Add contacts (SECURITY, TECHNICAL, and/or ADMINISTRATIVE)
+        _add_missing_contacts_if_unknown: Add contacts (SECURITY, TECHNICAL, and/or ADMINISTRATIVE)
         if they are missing, AND switch the state to DNS_NEEDED from UNKNOWN (if it
         is in an UNKNOWN state, that is an error state)
         Note: The transition state change happens at the end of the function
         """
-        # print("!! GOT INTO _add_missing_contacts ")
 
         missingAdmin = True
         missingSecurity = True
         missingTech = True
-        # print("cleaned ", cleaned)
 
         if len(cleaned.get("_contacts")) < 3:
-            # print("!! GOT INTO _add_missing_contacts -> in if statement")
             for contact in cleaned.get("_contacts"):
-                # this means we see it
-                if contact.type == "admin":
-                    missingAdmin = False
-                if contact.type == "security":
+                if contact.type == PublicContact.ContactTypeChoices.ADMINISTRATIVE:
+                    mitestssingAdmin = False
+                if contact.type == PublicContact.ContactTypeChoices.SECURITY:
                     missingSecurity = False
-                if contact.type == "tech":
+                if contact.type == PublicContact.ContactTypeChoices.TECHNICAL:
                     missingTech = False
 
-            # we are only creating if it doesn't exist so we don't overwrite
+            # We are only creating if it doesn't exist so we don't overwrite
             if missingAdmin:
                 administrative_contact = self.get_default_administrative_contact()
                 administrative_contact.save()
@@ -1738,8 +1731,6 @@ class Domain(TimeStampedModel, DomainHelper):
                 technical_contact = self.get_default_technical_contact()
                 technical_contact.save()
 
-        # print("!! GOT INTO _add_missing_contacts -> if statement finished ")
-
     def _fetch_cache(self, fetch_hosts=False, fetch_contacts=False):
         """Contact registry for info about a domain."""
         try:
@@ -1749,7 +1740,6 @@ class Domain(TimeStampedModel, DomainHelper):
             self._update_hosts_and_contacts(cleaned, fetch_hosts, fetch_contacts)
 
             if self.state == self.State.UNKNOWN:
-                # print("!! GOT INTO if self.state == self.State.UNKNOWN: ")
                 self._fix_unknown_state(cleaned)
             if fetch_hosts:
                 self._update_hosts_and_ips_in_db(cleaned)
@@ -1951,7 +1941,6 @@ class Domain(TimeStampedModel, DomainHelper):
         # Does the item we're grabbing match
         # what we have in our DB?
         if existing_contact.email != public_contact.email or existing_contact.registry_id != public_contact.registry_id:
-            print("******* IN IF STATEMENT!!!!! ***********")
             existing_contact.delete()
             public_contact.save()
             logger.warning("Requested PublicContact is out of sync " "with DB.")

--- a/src/registrar/tests/common.py
+++ b/src/registrar/tests/common.py
@@ -1064,7 +1064,6 @@ class MockEppLib(TestCase):
     mockDataSecurityContact = mockDataInfoDomain.dummyInfoContactResultData(
         id="securityContact", email="security@mail.gov", cr_date=datetime(2023, 5, 25, 19, 45, 35), pw="lastPw"
     )
-    # print("!! mockDataInfoContact is", mockDataInfoContact)
     InfoDomainWithContacts = fakedEppObject(
         "fakePw",
         cr_date=make_aware(datetime(2023, 5, 25, 19, 45, 35)),

--- a/src/registrar/tests/common.py
+++ b/src/registrar/tests/common.py
@@ -1058,13 +1058,13 @@ class MockEppLib(TestCase):
         ],
         ex_date=date(2023, 11, 15),
     )
-    mockDataInfoContact = mockDataInfoDomain.dummyInfoContactResultData(
-        id="SECURITY", email="security@mail.gov", cr_date=datetime(2023, 5, 25, 19, 45, 35), pw="lastPw"
-    )
+    # mockDataInfoContact = mockDataInfoDomain.dummyInfoContactResultData(
+    #     id="SECURITY", email="security@mail.gov", cr_date=datetime(2023, 5, 25, 19, 45, 35), pw="lastPw"
+    # )
     mockDataSecurityContact = mockDataInfoDomain.dummyInfoContactResultData(
-        id="SECURITY", email="security@mail.gov", cr_date=datetime(2023, 5, 25, 19, 45, 35), pw="lastPw"
+        id="securityContact", email="security@mail.gov", cr_date=datetime(2023, 5, 25, 19, 45, 35), pw="lastPw"
     )
-    print("!! mockDataInfoContact is", mockDataInfoContact)
+    # print("!! mockDataInfoContact is", mockDataInfoContact)
     InfoDomainWithContacts = fakedEppObject(
         "fakePw",
         cr_date=make_aware(datetime(2023, 5, 25, 19, 45, 35)),

--- a/src/registrar/tests/common.py
+++ b/src/registrar/tests/common.py
@@ -1059,8 +1059,12 @@ class MockEppLib(TestCase):
         ex_date=date(2023, 11, 15),
     )
     mockDataInfoContact = mockDataInfoDomain.dummyInfoContactResultData(
-        "123", "123@mail.gov", datetime(2023, 5, 25, 19, 45, 35), "lastPw"
+        id="SECURITY", email="security@mail.gov", cr_date=datetime(2023, 5, 25, 19, 45, 35), pw="lastPw"
     )
+    mockDataSecurityContact = mockDataInfoDomain.dummyInfoContactResultData(
+        id="SECURITY", email="security@mail.gov", cr_date=datetime(2023, 5, 25, 19, 45, 35), pw="lastPw"
+    )
+    print("!! mockDataInfoContact is", mockDataInfoContact)
     InfoDomainWithContacts = fakedEppObject(
         "fakepw",
         cr_date=make_aware(datetime(2023, 5, 25, 19, 45, 35)),
@@ -1497,6 +1501,7 @@ class MockEppLib(TestCase):
             "fakemeow.gov": (self.mockDataInfoDomainNotSubdomainNoIP, None),
             "subdomainwoip.gov": (self.mockDataInfoDomainSubdomainNoIP, None),
             "ddomain3.gov": (self.InfoDomainWithContacts, None),
+            "igorville.gov": (self.InfoDomainWithContacts, None),
         }
 
         # Retrieve the corresponding values from the dictionary
@@ -1509,8 +1514,6 @@ class MockEppLib(TestCase):
 
     def mockInfoContactCommands(self, _request, cleaned):
         mocked_result: info.InfoContactResultData
-
-        print("!!! _request is ", _request)
 
         # For testing contact types
         match getattr(_request, "id", None):

--- a/src/registrar/tests/common.py
+++ b/src/registrar/tests/common.py
@@ -1066,7 +1066,7 @@ class MockEppLib(TestCase):
     )
     print("!! mockDataInfoContact is", mockDataInfoContact)
     InfoDomainWithContacts = fakedEppObject(
-        "fakepw",
+        "fakePw",
         cr_date=make_aware(datetime(2023, 5, 25, 19, 45, 35)),
         contacts=[
             common.DomainContact(

--- a/src/registrar/tests/common.py
+++ b/src/registrar/tests/common.py
@@ -545,7 +545,6 @@ class MockDb(TestCase):
         self.domain_2, _ = Domain.objects.get_or_create(name="adomain2.gov", state=Domain.State.DNS_NEEDED)
         self.domain_3, _ = Domain.objects.get_or_create(name="ddomain3.gov", state=Domain.State.ON_HOLD)
         self.domain_4, _ = Domain.objects.get_or_create(name="bdomain4.gov", state=Domain.State.UNKNOWN)
-        self.domain_4, _ = Domain.objects.get_or_create(name="bdomain4.gov", state=Domain.State.UNKNOWN)
         self.domain_5, _ = Domain.objects.get_or_create(
             name="bdomain5.gov", state=Domain.State.DELETED, deleted=timezone.make_aware(datetime(2023, 11, 1))
         )
@@ -977,7 +976,7 @@ class MockEppLib(TestCase):
     mockDataInfoDomain = fakedEppObject(
         "fakePw",
         cr_date=make_aware(datetime(2023, 5, 25, 19, 45, 35)),
-                contacts=[
+        contacts=[
             common.DomainContact(
                 contact="securityContact",
                 type=PublicContact.ContactTypeChoices.SECURITY,
@@ -1085,6 +1084,7 @@ class MockEppLib(TestCase):
             common.Status(state="inactive", description="", lang="en"),
         ],
         registrant="regContact",
+        ex_date=date(2023, 11, 15),
     )
 
     InfoDomainWithDefaultSecurityContact = fakedEppObject(
@@ -1496,6 +1496,7 @@ class MockEppLib(TestCase):
             "meow.gov": (self.mockDataInfoDomainSubdomainAndIPAddress, None),
             "fakemeow.gov": (self.mockDataInfoDomainNotSubdomainNoIP, None),
             "subdomainwoip.gov": (self.mockDataInfoDomainSubdomainNoIP, None),
+            "ddomain3.gov": (self.InfoDomainWithContacts, None),
         }
 
         # Retrieve the corresponding values from the dictionary
@@ -1508,6 +1509,8 @@ class MockEppLib(TestCase):
 
     def mockInfoContactCommands(self, _request, cleaned):
         mocked_result: info.InfoContactResultData
+
+        print("!!! _request is ", _request)
 
         # For testing contact types
         match getattr(_request, "id", None):

--- a/src/registrar/tests/common.py
+++ b/src/registrar/tests/common.py
@@ -1058,9 +1058,9 @@ class MockEppLib(TestCase):
         ],
         ex_date=date(2023, 11, 15),
     )
-    # mockDataInfoContact = mockDataInfoDomain.dummyInfoContactResultData(
-    #     id="SECURITY", email="security@mail.gov", cr_date=datetime(2023, 5, 25, 19, 45, 35), pw="lastPw"
-    # )
+    mockDataInfoContact = mockDataInfoDomain.dummyInfoContactResultData(
+        id="123", email="123@mail.gov", cr_date=datetime(2023, 5, 25, 19, 45, 35), pw="lastPw"
+    )
     mockDataSecurityContact = mockDataInfoDomain.dummyInfoContactResultData(
         id="securityContact", email="security@mail.gov", cr_date=datetime(2023, 5, 25, 19, 45, 35), pw="lastPw"
     )

--- a/src/registrar/tests/common.py
+++ b/src/registrar/tests/common.py
@@ -977,7 +977,20 @@ class MockEppLib(TestCase):
     mockDataInfoDomain = fakedEppObject(
         "fakePw",
         cr_date=make_aware(datetime(2023, 5, 25, 19, 45, 35)),
-        contacts=[common.DomainContact(contact="123", type=PublicContact.ContactTypeChoices.SECURITY)],
+                contacts=[
+            common.DomainContact(
+                contact="securityContact",
+                type=PublicContact.ContactTypeChoices.SECURITY,
+            ),
+            common.DomainContact(
+                contact="technicalContact",
+                type=PublicContact.ContactTypeChoices.TECHNICAL,
+            ),
+            common.DomainContact(
+                contact="adminContact",
+                type=PublicContact.ContactTypeChoices.ADMINISTRATIVE,
+            ),
+        ],
         hosts=["fake.host.com"],
         statuses=[
             common.Status(state="serverTransferProhibited", description="", lang="en"),

--- a/src/registrar/tests/test_admin.py
+++ b/src/registrar/tests/test_admin.py
@@ -28,8 +28,9 @@ from registrar.models import (
     User,
     DomainInvitation,
     Contact,
+    PublicContact,
+    Host,
     Website,
-    DraftDomain,
 )
 from registrar.models.user_domain_role import UserDomainRole
 from registrar.models.verified_by_staff import VerifiedByStaff
@@ -618,6 +619,8 @@ class TestDomainAdmin(MockEppLib, WebTest):
 
     def tearDown(self):
         super().tearDown()
+        PublicContact.objects.all().delete()
+        Host.objects.all().delete()
         Domain.objects.all().delete()
         DomainInformation.objects.all().delete()
         DomainRequest.objects.all().delete()

--- a/src/registrar/tests/test_admin.py
+++ b/src/registrar/tests/test_admin.py
@@ -25,6 +25,7 @@ from registrar.models import (
     Domain,
     DomainRequest,
     DomainInformation,
+    DraftDomain,
     User,
     DomainInvitation,
     Contact,

--- a/src/registrar/tests/test_models_domain.py
+++ b/src/registrar/tests/test_models_domain.py
@@ -129,8 +129,6 @@ class TestDomainCache(MockEppLib):
             # The contact list should not contain what is sent by the registry by default,
             # as _fetch_cache will transform the type to PublicContact
             self.assertNotEqual(domain._cache["contacts"], expectedUnfurledContactsList)
-            # print("!!! domain._cache[contacts] is", domain._cache["contacts"])
-            # print("!!! expectedContactsDict is", expectedContactsDict)
 
             self.assertEqual(domain._cache["contacts"], expectedContactsDict)
 
@@ -213,16 +211,12 @@ class TestDomainCache(MockEppLib):
                 self.mockDataSecurityContact.id,
                 security,
             )
-            # print("self.mockDataInfoContact.id is", self.mockDataInfoContact.id)
-            print("self.mockDataSecurityContact", self.mockDataSecurityContact)
-            print("self.mockDataSecurityContact.id is", self.mockDataSecurityContact.id)
-            print("mapped is", mapped)
 
-            # id and registry_id are the same thing
+            # id, registry_id, and contact are the same thing
             expected_contact = PublicContact(
                 domain=domain,
                 contact_type=security,
-                registry_id="securityContact",  # self.mockDataInfoContact.id
+                registry_id="securityContact",
                 email="security@mail.gov",
                 voice="+1.8882820870",
                 fax="+1-212-9876543",
@@ -240,8 +234,6 @@ class TestDomainCache(MockEppLib):
             # two duplicate objects. We would expect
             # these not to have the same state.
             expected_contact._state = mapped._state
-            print("!!! expected_contact._state is", expected_contact.__dict__)
-            print("!!! mapped.__dict__ is", mapped.__dict__)
             # Mapped object is what we expect
             self.assertEqual(mapped.__dict__, expected_contact.__dict__)
 
@@ -253,13 +245,6 @@ class TestDomainCache(MockEppLib):
                 contact_type=security,
             ).get()
 
-            """
-            !!! db_object is Registry Customer Service <123@mail.gov>id: 123 type: security
-            !!! in_db is Registry Customer Service <123@mail.gov>id: securityContact type: security
-            """
-            print("!!! domain.security_contact.registry_id ", domain.security_contact.registry_id)
-            print("!!! db_object is", db_object)
-            print("!!! in_db is", in_db)
             # DB Object is the same as the mapped object
             self.assertEqual(db_object, in_db)
             domain.security_contact = in_db
@@ -337,6 +322,7 @@ class TestDomainCache(MockEppLib):
         """
         with less_console_noise():
             domain, _ = Domain.objects.get_or_create(name="justnameserver.com")
+            # trigger the getter
             _ = domain.nameservers
             self.assertEqual(domain.state, Domain.State.READY)
             self.assertEqual(PublicContact.objects.filter(domain=domain.id).count(), 0)

--- a/src/registrar/tests/test_models_domain.py
+++ b/src/registrar/tests/test_models_domain.py
@@ -339,6 +339,7 @@ class TestDomainCache(MockEppLib):
         """
         with less_console_noise():
             domain, _ = Domain.objects.get_or_create(name="defaulttechnical.gov")
+            # trigger the getter
             _ = domain.nameservers
             self.assertEqual(domain.state, Domain.State.DNS_NEEDED)
             self.assertEqual(PublicContact.objects.filter(domain=domain.id).count(), 2)

--- a/src/registrar/tests/test_models_domain.py
+++ b/src/registrar/tests/test_models_domain.py
@@ -432,6 +432,7 @@ class TestDomainCreation(MockEppLib):
         DomainInformation.objects.all().delete()
         DomainRequest.objects.all().delete()
         PublicContact.objects.all().delete()
+        Host.objects.all().delete()
         Domain.objects.all().delete()
         User.objects.all().delete()
         DraftDomain.objects.all().delete()

--- a/src/registrar/tests/test_models_domain.py
+++ b/src/registrar/tests/test_models_domain.py
@@ -99,7 +99,7 @@ class TestDomainCache(MockEppLib):
     def test_cache_nested_elements_not_subdomain(self):
         """Cache works correctly with the nested objects cache and hosts"""
         with less_console_noise():
-            domain, _ = Domain.objects.get_or_create(name="igorville.gov")
+            domain, _ = Domain.objects.get_or_create(name="igorville.gov", state=Domain.State.DNS_NEEDED)
             # The contact list will initially contain objects of type 'DomainContact'
             # this is then transformed into PublicContact, and cache should NOT
             # hold onto the DomainContact object
@@ -203,7 +203,7 @@ class TestDomainCache(MockEppLib):
     def test_map_epp_contact_to_public_contact(self):
         # Tests that the mapper is working how we expect
         with less_console_noise():
-            domain, _ = Domain.objects.get_or_create(name="registry.gov")
+            domain, _ = Domain.objects.get_or_create(name="registry.gov", state=Domain.state.DNS_NEEDED)
             security = PublicContact.ContactTypeChoices.SECURITY
             mapped = domain.map_epp_contact_to_public_contact(
                 self.mockDataInfoContact,
@@ -1033,7 +1033,7 @@ class TestRegistrantContacts(MockEppLib):
             And the field `disclose` is set to true for DF.EMAIL
         """
         with less_console_noise():
-            domain, _ = Domain.objects.get_or_create(name="igorville.gov")
+            domain, _ = Domain.objects.get_or_create(name="igorville.gov", domain=Domain.State.DNS_NEEDED)
             expectedSecContact = PublicContact.get_default_security()
             expectedSecContact.domain = domain
             expectedSecContact.email = "123@mail.gov"
@@ -2166,7 +2166,7 @@ class TestRegistrantDNSSEC(MockEppLib):
                         ),
                         cleaned=True,
                     ),
-                    call(commands.InfoHost(name='fake.host.com'), cleaned=True),
+                    call(commands.InfoHost(name="fake.host.com"), cleaned=True),
                     call(
                         commands.UpdateDomain(
                             name="dnssec-dsdata.gov",

--- a/src/registrar/tests/test_models_domain.py
+++ b/src/registrar/tests/test_models_domain.py
@@ -2166,6 +2166,7 @@ class TestRegistrantDNSSEC(MockEppLib):
                         ),
                         cleaned=True,
                     ),
+                    call(commands.InfoHost(name='fake.host.com'), cleaned=True),
                     call(
                         commands.UpdateDomain(
                             name="dnssec-dsdata.gov",

--- a/src/registrar/tests/test_models_domain.py
+++ b/src/registrar/tests/test_models_domain.py
@@ -203,7 +203,7 @@ class TestDomainCache(MockEppLib):
     def test_map_epp_contact_to_public_contact(self):
         # Tests that the mapper is working how we expect
         with less_console_noise():
-            domain, _ = Domain.objects.get_or_create(name="registry.gov", state=Domain.state.DNS_NEEDED)
+            domain, _ = Domain.objects.get_or_create(name="registry.gov", state=Domain.State.DNS_NEEDED)
             security = PublicContact.ContactTypeChoices.SECURITY
             mapped = domain.map_epp_contact_to_public_contact(
                 self.mockDataInfoContact,
@@ -1033,7 +1033,7 @@ class TestRegistrantContacts(MockEppLib):
             And the field `disclose` is set to true for DF.EMAIL
         """
         with less_console_noise():
-            domain, _ = Domain.objects.get_or_create(name="igorville.gov", domain=Domain.State.DNS_NEEDED)
+            domain, _ = Domain.objects.get_or_create(name="igorville.gov", state=Domain.State.DNS_NEEDED)
             expectedSecContact = PublicContact.get_default_security()
             expectedSecContact.domain = domain
             expectedSecContact.email = "123@mail.gov"
@@ -1941,6 +1941,7 @@ class TestRegistrantDNSSEC(MockEppLib):
                         ),
                         cleaned=True,
                     ),
+                    call(commands.InfoHost(name="fake.host.com"), cleaned=True),
                     call(
                         commands.UpdateDomain(
                             name="dnssec-dsdata.gov",

--- a/src/registrar/tests/test_models_domain.py
+++ b/src/registrar/tests/test_models_domain.py
@@ -215,7 +215,7 @@ class TestDomainCache(MockEppLib):
                 domain=domain,
                 contact_type=security,
                 registry_id="123",
-                email="123@mail.gov",
+                email="security@mail.gov",
                 voice="+1.8882820870",
                 fax="+1-212-9876543",
                 pw="lastPw",
@@ -1036,7 +1036,7 @@ class TestRegistrantContacts(MockEppLib):
             domain, _ = Domain.objects.get_or_create(name="igorville.gov", state=Domain.State.DNS_NEEDED)
             expectedSecContact = PublicContact.get_default_security()
             expectedSecContact.domain = domain
-            expectedSecContact.email = "123@mail.gov"
+            expectedSecContact.email = "security@mail.gov"
             domain.security_contact = expectedSecContact
             expectedCreateCommand = self._convertPublicContactToEpp(expectedSecContact, disclose_email=True)
             self.mockedSendFunction.assert_any_call(expectedCreateCommand, cleaned=True)
@@ -2014,6 +2014,13 @@ class TestRegistrantDNSSEC(MockEppLib):
                         ),
                         cleaned=True,
                     ),
+                    call(
+                        commands.InfoDomain(
+                            name="dnssec-dsdata.gov",
+                        ),
+                        cleaned=True,
+                    ),
+                    call(commands.InfoHost(name="fake.host.com"), cleaned=True),
                     call(
                         commands.UpdateDomain(
                             name="dnssec-dsdata.gov",

--- a/src/registrar/tests/test_models_domain.py
+++ b/src/registrar/tests/test_models_domain.py
@@ -213,14 +213,16 @@ class TestDomainCache(MockEppLib):
                 self.mockDataSecurityContact.id,
                 security,
             )
-            print("self.mockDataInfoContact.id is", self.mockDataInfoContact.id)
+            # print("self.mockDataInfoContact.id is", self.mockDataInfoContact.id)
+            print("self.mockDataSecurityContact", self.mockDataSecurityContact)
             print("self.mockDataSecurityContact.id is", self.mockDataSecurityContact.id)
+            print("mapped is", mapped)
 
             # id and registry_id are the same thing
             expected_contact = PublicContact(
                 domain=domain,
                 contact_type=security,
-                registry_id="SECURITY",  # self.mockDataInfoContact.id
+                registry_id="securityContact",  # self.mockDataInfoContact.id
                 email="security@mail.gov",
                 voice="+1.8882820870",
                 fax="+1-212-9876543",
@@ -253,7 +255,7 @@ class TestDomainCache(MockEppLib):
 
             """
             !!! db_object is Registry Customer Service <123@mail.gov>id: 123 type: security
-            !!! in_db is Registry Customer Service <security@mail.gov>id: securityContact type: security
+            !!! in_db is Registry Customer Service <123@mail.gov>id: securityContact type: security
             """
             print("!!! domain.security_contact.registry_id ", domain.security_contact.registry_id)
             print("!!! db_object is", db_object)

--- a/src/registrar/tests/test_reports.py
+++ b/src/registrar/tests/test_reports.py
@@ -263,7 +263,7 @@ class ExportDataTest(MockDb, MockEppLib):
                 "adomain10.gov,Federal,Armed Forces Retirement Home,Ready\n"
                 "adomain2.gov,Interstate,(blank),Dns needed\n"
                 "cdomain11.govFederal-ExecutiveWorldWarICentennialCommissionReady\n"
-                "ddomain3.gov,Federal,Armed Forces Retirement Home,123@mail.gov,On hold,2023-05-25\n"
+                "ddomain3.gov,Federal,Armed Forces Retirement Home,security@mail.gov,On hold,2023-05-25\n"
                 "defaultsecurity.gov,Federal - Executive,World War I Centennial Commission,(blank),Ready\n"
                 "zdomain12.govInterstateReady\n"
             )

--- a/src/registrar/tests/test_reports.py
+++ b/src/registrar/tests/test_reports.py
@@ -263,7 +263,7 @@ class ExportDataTest(MockDb, MockEppLib):
                 "adomain10.gov,Federal,Armed Forces Retirement Home,Ready\n"
                 "adomain2.gov,Interstate,(blank),Dns needed\n"
                 "cdomain11.govFederal-ExecutiveWorldWarICentennialCommissionReady\n"
-                "ddomain3.gov,Federal,Armed Forces Retirement Home,security@mail.gov,On hold,2023-05-25\n"
+                "ddomain3.gov,Federal,Armed Forces Retirement Home,security@mail.gov,On hold,2023-11-15\n"
                 "defaultsecurity.gov,Federal - Executive,World War I Centennial Commission,(blank),Ready\n"
                 "zdomain12.govInterstateReady\n"
             )

--- a/src/registrar/tests/test_views_domain.py
+++ b/src/registrar/tests/test_views_domain.py
@@ -257,7 +257,7 @@ class TestDomainDetail(TestDomainOverview):
             detail_page = home_page.click("Manage", index=0)
             self.assertContains(detail_page, "Expired")
 
-            self.assertContains(detail_page, "DNS needed")
+            self.assertNotContains(detail_page, "DNS needed")
 
     def test_domain_detail_blocked_for_ineligible_user(self):
         """We could easily duplicate this test for all domain management

--- a/src/registrar/tests/test_views_domain.py
+++ b/src/registrar/tests/test_views_domain.py
@@ -235,7 +235,6 @@ class TestDomainDetail(TestDomainOverview):
             self.assertContains(home_page, "DNS needed")
 
     def test_unknown_domain_does_not_show_as_expired_on_detail_page(self):
-        # TODO: Fix the caption of this part
         """An UNKNOWN domain should not exist on the detail_page anymore.
         It shows as 'DNS needed'"""
         # At the time of this test's writing, there are 6 UNKNOWN domains inherited

--- a/src/registrar/tests/test_views_domain.py
+++ b/src/registrar/tests/test_views_domain.py
@@ -235,7 +235,8 @@ class TestDomainDetail(TestDomainOverview):
             self.assertContains(home_page, "DNS needed")
 
     def test_unknown_domain_does_not_show_as_expired_on_detail_page(self):
-        """An UNKNOWN domain does not show as expired on the detail page.
+        # TODO: Fix the caption of this part
+        """An UNKNOWN domain should not exist on the detail_page anymore.
         It shows as 'DNS needed'"""
         # At the time of this test's writing, there are 6 UNKNOWN domains inherited
         # from constructors. Let's reset.
@@ -254,7 +255,7 @@ class TestDomainDetail(TestDomainOverview):
             igorville = Domain.objects.get(name="igorville.gov")
             self.assertEquals(igorville.state, Domain.State.UNKNOWN)
             detail_page = home_page.click("Manage", index=0)
-            self.assertNotContains(detail_page, "Expired")
+            self.assertContains(detail_page, "Expired")
 
             self.assertContains(detail_page, "DNS needed")
 


### PR DESCRIPTION
## Ticket

Resolves #1979 

## Changes

See [previous commits on this original PR](https://github.com/cisagov/manage.get.gov/pull/2017) -- had to create a new PR bc tests were not running for some reason.

We make sure that if it's in the error state of "UNKNOWN" that we remedy it into DNS_NEEDED or READY state by creating the 3 public contacts if needed.

## Context for reviewers

Before we had an error UNKNOWN state and users would get stuck there. Now we remedy that state immediately.

## Setup

A bit hard to replicate the UNKNOWN state :'( Please reference the logic and unit tests and the unit tests that were updated to reflect these changes!

## Code Review Verification Steps

### As the original developer, I have

#### Satisfied acceptance criteria and met development standards

- [ ] Met the acceptance criteria, or will meet them in a subsequent PR
- [ ] Created/modified automated tests
- [ ] Added at least 2 developers as PR reviewers (only 1 will need to approve)
- [ ] Messaged on Slack or in standup to notify the team that a PR is ready for review
- [ ] Changes to “how we do things” are documented in READMEs and or onboarding guide
- [ ] If any model was updated to modify/add/delete columns, makemigrations was ran and the associated migrations file has been commited.

#### Ensured code standards are met (Original Developer)

- [ ] All new functions and methods are commented using plain language
- [ ] Did dependency updates in Pipfile also get changed in requirements.txt?
- [ ] Interactions with external systems are wrapped in try/except
- [ ] Error handling exists for unusual or missing values

#### Validated user-facing changes (if applicable)

- [ ] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Checked keyboard navigability
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)
- [ ] Add at least 1 designer as PR reviewer

### As a code reviewer, I have

#### Reviewed, tested, and left feedback about the changes

- [ ] Pulled this branch locally and tested it
- [ ] Reviewed this code and left comments
- [ ] Checked that all code is adequately covered by tests
- [ ] Made it clear which comments need to be addressed before this work is merged
- [ ] If any model was updated to modify/add/delete columns, makemigrations was ran and the associated migrations file has been commited.

#### Ensured code standards are met (Code reviewer)

- [ ] All new functions and methods are commented using plain language
- [ ] Interactions with external systems are wrapped in try/except
- [ ] Error handling exists for unusual or missing values
- [ ] (Rarely needed) Did dependency updates in Pipfile also get changed in requirements.txt?

#### Validated user-facing changes as a developer

- [ ] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Checked keyboard navigability
- [ ] Meets all designs and user flows provided by design/product
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)

- [ ] Tested with multiple browsers, the suggestion is to use ones that the developer didn't (check off which ones were used)
  - [ ] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari

- [ ] (Rarely needed) Tested as both an analyst and applicant user

**Note:** Multiple code reviewers can share the checklists above, a second reviewers should not make a duplicate checklist

### As a designer reviewer, I have

#### Verified that the changes match the design intention

- [ ] Checked that the design translated visually
- [ ] Checked behavior
- [ ] Checked different states (empty, one, some, error)
- [ ] Checked for landmarks, page heading structure, and links
- [ ] Tried to break the intended flow

#### Validated user-facing changes as a designer

- [ ] Checked keyboard navigability
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)

- [ ] Tested with multiple browsers (check off which ones were used)
  - [ ] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari

- [ ] (Rarely needed) Tested as both an analyst and applicant user

## Screenshots

<!-- If this PR makes visible interface changes, an image of the finished interface can help reviewers
and casual observers understand the context of the changes.
A before image is optional and can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow.
You may want to use [GIPHY Capture](https://giphy.com/apps/giphycapture) for this! 📸

_Please frame images to show useful context but also highlight the affected regions._
--->
