### PR TITLE
Small updates to our onboarding issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/designer-onboarding.md
+++ b/.github/ISSUE_TEMPLATE/designer-onboarding.md
@@ -1,6 +1,6 @@
 ---
 name: Designer Onboarding
-about: Onboarding steps for designers.
+about: Onboarding steps for new designers joining the .gov team.
 title: 'Designer Onboarding: GH_HANDLE'
 labels: design, onboarding
 assignees: katherineosos

--- a/.github/ISSUE_TEMPLATE/developer-onboarding.md
+++ b/.github/ISSUE_TEMPLATE/developer-onboarding.md
@@ -1,6 +1,6 @@
 ---
 name: Developer Onboarding
-about: Onboarding steps for developers.
+about: Onboarding steps for new developers joining the .gov team.
 title: 'Developer Onboarding: GH_HANDLE'
 labels: dev, onboarding
 assignees: abroddrick


### PR DESCRIPTION
We sometimes have members of the public who _love_ .gov and attempt to go through our onboarding issues thinking it's something they need to do before we can contribute. This small change to the description of our role-centric issue templates aims to help random internet people know this isn't something they need to do.