### PR TITLE
Issue #1983: default filter applied when clicking domain requests from editing a domain request

### DIFF
--- a/src/registrar/admin.py
+++ b/src/registrar/admin.py
@@ -1455,8 +1455,9 @@ class DomainRequestAdmin(ListHeaderAdmin):
                 # find the index to determine the referring url after the path
                 index = http_referer.find(request.path)
                 # Check if there is a character following the path in http_referer
-                if index + len(request.path) < len(http_referer):
-                    next_char = http_referer[index + len(request.path)]
+                next_char_index = index + len(request.path)
+                if index + next_char_index < len(http_referer):
+                    next_char = http_referer[next_char_index]
 
                     # Check if the next character is a digit, if so, this indicates
                     # a change view for domain request

--- a/src/registrar/admin.py
+++ b/src/registrar/admin.py
@@ -1435,12 +1435,35 @@ class DomainRequestAdmin(ListHeaderAdmin):
         """
         Override changelist_view to set the selected value of status filter.
         """
+        # there are two conditions which should set the default selected filter:
+        # 1 - there are no query parameters in the request and the request is the
+        #     initial request for this view
+        # 2 - there are no query parameters in the request and the referring url is
+        #     the change view for a domain request
+        should_apply_default_filter = False
         # use http_referer in order to distinguish between request as a link from another page
         # and request as a removal of all filters
         http_referer = request.META.get("HTTP_REFERER", "")
         # if there are no query parameters in the request
-        # and the request is the initial request for this view
-        if not bool(request.GET) and request.path not in http_referer:
+        if not bool(request.GET):
+            # if the request is the initial request for this view
+            if request.path not in http_referer:
+                should_apply_default_filter = True
+            # elif the request is a referral from changelist view or from
+            # domain request change view
+            elif request.path in http_referer:
+                # find the index to determine the referring url after the path
+                index = http_referer.find(request.path)
+                # Check if there is a character following the path in http_referer
+                if index + len(request.path) < len(http_referer):
+                    next_char = http_referer[index + len(request.path)]
+
+                    # Check if the next character is a digit, if so, this indicates
+                    # a change view for domain request
+                    if next_char.isdigit():
+                        should_apply_default_filter = True
+
+        if should_apply_default_filter:
             # modify the GET of the request to set the selected filter
             modified_get = copy.deepcopy(request.GET)
             modified_get["status__in"] = "submitted,in review,action needed"


### PR DESCRIPTION
## Ticket

Resolves #1983 
<!--Reminder, when a code change is made that is user facing, beyond content updates, then the following are required:
- a developer approves the PR
- a designer approves the PR or checks off all relevant items in this checklist.

All other changes require just a single approving review.-->

## Changes

<!-- What was added, updated, or removed in this PR. -->
- Adjusted behavior for applying default select filter on domain requests list to include applying the filter when a user clicks "Domain requests" in the left nav from the change view of a domain request.

<!--
    Please add/remove/edit any of the template below to fit the needs
    of this specific PR.
--->

## Context for reviewers

<!--Background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers.  -->

Navigate to Domain Requests list in django admin.  Note that the default filter is applied.  Verify that both scenarios below work as expected:

1. Click on a domain request in the list.  Click the Domain Requests link in the left nav and verify that the default filter is applied
2. Click on a domain request in the list.  Click Back button in browser.  Verify that the default filter is applied.

## Setup

<!--  Add any steps or code to run in this section to help others run your code.
    
    Example 1:
    ```sh
    echo "Code goes here"
    ``` 
    
    Example 2: If the PR was to add a new link with a redirect, this section could simply be:
    -go to /path/to/start/page
    -click the blue link in the <insert location>
    -notice user is redirected to <proper end location>
-->

## Code Review Verification Steps

### As the original developer, I have

#### Satisfied acceptance criteria and met development standards

- [ ] Met the acceptance criteria, or will meet them in a subsequent PR
- [ ] Created/modified automated tests
- [ ] Added at least 2 developers as PR reviewers (only 1 will need to approve)
- [ ] Messaged on Slack or in standup to notify the team that a PR is ready for review
- [ ] Changes to “how we do things” are documented in READMEs and or onboarding guide
- [ ] If any model was updated to modify/add/delete columns, makemigrations was ran and the associated migrations file has been commited.

#### Ensured code standards are met (Original Developer)

- [ ] All new functions and methods are commented using plain language
- [ ] Did dependency updates in Pipfile also get changed in requirements.txt?
- [ ] Interactions with external systems are wrapped in try/except
- [ ] Error handling exists for unusual or missing values

#### Validated user-facing changes (if applicable)

- [ ] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Checked keyboard navigability
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)
- [ ] Add at least 1 designer as PR reviewer

### As a code reviewer, I have

#### Reviewed, tested, and left feedback about the changes

- [ ] Pulled this branch locally and tested it
- [ ] Reviewed this code and left comments
- [ ] Checked that all code is adequately covered by tests
- [ ] Made it clear which comments need to be addressed before this work is merged
- [ ] If any model was updated to modify/add/delete columns, makemigrations was ran and the associated migrations file has been commited.

#### Ensured code standards are met (Code reviewer)

- [ ] All new functions and methods are commented using plain language
- [ ] Interactions with external systems are wrapped in try/except
- [ ] Error handling exists for unusual or missing values
- [ ] (Rarely needed) Did dependency updates in Pipfile also get changed in requirements.txt?

#### Validated user-facing changes as a developer

- [ ] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Checked keyboard navigability
- [ ] Meets all designs and user flows provided by design/product
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)

- [ ] Tested with multiple browsers, the suggestion is to use ones that the developer didn't (check off which ones were used)
  - [ ] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari

- [ ] (Rarely needed) Tested as both an analyst and applicant user

**Note:** Multiple code reviewers can share the checklists above, a second reviewers should not make a duplicate checklist

### As a designer reviewer, I have

#### Verified that the changes match the design intention

- [ ] Checked that the design translated visually
- [ ] Checked behavior
- [ ] Checked different states (empty, one, some, error)
- [ ] Checked for landmarks, page heading structure, and links
- [ ] Tried to break the intended flow

#### Validated user-facing changes as a designer

- [ ] Checked keyboard navigability
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)

- [ ] Tested with multiple browsers (check off which ones were used)
  - [ ] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari

- [ ] (Rarely needed) Tested as both an analyst and applicant user

## Screenshots

<!-- If this PR makes visible interface changes, an image of the finished interface can help reviewers
and casual observers understand the context of the changes.
A before image is optional and can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow.
You may want to use [GIPHY Capture](https://giphy.com/apps/giphycapture) for this! 📸

_Please frame images to show useful context but also highlight the affected regions._
--->
