### PR TITLE
Remove widget def for agency name to fix form input on domain manage agency form

### DIFF
--- a/src/registrar/forms/domain.py
+++ b/src/registrar/forms/domain.py
@@ -385,7 +385,6 @@ class DomainOrgNameAddressForm(forms.ModelForm):
             # because for this fields we are creating an individual
             # instance of the Select. For the other fields we use the for loop to set
             # the class's required attribute to true.
-            "federal_agency": forms.TextInput,
             "organization_name": forms.TextInput,
             "address_line1": forms.TextInput,
             "address_line2": forms.TextInput,

--- a/src/registrar/tests/test_views_domain.py
+++ b/src/registrar/tests/test_views_domain.py
@@ -1447,7 +1447,7 @@ class TestDomainOrganization(TestDomainOverview):
 
         session_id = self.app.cookies[settings.SESSION_COOKIE_NAME]
 
-        org_name_page.form["federal_agency"] = "Department of State"
+        org_name_page.form["federal_agency"] = FederalAgency.objects.filter(agency="Department of State").get().id
         org_name_page.form["city"] = "Faketown"
 
         self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
@@ -1456,9 +1456,8 @@ class TestDomainOrganization(TestDomainOverview):
         success_result_page = org_name_page.form.submit()
         self.assertEqual(success_result_page.status_code, 200)
 
-        # Check for the old and new value
-        self.assertContains(success_result_page, federal_agency.id)
-        self.assertNotContains(success_result_page, "Department of State")
+        # Check that the agency has not changed
+        self.assertEqual(self.domain_information.federal_agency.agency, "AMTRAK")
 
         # Do another check on the form itself
         form = success_result_page.forms[0]


### PR DESCRIPTION
## Ticket

Hotfix for domain agency management form, agency name input (was showing id instead of agency name)
