### PR TITLE
Issue #1777: Allow blanking of first and/or second nameserver if enough entries are present (rjm)

### DIFF
--- a/src/registrar/assets/js/get-gov.js
+++ b/src/registrar/assets/js/get-gov.js
@@ -776,7 +776,7 @@ function toggleTwoDomElements(ele1, ele2, index) {
     let forms = document.querySelectorAll(".repeatable-form");
     if (forms.length < 3) {
       // Hide the delete buttons on the 2 nameservers
-      forms.forEach((form, index) => {
+      forms.forEach((form) => {
         Array.from(form.querySelectorAll('.delete-record')).forEach((deleteButton) => {
           deleteButton.setAttribute("disabled", "true");
         });

--- a/src/registrar/assets/js/get-gov.js
+++ b/src/registrar/assets/js/get-gov.js
@@ -530,7 +530,7 @@ function hideDeletedForms() {
   let isDotgovDomain = document.querySelector(".dotgov-domain-form");
   // The Nameservers formset features 2 required and 11 optionals
   if (isNameserversForm) {
-    cloneIndex = 2;
+    // cloneIndex = 2;
     formLabel = "Name server";
   // DNSSEC: DS Data
   } else if (isDsDataForm) {
@@ -766,3 +766,21 @@ function toggleTwoDomElements(ele1, ele2, index) {
   }
 })();
 
+/**
+ * An IIFE that listens to the other contacts radio form on DAs and toggles the contacts/no other contacts forms 
+ *
+ */
+(function otherContactsFormListener() {
+  let isNameserversForm = document.querySelector(".nameservers-form");
+  if (isNameserversForm) {
+    let forms = document.querySelectorAll(".repeatable-form");
+    if (forms.length < 3) {
+      // Hide the delete buttons on the 2 nameservers
+      forms.forEach((form, index) => {
+        Array.from(form.querySelectorAll('.delete-record')).forEach((deleteButton) => {
+          deleteButton.setAttribute("disabled", "true");
+        });
+      });
+    }
+  }
+})();

--- a/src/registrar/assets/js/get-gov.js
+++ b/src/registrar/assets/js/get-gov.js
@@ -767,10 +767,10 @@ function toggleTwoDomElements(ele1, ele2, index) {
 })();
 
 /**
- * An IIFE that listens to the other contacts radio form on DAs and toggles the contacts/no other contacts forms 
+ * An IIFE that disables the delete buttons on nameserver forms on page load if < 3 forms
  *
  */
-(function otherContactsFormListener() {
+(function nameserversFormListener() {
   let isNameserversForm = document.querySelector(".nameservers-form");
   if (isNameserversForm) {
     let forms = document.querySelectorAll(".repeatable-form");

--- a/src/registrar/forms/domain.py
+++ b/src/registrar/forms/domain.py
@@ -181,6 +181,9 @@ class BaseNameserverFormset(forms.BaseFormSet):
         for index, form in enumerate(self.forms):
             if form.cleaned_data:
                 value = form.cleaned_data["server"]
+                # We need to make sure not to trigger the duplicate error in case the first and second nameservers are empty
+                # If there are enough records in the formset, that error is an unecessary blocker. If there aren't, the required
+                # error will block the submit.
                 if value in data and not (form.cleaned_data.get("server", "").strip() == '' and index == 1):
                     form.add_error(
                         "server",

--- a/src/registrar/forms/domain.py
+++ b/src/registrar/forms/domain.py
@@ -178,10 +178,10 @@ class BaseNameserverFormset(forms.BaseFormSet):
         data = []
         duplicates = []
 
-        for form in self.forms:
+        for index, form in enumerate(self.forms):
             if form.cleaned_data:
                 value = form.cleaned_data["server"]
-                if value in data:
+                if value in data and not (form.cleaned_data.get("server", "").strip() == '' and index == 1):
                     form.add_error(
                         "server",
                         NameserverError(code=nsErrorCodes.DUPLICATE_HOST, nameserver=value),

--- a/src/registrar/forms/domain.py
+++ b/src/registrar/forms/domain.py
@@ -99,7 +99,7 @@ class DomainNameserverForm(forms.Form):
         ip_list = self.extract_ip_list(ip)
 
         # Capture the server_value
-        server_value = self.cleaned_data["server"]
+        server_value = self.cleaned_data.get("server")
 
         # Validate if the form has a server or an ip
         if (ip and ip_list) or server:

--- a/src/registrar/forms/domain.py
+++ b/src/registrar/forms/domain.py
@@ -181,10 +181,10 @@ class BaseNameserverFormset(forms.BaseFormSet):
         for index, form in enumerate(self.forms):
             if form.cleaned_data:
                 value = form.cleaned_data["server"]
-                # We need to make sure not to trigger the duplicate error in case the first and second nameservers are empty
-                # If there are enough records in the formset, that error is an unecessary blocker. If there aren't, the required
-                # error will block the submit.
-                if value in data and not (form.cleaned_data.get("server", "").strip() == '' and index == 1):
+                # We need to make sure not to trigger the duplicate error in case the first and second nameservers
+                # are empty. If there are enough records in the formset, that error is an unecessary blocker.
+                # If there aren't, the required error will block the submit.
+                if value in data and not (form.cleaned_data.get("server", "").strip() == "" and index == 1):
                     form.add_error(
                         "server",
                         NameserverError(code=nsErrorCodes.DUPLICATE_HOST, nameserver=value),

--- a/src/registrar/tests/common.py
+++ b/src/registrar/tests/common.py
@@ -1153,7 +1153,7 @@ class MockEppLib(TestCase):
     )
 
     infoDomainFourHosts = fakedEppObject(
-        "my-nameserver.gov",
+        "fournameserversDomain.gov",
         cr_date=make_aware(datetime(2023, 5, 25, 19, 45, 35)),
         contacts=[],
         hosts=[
@@ -1464,7 +1464,9 @@ class MockEppLib(TestCase):
                 )
 
     def mockInfoDomainCommands(self, _request, cleaned):
-        request_name = getattr(_request, "name", None)
+        request_name = getattr(_request, "name", None).lower()
+
+        print(request_name)
 
         # Define a dictionary to map request names to data and extension values
         request_mappings = {
@@ -1486,8 +1488,8 @@ class MockEppLib(TestCase):
             "nameserverwithip.gov": (self.infoDomainHasIP, None),
             "namerserversubdomain.gov": (self.infoDomainCheckHostIPCombo, None),
             "freeman.gov": (self.InfoDomainWithContacts, None),
-            "threenameserversDomain.gov": (self.infoDomainThreeHosts, None),
-            "fournameserversDomain.gov": (self.infoDomainFourHosts, None),
+            "threenameserversdomain.gov": (self.infoDomainThreeHosts, None),
+            "fournameserversdomain.gov": (self.infoDomainFourHosts, None),
             "defaultsecurity.gov": (self.InfoDomainWithDefaultSecurityContact, None),
             "adomain2.gov": (self.InfoDomainWithVerisignSecurityContact, None),
             "defaulttechnical.gov": (self.InfoDomainWithDefaultTechnicalContact, None),

--- a/src/registrar/tests/common.py
+++ b/src/registrar/tests/common.py
@@ -1152,6 +1152,18 @@ class MockEppLib(TestCase):
         ],
     )
 
+    infoDomainFourHosts = fakedEppObject(
+        "my-nameserver.gov",
+        cr_date=make_aware(datetime(2023, 5, 25, 19, 45, 35)),
+        contacts=[],
+        hosts=[
+            "ns1.my-nameserver-1.com",
+            "ns1.my-nameserver-2.com",
+            "ns1.cats-are-superior3.com",
+            "ns1.explosive-chicken-nuggets.com",
+        ],
+    )
+
     infoDomainNoHost = fakedEppObject(
         "my-nameserver.gov",
         cr_date=make_aware(datetime(2023, 5, 25, 19, 45, 35)),
@@ -1475,6 +1487,7 @@ class MockEppLib(TestCase):
             "namerserversubdomain.gov": (self.infoDomainCheckHostIPCombo, None),
             "freeman.gov": (self.InfoDomainWithContacts, None),
             "threenameserversDomain.gov": (self.infoDomainThreeHosts, None),
+            "fournameserversDomain.gov": (self.infoDomainFourHosts, None),
             "defaultsecurity.gov": (self.InfoDomainWithDefaultSecurityContact, None),
             "adomain2.gov": (self.InfoDomainWithVerisignSecurityContact, None),
             "defaulttechnical.gov": (self.InfoDomainWithDefaultTechnicalContact, None),

--- a/src/registrar/tests/test_views_domain.py
+++ b/src/registrar/tests/test_views_domain.py
@@ -974,6 +974,68 @@ class TestDomainNameservers(TestDomainOverview):
         page = result.follow()
         self.assertContains(page, "The name servers for this domain have been updated")
 
+    def test_domain_nameservers_can_blank_out_first_or_second_one_if_enough_entries(self):
+        """Nameserver form submits successfully with 2 valid inputs, even if the first or
+        second entries are blanked out.
+
+        Uses self.app WebTest because we need to interact with forms.
+        """
+
+        nameserver1 = ""
+        nameserver2 = "ns2.igorville.gov"
+        nameserver3 = "ns3.igorville.gov"
+        valid_ip = ""
+        valid_ip_2 = "128.0.0.2"
+        valid_ip_3 = "128.0.0.3"
+        nameservers_page = self.app.get(reverse("domain-dns-nameservers", kwargs={"pk": self.domain.id}))
+        session_id = self.app.cookies[settings.SESSION_COOKIE_NAME]
+        self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
+        nameservers_page.form["form-0-server"] = nameserver1
+        nameservers_page.form["form-0-ip"] = valid_ip
+        nameservers_page.form["form-1-server"] = nameserver2
+        nameservers_page.form["form-1-ip"] = valid_ip_2
+        nameservers_page.form["form-2-server"] = nameserver3
+        nameservers_page.form["form-2-ip"] = valid_ip_3
+        with less_console_noise():  # swallow log warning message
+            result = nameservers_page.form.submit()
+
+        # form submission was a successful post, response should be a 302
+        self.assertEqual(result.status_code, 302)
+        self.assertEqual(
+            result["Location"],
+            reverse("domain-dns-nameservers", kwargs={"pk": self.domain.id}),
+        )
+        self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
+        nameservers_page = result.follow()
+        self.assertContains(nameservers_page, "The name servers for this domain have been updated")
+
+        nameserver1 = "ns1.igorville.gov"
+        nameserver2 = ""
+        nameserver3 = "ns3.igorville.gov"
+        valid_ip = "128.0.0.1"
+        valid_ip_2 = ""
+        valid_ip_3 = "128.0.0.3"
+        session_id = self.app.cookies[settings.SESSION_COOKIE_NAME]
+        self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
+        nameservers_page.form["form-0-server"] = nameserver1
+        nameservers_page.form["form-0-ip"] = valid_ip
+        nameservers_page.form["form-1-server"] = nameserver2
+        nameservers_page.form["form-1-ip"] = valid_ip_2
+        nameservers_page.form["form-2-server"] = nameserver3
+        nameservers_page.form["form-2-ip"] = valid_ip_3
+        with less_console_noise():  # swallow log warning message
+            result = nameservers_page.form.submit()
+
+        # form submission was a successful post, response should be a 302
+        self.assertEqual(result.status_code, 302)
+        self.assertEqual(
+            result["Location"],
+            reverse("domain-dns-nameservers", kwargs={"pk": self.domain.id}),
+        )
+        self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
+        nameservers_page = result.follow()
+        self.assertContains(nameservers_page, "The name servers for this domain have been updated")
+
     def test_domain_nameservers_form_invalid(self):
         """Nameserver form does not submit with invalid data.
 


### PR DESCRIPTION
## Ticket

Resolves #1777 
<!--Reminder, when a code change is made that is user facing, beyond content updates, then the following are required:
- a developer approves the PR
- a designer approves the PR or checks off all relevant items in this checklist.

All other changes require just a single approving review.-->

## Changes

<!-- What was added, updated, or removed in this PR. -->
- Don't let the nameserver form clean remove the entered data
- Use the data in the nameserver formset clean to see whether we have enough entries
- Fix an undiscovered bug where if you submit a formset with only 2 visible forms that subsequently errors, you cannot add a new form to the formset after the failed submission
- Fix an undiscovered bug where if you submit a formset with only 2 visible forms that subsequently errors, you can still click on 'delete' for forms 1 and 2 (that delete should be disabled and unclickable)

<!--
    Please add/remove/edit any of the template below to fit the needs
    of this specific PR.
--->

## Context for reviewers

<!--Background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers.  -->

Make sure to test for the 2 undiscovered bug fixes mentioned above.

## Setup

<!--  Add any steps or code to run in this section to help others run your code.
    
    Example 1:
    ```sh
    echo "Code goes here"
    ``` 
    
    Example 2: If the PR was to add a new link with a redirect, this section could simply be:
    -go to /path/to/start/page
    -click the blue link in the <insert location>
    -notice user is redirected to <proper end location>
-->

## Code Review Verification Steps

### As the original developer, I have

#### Satisfied acceptance criteria and met development standards

- [x] Met the acceptance criteria, or will meet them in a subsequent PR
- [x] Created/modified automated tests
- [x] Added at least 2 developers as PR reviewers (only 1 will need to approve)
- [x] Messaged on Slack or in standup to notify the team that a PR is ready for review
- [ ] Changes to “how we do things” are documented in READMEs and or onboarding guide
- [ ] If any model was updated to modify/add/delete columns, makemigrations was ran and the associated migrations file has been commited.

#### Ensured code standards are met (Original Developer)

- [x] All new functions and methods are commented using plain language
- [ ] Did dependency updates in Pipfile also get changed in requirements.txt?
- [ ] Interactions with external systems are wrapped in try/except
- [ ] Error handling exists for unusual or missing values

#### Validated user-facing changes (if applicable)

- [ ] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Checked keyboard navigability
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)
- [ ] Add at least 1 designer as PR reviewer

### As a code reviewer, I have

#### Reviewed, tested, and left feedback about the changes

- [ ] Pulled this branch locally and tested it
- [ ] Reviewed this code and left comments
- [ ] Checked that all code is adequately covered by tests
- [ ] Made it clear which comments need to be addressed before this work is merged
- [ ] If any model was updated to modify/add/delete columns, makemigrations was ran and the associated migrations file has been commited.

#### Ensured code standards are met (Code reviewer)

- [ ] All new functions and methods are commented using plain language
- [ ] Interactions with external systems are wrapped in try/except
- [ ] Error handling exists for unusual or missing values
- [ ] (Rarely needed) Did dependency updates in Pipfile also get changed in requirements.txt?

#### Validated user-facing changes as a developer

- [ ] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Checked keyboard navigability
- [ ] Meets all designs and user flows provided by design/product
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)

- [ ] Tested with multiple browsers, the suggestion is to use ones that the developer didn't (check off which ones were used)
  - [ ] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari

- [ ] (Rarely needed) Tested as both an analyst and applicant user

**Note:** Multiple code reviewers can share the checklists above, a second reviewers should not make a duplicate checklist

### As a designer reviewer, I have

#### Verified that the changes match the design intention

- [ ] Checked that the design translated visually
- [ ] Checked behavior
- [ ] Checked different states (empty, one, some, error)
- [ ] Checked for landmarks, page heading structure, and links
- [ ] Tried to break the intended flow

#### Validated user-facing changes as a designer

- [ ] Checked keyboard navigability
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)

- [ ] Tested with multiple browsers (check off which ones were used)
  - [ ] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari

- [ ] (Rarely needed) Tested as both an analyst and applicant user

## Screenshots

<!-- If this PR makes visible interface changes, an image of the finished interface can help reviewers
and casual observers understand the context of the changes.
A before image is optional and can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow.
You may want to use [GIPHY Capture](https://giphy.com/apps/giphycapture) for this! 📸

_Please frame images to show useful context but also highlight the affected regions._
--->
