### PR TITLE
2236: Remove domain state filters from metadata report

### DIFF
--- a/src/registrar/tests/test_reports.py
+++ b/src/registrar/tests/test_reports.py
@@ -743,4 +743,3 @@ class HelperFunctions(MockDb):
             submitted_requests_sliced_at_end_date = get_sliced_requests(filter_condition)
             expected_content = [2, 2, 0, 0, 0, 0, 0, 0, 0, 0]
             self.assertEqual(submitted_requests_sliced_at_end_date, expected_content)
-

--- a/src/registrar/tests/test_reports.py
+++ b/src/registrar/tests/test_reports.py
@@ -743,3 +743,4 @@ class HelperFunctions(MockDb):
             submitted_requests_sliced_at_end_date = get_sliced_requests(filter_condition)
             expected_content = [2, 2, 0, 0, 0, 0, 0, 0, 0, 0]
             self.assertEqual(submitted_requests_sliced_at_end_date, expected_content)
+

--- a/src/registrar/utility/csv_export.py
+++ b/src/registrar/utility/csv_export.py
@@ -381,6 +381,7 @@ def export_data_type_to_csv(csv_file):
     """
     All domains report with extra columns.
     This maps to the "All domain metadata" button.
+    Exports domains of all statuses.
     """
 
     writer = csv.writer(csv_file)
@@ -408,15 +409,8 @@ def export_data_type_to_csv(csv_file):
         "federal_agency",
         "domain__name",
     ]
-    filter_condition = {
-        "domain__state__in": [
-            Domain.State.READY,
-            Domain.State.DNS_NEEDED,
-            Domain.State.ON_HOLD,
-        ],
-    }
     write_csv_for_domains(
-        writer, columns, sort_fields, filter_condition, should_get_domain_managers=True, should_write_header=True
+        writer, columns, sort_fields, filter_condition={}, should_get_domain_managers=True, should_write_header=True
     )
 
 


### PR DESCRIPTION
## Ticket

Resolves #2236 
<!--Reminder, when a code change is made that is user facing, beyond content updates, then the following are required:
- a developer approves the PR
- a designer approves the PR or checks off all relevant items in this checklist.

All other changes require just a single approving review.-->

## Changes

<!-- What was added, updated, or removed in this PR. -->
- Removes filtering by domain state on domain metadata report. Domain metadata report now includes domain information from all domains rather than just those in the `Ready`, `DNS Needed`, or `On hold` state.

<!--
    Please add/remove/edit any of the template below to fit the needs
    of this specific PR.
--->

## Context for reviewers

<!--Background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers.  -->

## Setup

<!--  Add any steps or code to run in this section to help others run your code.
    
    Example 1:
    ```sh
    echo "Code goes here"
    ``` 
    
    Example 2: If the PR was to add a new link with a redirect, this section could simply be:
    -go to /path/to/start/page
    -click the blue link in the <insert location>
    -notice user is redirected to <proper end location>
-->
On getgov-es, go to the [admin analytics page](https://getgov-es.app.cloud.gov/admin/analytics/). On the Current domains section, click on the All metadata button. Verify that All metadata generates a metadata report of all domains regardless of status. In the image snippet example below, domains with the state `Unknown` are still included in the report.
<img width="948" alt="image" src="https://github.com/cisagov/manage.get.gov/assets/121973038/2d6633d5-0289-433e-a294-c0c8f832097e">

## Code Review Verification Steps

### As the original developer, I have

#### Satisfied acceptance criteria and met development standards

- [x] Met the acceptance criteria, or will meet them in a subsequent PR
- [ ] Created/modified automated tests
- [ ] Added at least 2 developers as PR reviewers (only 1 will need to approve)
- [ ] Messaged on Slack or in standup to notify the team that a PR is ready for review
- [ ] Changes to “how we do things” are documented in READMEs and or onboarding guide
- [ ] If any model was updated to modify/add/delete columns, makemigrations was ran and the associated migrations file has been commited.

#### Ensured code standards are met (Original Developer)

- [ ] All new functions and methods are commented using plain language
- [ ] Did dependency updates in Pipfile also get changed in requirements.txt?
- [ ] Interactions with external systems are wrapped in try/except
- [ ] Error handling exists for unusual or missing values

#### Validated user-facing changes (if applicable)

- [ ] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Checked keyboard navigability
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)
- [ ] Add at least 1 designer as PR reviewer

### As a code reviewer, I have

#### Reviewed, tested, and left feedback about the changes

- [ ] Pulled this branch locally and tested it
- [ ] Reviewed this code and left comments
- [ ] Checked that all code is adequately covered by tests
- [ ] Made it clear which comments need to be addressed before this work is merged
- [ ] If any model was updated to modify/add/delete columns, makemigrations was ran and the associated migrations file has been commited.

#### Ensured code standards are met (Code reviewer)

- [ ] All new functions and methods are commented using plain language
- [ ] Interactions with external systems are wrapped in try/except
- [ ] Error handling exists for unusual or missing values
- [ ] (Rarely needed) Did dependency updates in Pipfile also get changed in requirements.txt?

#### Validated user-facing changes as a developer

- [ ] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Checked keyboard navigability
- [ ] Meets all designs and user flows provided by design/product
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)

- [ ] Tested with multiple browsers, the suggestion is to use ones that the developer didn't (check off which ones were used)
  - [ ] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari

- [ ] (Rarely needed) Tested as both an analyst and applicant user

**Note:** Multiple code reviewers can share the checklists above, a second reviewers should not make a duplicate checklist

### As a designer reviewer, I have

#### Verified that the changes match the design intention

- [ ] Checked that the design translated visually
- [ ] Checked behavior
- [ ] Checked different states (empty, one, some, error)
- [ ] Checked for landmarks, page heading structure, and links
- [ ] Tried to break the intended flow

#### Validated user-facing changes as a designer

- [ ] Checked keyboard navigability
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)

- [ ] Tested with multiple browsers (check off which ones were used)
  - [ ] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari

- [ ] (Rarely needed) Tested as both an analyst and applicant user

## Screenshots

<!-- If this PR makes visible interface changes, an image of the finished interface can help reviewers
and casual observers understand the context of the changes.
A before image is optional and can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow.
You may want to use [GIPHY Capture](https://giphy.com/apps/giphycapture) for this! 📸

_Please frame images to show useful context but also highlight the affected regions._
--->
