### PR TITLE
Issue #2057: Manage user phone number - (no sandbox)

### DIFF
--- a/src/djangooidc/backends.py
+++ b/src/djangooidc/backends.py
@@ -85,9 +85,7 @@ class OpenIdConnectBackend(ModelBackend):
         for key, value in kwargs.items():
             # Check if the field is not 'first_name', 'last_name', or 'phone',
             # or if it's 'first_name' or 'last_name' or 'phone' and the provided value is not empty
-            if key not in fields_to_check or (
-                key in fields_to_check and value
-            ):
+            if key not in fields_to_check or (key in fields_to_check and value):
                 # Update the corresponding attribute of the user object
                 setattr(user, key, value)
 

--- a/src/djangooidc/backends.py
+++ b/src/djangooidc/backends.py
@@ -76,7 +76,6 @@ class OpenIdConnectBackend(ModelBackend):
             This method updates user fields while preserving the values of 'first_name',
             'last_name', and 'phone' fields, unless specific conditions are met.
 
-            - 'phone' field will be updated if it's None or an empty string.
             - 'first_name', 'last_name' or 'phone' will be updated if the provided value is not empty.
         """
 

--- a/src/djangooidc/backends.py
+++ b/src/djangooidc/backends.py
@@ -65,13 +65,35 @@ class OpenIdConnectBackend(ModelBackend):
         return user
 
     def update_existing_user(self, user, kwargs):
-        """Update other fields without overwriting first_name and last_name.
-        Overwrite first_name and last_name if not empty string"""
+        """
+        Update user fields without overwriting certain fields.
 
+        Args:
+            user: User object to be updated.
+            kwargs: Dictionary containing fields to update and their new values.
+
+        Note:
+            This method updates user fields while preserving the values of 'first_name',
+            'last_name', and 'phone' fields, unless specific conditions are met.
+
+            - 'phone' field will be updated if it's None or an empty string.
+            - 'first_name' and 'last_name' will be updated if the provided value is not empty.
+        """
+
+        # Iterate over fields to update
         for key, value in kwargs.items():
-            # Check if the key is not first_name or last_name or value is not empty string
-            if key not in ["first_name", "last_name"] or value:
+            # Check if the field is not 'first_name', 'last_name', or 'phone',
+            # or if it's the 'phone' field and 'user.phone' is None or empty,
+            # or if it's 'first_name' or 'last_name' and the provided value is not empty
+            if (
+                key not in ["first_name", "last_name", "phone"]
+                or (key == "phone" and (user.phone is None or user.phone == ""))
+                or (key in ["first_name", "last_name"] and value)
+            ):
+                # Update the corresponding attribute of the user object
                 setattr(user, key, value)
+
+        # Save the user object with the updated fields
         user.save()
 
     def clean_username(self, username):

--- a/src/djangooidc/backends.py
+++ b/src/djangooidc/backends.py
@@ -79,12 +79,14 @@ class OpenIdConnectBackend(ModelBackend):
             - 'first_name', 'last_name' or 'phone' will be updated if the provided value is not empty.
         """
 
+        fields_to_check = ["first_name", "last_name", "phone"]
+
         # Iterate over fields to update
         for key, value in kwargs.items():
             # Check if the field is not 'first_name', 'last_name', or 'phone',
             # or if it's 'first_name' or 'last_name' or 'phone' and the provided value is not empty
-            if key not in ["first_name", "last_name", "phone"] or (
-                key in ["first_name", "last_name", "phone"] and value
+            if key not in fields_to_check or (
+                key in fields_to_check and value
             ):
                 # Update the corresponding attribute of the user object
                 setattr(user, key, value)

--- a/src/djangooidc/backends.py
+++ b/src/djangooidc/backends.py
@@ -8,8 +8,6 @@ from django.contrib.auth import get_user_model
 from django.contrib.auth.backends import ModelBackend
 from django.utils import timezone
 
-from registrar.models.contact import Contact
-
 logger = logging.getLogger(__name__)
 
 
@@ -79,26 +77,15 @@ class OpenIdConnectBackend(ModelBackend):
             'last_name', and 'phone' fields, unless specific conditions are met.
 
             - 'phone' field will be updated if it's None or an empty string.
-            - 'first_name' and 'last_name' will be updated if the provided value is not empty.
+            - 'first_name', 'last_name' or 'phone' will be updated if the provided value is not empty.
         """
-
-        contacts = Contact.objects.filter(user=user)
-
-        if len(contacts) == 0:  # no matching contact
-            logger.warning("Could not find a contact when one should've existed.")
-
-        if len(contacts) > 1:  # multiple matches
-            logger.warning("There are multiple Contacts with the same email address.")
 
         # Iterate over fields to update
         for key, value in kwargs.items():
             # Check if the field is not 'first_name', 'last_name', or 'phone',
-            # or if it's the 'phone' field and 'user.phone' is None or empty,
-            # or if it's 'first_name' or 'last_name' and the provided value is not empty
-            if (
-                key not in ["first_name", "last_name", "phone"]
-                or (key == "phone" and not contacts[0].phone)
-                or (key in ["first_name", "last_name"] and value)
+            # or if it's 'first_name' or 'last_name' or 'phone' and the provided value is not empty
+            if key not in ["first_name", "last_name", "phone"] or (
+                key in ["first_name", "last_name", "phone"] and value
             ):
                 # Update the corresponding attribute of the user object
                 setattr(user, key, value)

--- a/src/djangooidc/tests/test_backends.py
+++ b/src/djangooidc/tests/test_backends.py
@@ -64,6 +64,7 @@ class OpenIdConnectBackendTestCase(TestCase):
         # Remove given_name and family_name from the input, self.kwargs
         self.kwargs.pop("given_name", None)
         self.kwargs.pop("family_name", None)
+        self.kwargs.pop("phone", None)
 
         # Ensure that the authenticate method updates the existing user
         # and preserves existing first and last names
@@ -78,53 +79,13 @@ class OpenIdConnectBackendTestCase(TestCase):
         self.assertEqual(user.email, "john.doe@example.com")
         self.assertEqual(user.phone, "9999999999")
 
-    def test_authenticate_with_existing_user_with_no_phone_will_update_phone(self):
-        """Test that authenticate updates an existing user if it finds one.
-        For this test, the existing user has an empty string for phone
-
-        The existing user's phone number is overwritten"""
-        # Create an existing user with the same username and with first and last names
-        existing_user = User.objects.create_user(username="test_user", phone="")
-
-        # Ensure that the authenticate method updates the existing user
-        # and preserves existing first and last names
-        user = self.backend.authenticate(request=None, **self.kwargs)
-        self.assertIsNotNone(user)
-        self.assertIsInstance(user, User)
-        self.assertEqual(user, existing_user)  # The same user instance should be returned
-
-        # Verify that user fields are correctly updated
-        self.assertEqual(user.first_name, "John")
-        self.assertEqual(user.last_name, "Doe")
-        self.assertEqual(user.email, "john.doe@example.com")
-        self.assertEqual(user.phone, "123456789")
-
-    def test_authenticate_with_existing_user_with_none_phone_will_update_phone(self):
-        """Test that authenticate updates an existing user if it finds one.
-        For this test, the existing user has None for phone
-
-        The existing user's phone number is overwritten"""
-        # Create an existing user with the same username and with first and last names
-        existing_user = User.objects.create_user(username="test_user")
-
-        # Ensure that the authenticate method updates the existing user
-        # and preserves existing first and last names
-        user = self.backend.authenticate(request=None, **self.kwargs)
-        self.assertIsNotNone(user)
-        self.assertIsInstance(user, User)
-        self.assertEqual(user, existing_user)  # The same user instance should be returned
-
-        # Verify that user fields are correctly updated
-        self.assertEqual(user.first_name, "John")
-        self.assertEqual(user.last_name, "Doe")
-        self.assertEqual(user.email, "john.doe@example.com")
-        self.assertEqual(user.phone, "123456789")
-
-    def test_authenticate_with_existing_user_different_name(self):
+    def test_authenticate_with_existing_user_different_name_phone(self):
         """Test that authenticate updates an existing user if it finds one.
         For this test, given_name and family_name are supplied and overwrite"""
         # Create an existing user with the same username and with first and last names
-        existing_user = User.objects.create_user(username="test_user", first_name="WillBe", last_name="Replaced")
+        existing_user = User.objects.create_user(
+            username="test_user", first_name="WillBe", last_name="Replaced", phone="987654321"
+        )
 
         # Ensure that the authenticate method updates the existing user
         # and preserves existing first and last names

--- a/src/djangooidc/tests/test_backends.py
+++ b/src/djangooidc/tests/test_backends.py
@@ -50,15 +50,62 @@ class OpenIdConnectBackendTestCase(TestCase):
         self.assertEqual(user.email, "john.doe@example.com")
         self.assertEqual(user.phone, "123456789")
 
-    def test_authenticate_with_existing_user_no_name(self):
+    def test_authenticate_with_existing_user_with_existing_first_last_phone(self):
         """Test that authenticate updates an existing user if it finds one.
-        For this test, given_name and family_name are not supplied"""
+        For this test, given_name and family_name are not supplied.
+
+        The existing user's first and last name are not overwritten.
+        The existing user's phone number is not overwritten"""
         # Create an existing user with the same username and with first and last names
-        existing_user = User.objects.create_user(username="test_user", first_name="John", last_name="Doe")
+        existing_user = User.objects.create_user(
+            username="test_user", first_name="WillNotBe", last_name="Replaced", phone="9999999999"
+        )
 
         # Remove given_name and family_name from the input, self.kwargs
         self.kwargs.pop("given_name", None)
         self.kwargs.pop("family_name", None)
+
+        # Ensure that the authenticate method updates the existing user
+        # and preserves existing first and last names
+        user = self.backend.authenticate(request=None, **self.kwargs)
+        self.assertIsNotNone(user)
+        self.assertIsInstance(user, User)
+        self.assertEqual(user, existing_user)  # The same user instance should be returned
+
+        # Verify that user fields are correctly updated
+        self.assertEqual(user.first_name, "WillNotBe")
+        self.assertEqual(user.last_name, "Replaced")
+        self.assertEqual(user.email, "john.doe@example.com")
+        self.assertEqual(user.phone, "9999999999")
+
+    def test_authenticate_with_existing_user_with_no_phone_will_update_phone(self):
+        """Test that authenticate updates an existing user if it finds one.
+        For this test, the existing user has an empty string for phone
+
+        The existing user's phone number is overwritten"""
+        # Create an existing user with the same username and with first and last names
+        existing_user = User.objects.create_user(username="test_user", phone="")
+
+        # Ensure that the authenticate method updates the existing user
+        # and preserves existing first and last names
+        user = self.backend.authenticate(request=None, **self.kwargs)
+        self.assertIsNotNone(user)
+        self.assertIsInstance(user, User)
+        self.assertEqual(user, existing_user)  # The same user instance should be returned
+
+        # Verify that user fields are correctly updated
+        self.assertEqual(user.first_name, "John")
+        self.assertEqual(user.last_name, "Doe")
+        self.assertEqual(user.email, "john.doe@example.com")
+        self.assertEqual(user.phone, "123456789")
+
+    def test_authenticate_with_existing_user_with_none_phone_will_update_phone(self):
+        """Test that authenticate updates an existing user if it finds one.
+        For this test, the existing user has None for phone
+
+        The existing user's phone number is overwritten"""
+        # Create an existing user with the same username and with first and last names
+        existing_user = User.objects.create_user(username="test_user")
 
         # Ensure that the authenticate method updates the existing user
         # and preserves existing first and last names

--- a/src/registrar/models/contact.py
+++ b/src/registrar/models/contact.py
@@ -101,12 +101,23 @@ class Contact(TimeStampedModel):
         # Call the parent class's save method to perform the actual save
         super().save(*args, **kwargs)
 
-        # Update the related User object's first_name and last_name
-        if self.user and (not self.user.first_name or not self.user.last_name or not self.user.phone):
-            self.user.first_name = self.first_name
-            self.user.last_name = self.last_name
-            self.user.phone = self.phone
-            self.user.save()
+        if self.user:
+            updated = False
+
+            # Update first name and last name if necessary
+            if not self.user.first_name or not self.user.last_name:
+                self.user.first_name = self.first_name
+                self.user.last_name = self.last_name
+                updated = True
+
+            # Update phone if necessary
+            if not self.user.phone:
+                self.user.phone = self.phone
+                updated = True
+
+            # Save user if any updates were made
+            if updated:
+                self.user.save()
 
     def __str__(self):
         if self.first_name or self.last_name:

--- a/src/registrar/models/contact.py
+++ b/src/registrar/models/contact.py
@@ -102,9 +102,10 @@ class Contact(TimeStampedModel):
         super().save(*args, **kwargs)
 
         # Update the related User object's first_name and last_name
-        if self.user and (not self.user.first_name or not self.user.last_name):
+        if self.user and (not self.user.first_name or not self.user.last_name or not self.user.phone):
             self.user.first_name = self.first_name
             self.user.last_name = self.last_name
+            self.user.phone = self.phone
             self.user.save()
 
     def __str__(self):

--- a/src/registrar/tests/common.py
+++ b/src/registrar/tests/common.py
@@ -834,7 +834,7 @@ def completed_domain_request(
     )
     if not investigator:
         investigator, _ = User.objects.get_or_create(
-            username="incrediblyfakeinvestigator",
+            username="incrediblyfakeinvestigator" + str(uuid.uuid4())[:8],
             first_name="Joe",
             last_name="Bob",
             is_staff=True,


### PR DESCRIPTION
## Ticket

Resolves #2057 
<!--Reminder, when a code change is made that is user facing, beyond content updates, then the following are required:
- a developer approves the PR
- a designer approves the PR or checks off all relevant items in this checklist.

All other changes require just a single approving review.-->

## Changes

<!-- What was added, updated, or removed in this PR. -->
- We're already capturing phone for ial2 logins
- Overwrite contact on login if the linked contact has no phone number (yes contact, not user)
- Same logic for first_name and last_name
- When saving a contact, save the phone number on the user as well if user does not have phone number
- Update unit tests

<!--
    Please add/remove/edit any of the template below to fit the needs
    of this specific PR.
--->

## Context for reviewers

<!--Background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers.  -->

Recap (cc @abroddrick for refactor tickets):
- On login: We get the phone number from login if one is not set on the contact. Both user/contact get updated
- On login: If a contact has a phone number already, we'll update the user's phone and leave the contact's phone alone
- On contact save: If a user has a phone number, we'll update the contact on save and leave the user alone
- On contact save: If a user does not have a phone number. we'll update the contact and the user

## Setup

<!--  Add any steps or code to run in this section to help others run your code.
    
    Example 1:
    ```sh
    echo "Code goes here"
    ``` 
    
    Example 2: If the PR was to add a new link with a redirect, this section could simply be:
    -go to /path/to/start/page
    -click the blue link in the <insert location>
    -notice user is redirected to <proper end location>
-->

## Code Review Verification Steps

### As the original developer, I have

#### Satisfied acceptance criteria and met development standards

- [x] Met the acceptance criteria, or will meet them in a subsequent PR
- [x] Created/modified automated tests
- [x] Added at least 2 developers as PR reviewers (only 1 will need to approve)
- [x] Messaged on Slack or in standup to notify the team that a PR is ready for review
- [ ] Changes to “how we do things” are documented in READMEs and or onboarding guide
- [ ] If any model was updated to modify/add/delete columns, makemigrations was ran and the associated migrations file has been commited.

#### Ensured code standards are met (Original Developer)

- [x] All new functions and methods are commented using plain language
- [ ] Did dependency updates in Pipfile also get changed in requirements.txt?
- [ ] Interactions with external systems are wrapped in try/except
- [x] Error handling exists for unusual or missing values

#### Validated user-facing changes (if applicable)

- [ ] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Checked keyboard navigability
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)
- [ ] Add at least 1 designer as PR reviewer

### As a code reviewer, I have

#### Reviewed, tested, and left feedback about the changes

- [ ] Pulled this branch locally and tested it
- [ ] Reviewed this code and left comments
- [ ] Checked that all code is adequately covered by tests
- [ ] Made it clear which comments need to be addressed before this work is merged
- [ ] If any model was updated to modify/add/delete columns, makemigrations was ran and the associated migrations file has been commited.

#### Ensured code standards are met (Code reviewer)

- [ ] All new functions and methods are commented using plain language
- [ ] Interactions with external systems are wrapped in try/except
- [ ] Error handling exists for unusual or missing values
- [ ] (Rarely needed) Did dependency updates in Pipfile also get changed in requirements.txt?

#### Validated user-facing changes as a developer

- [ ] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Checked keyboard navigability
- [ ] Meets all designs and user flows provided by design/product
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)

- [ ] Tested with multiple browsers, the suggestion is to use ones that the developer didn't (check off which ones were used)
  - [ ] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari

- [ ] (Rarely needed) Tested as both an analyst and applicant user

**Note:** Multiple code reviewers can share the checklists above, a second reviewers should not make a duplicate checklist

### As a designer reviewer, I have

#### Verified that the changes match the design intention

- [ ] Checked that the design translated visually
- [ ] Checked behavior
- [ ] Checked different states (empty, one, some, error)
- [ ] Checked for landmarks, page heading structure, and links
- [ ] Tried to break the intended flow

#### Validated user-facing changes as a designer

- [ ] Checked keyboard navigability
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)

- [ ] Tested with multiple browsers (check off which ones were used)
  - [ ] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari

- [ ] (Rarely needed) Tested as both an analyst and applicant user

## Screenshots

<!-- If this PR makes visible interface changes, an image of the finished interface can help reviewers
and casual observers understand the context of the changes.
A before image is optional and can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow.
You may want to use [GIPHY Capture](https://giphy.com/apps/giphycapture) for this! 📸

_Please frame images to show useful context but also highlight the affected regions._
--->
