### PR TITLE
ISSUE #1793: Exclude gov Administration and Non-Federal Agency in Domain Request form

### DIFF
--- a/src/registrar/forms/domain_request_wizard.py
+++ b/src/registrar/forms/domain_request_wizard.py
@@ -97,6 +97,7 @@ class OrganizationElectionForm(RegistrarForm):
 
 class OrganizationContactForm(RegistrarForm):
     # for federal agencies we also want to know the top-level agency.
+    excluded_agencies = ["gov Administration", "Non-Federal Agency"]
     federal_agency = forms.ModelChoiceField(
         label="Federal agency",
         # not required because this field won't be filled out unless
@@ -104,9 +105,8 @@ class OrganizationContactForm(RegistrarForm):
         # if it has been filled in when required.
         # uncomment to see if modelChoiceField can be an arg later
         required=False,
-        queryset=FederalAgency.objects.all(),
+        queryset=FederalAgency.objects.exclude(agency__in=excluded_agencies),
         empty_label="--Select--",
-        # choices=[("", "--Select--")] + DomainRequest.AGENCY_CHOICES,
     )
     organization_name = forms.CharField(
         label="Organization name",

--- a/src/registrar/tests/test_views_request.py
+++ b/src/registrar/tests/test_views_request.py
@@ -717,7 +717,7 @@ class DomainRequestTests(TestWithUser, WebTest):
         type_form["generic_org_type-generic_org_type"] = DomainRequest.OrganizationChoices.SPECIAL_DISTRICT
         self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
         type_result = type_page.forms[0].submit()
-        # follow first redirectt
+        # follow first redirect
         self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
         contact_page = type_result.follow()
 
@@ -725,7 +725,7 @@ class DomainRequestTests(TestWithUser, WebTest):
 
     def test_federal_agency_dropdown_excludes_expected_values(self):
         """The Federal Agency dropdown on a domain request form should not
-        include options for gov Administration or Non-Federal Agency"""
+        include options for gov Administration and Non-Federal Agency"""
         intro_page = self.app.get(reverse("domain-request:"))
         # django-webtest does not handle cookie-based sessions well because it keeps
         # resetting the session key on each new request, thus destroying the concept
@@ -767,6 +767,7 @@ class DomainRequestTests(TestWithUser, WebTest):
         # gov Administration and Non-Federal Agency should not be federal agency options
         self.assertNotContains(org_contact_page, "gov Administration")
         self.assertNotContains(org_contact_page, "Non-Federal Agency")
+        # make sure correct federal agency options still show up
         self.assertContains(org_contact_page, "General Services Administration")
 
     def test_yes_no_contact_form_inits_blank_for_new_domain_request(self):


### PR DESCRIPTION
## Ticket

Resolves #1793 - quickfix fulfilling a missing AC

## Changes

* Excludes `gov Administration` and `Non-Federal Agency` as Federal Agency options on the domain request form. These options make it confusing for people making domain requests and should only be referenced on admin for analysts.

## Context for reviewers

We want to make sure that when a user comes into the form for a domain request and chooses Federal > Federal Agency, that in the dropdown form they do not see `gov Administration` and `Non-Federal Agency`

## Setup

1. Go to [my sandbox](https://getgov-rh.app.cloud.gov/) 
2. Click on a domain request that is Started and click "Edit"
3. Go to the "Organization name and mailing address" part of the form
4. Click on the "Federal Agency" drop down and make sure that "gov Administration" and "Non-Federal Agency" are not visible in that list.
5. Go to /admin > Federal Agency > search to make sure that "gov Administration" and "Non-Federal Agency" show up
6. Go to /admin > Domain Request > click on any domain > go to Federal Agency > search to make sure that "gov Administration" and "Non-Federal Agency" show up in the drop down
7. Go to /admin > Domain Information > click on any domain > go to Federal Agency > search to make sure that "gov Administration" and "Non-Federal Agency" show up in the drop down

## Code Review Verification Steps

### As the original developer, I have

#### Satisfied acceptance criteria and met development standards

- [ ] Met the acceptance criteria, or will meet them in a subsequent PR
- [ ] Created/modified automated tests
- [ ] Added at least 2 developers as PR reviewers (only 1 will need to approve)
- [ ] Messaged on Slack or in standup to notify the team that a PR is ready for review
- [ ] Changes to “how we do things” are documented in READMEs and or onboarding guide
- [ ] If any model was updated to modify/add/delete columns, makemigrations was ran and the associated migrations file has been commited.

#### Ensured code standards are met (Original Developer)

- [ ] All new functions and methods are commented using plain language
- [ ] Did dependency updates in Pipfile also get changed in requirements.txt?
- [ ] Interactions with external systems are wrapped in try/except
- [ ] Error handling exists for unusual or missing values

#### Validated user-facing changes (if applicable)

- [ ] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Checked keyboard navigability
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)
- [ ] Add at least 1 designer as PR reviewer

### As a code reviewer, I have

#### Reviewed, tested, and left feedback about the changes

- [ ] Pulled this branch locally and tested it
- [ ] Reviewed this code and left comments
- [ ] Checked that all code is adequately covered by tests
- [ ] Made it clear which comments need to be addressed before this work is merged
- [ ] If any model was updated to modify/add/delete columns, makemigrations was ran and the associated migrations file has been commited.

#### Ensured code standards are met (Code reviewer)

- [ ] All new functions and methods are commented using plain language
- [ ] Interactions with external systems are wrapped in try/except
- [ ] Error handling exists for unusual or missing values
- [ ] (Rarely needed) Did dependency updates in Pipfile also get changed in requirements.txt?

#### Validated user-facing changes as a developer

- [ ] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Checked keyboard navigability
- [ ] Meets all designs and user flows provided by design/product
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)

- [ ] Tested with multiple browsers, the suggestion is to use ones that the developer didn't (check off which ones were used)
  - [ ] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari

- [ ] (Rarely needed) Tested as both an analyst and applicant user

**Note:** Multiple code reviewers can share the checklists above, a second reviewers should not make a duplicate checklist

### As a designer reviewer, I have

#### Verified that the changes match the design intention

- [ ] Checked that the design translated visually
- [ ] Checked behavior
- [ ] Checked different states (empty, one, some, error)
- [ ] Checked for landmarks, page heading structure, and links
- [ ] Tried to break the intended flow

#### Validated user-facing changes as a designer

- [ ] Checked keyboard navigability
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)

- [ ] Tested with multiple browsers (check off which ones were used)
  - [ ] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari

- [ ] (Rarely needed) Tested as both an analyst and applicant user

## Screenshots
In domain request form:
<img width="595" alt="Screenshot 2024-05-07 at 4 27 04 PM" src="https://github.com/cisagov/manage.get.gov/assets/13954664/79806874-dc78-4c11-99e3-4b9f2fcf7d23">
<img width="761" alt="Screenshot 2024-05-07 at 4 27 12 PM" src="https://github.com/cisagov/manage.get.gov/assets/13954664/c8ced354-d5af-4652-8871-e25d7a9933c1">
