### PR TITLE
Fix delete request bug to ensure event listeners are not duplicated

### DIFF
--- a/src/registrar/assets/js/get-gov.js
+++ b/src/registrar/assets/js/get-gov.js
@@ -33,6 +33,33 @@ const showElement = (element) => {
   element.classList.remove('display-none');
 };
 
+/**
+ * Helper function that scrolls to an element
+ * @param {string} attributeName - The string "class" or "id"
+ * @param {string} attributeValue - The class or id name
+ */
+function ScrollToElement(attributeName, attributeValue) {
+  let targetEl = null;
+
+  if (attributeName === 'class') {
+    targetEl = document.getElementsByClassName(attributeValue)[0];
+  } else if (attributeName === 'id') {
+    targetEl = document.getElementById(attributeValue);
+  } else {
+    console.log('Error: unknown attribute name provided.');
+    return; // Exit the function if an invalid attributeName is provided
+  }
+
+  if (targetEl) {
+    const rect = targetEl.getBoundingClientRect();
+    const scrollTop = window.scrollY || document.documentElement.scrollTop;
+    window.scrollTo({
+      top: rect.top + scrollTop,
+      behavior: 'smooth' // Optional: for smooth scrolling
+    });
+  }
+}
+
 /** Makes an element invisible. */
 function makeHidden(el) {
   el.style.position = "absolute";
@@ -896,33 +923,6 @@ function unloadModals() {
 }
 
 /**
- * Helper function that scrolls to an element
- * @param {string} attributeName - The string "class" or "id"
- * @param {string} attributeValue - The class or id name
- */
-function ScrollToElement(attributeName, attributeValue) {
-  let targetEl = null;
-
-  if (attributeName === 'class') {
-    targetEl = document.getElementsByClassName(attributeValue)[0];
-  } else if (attributeName === 'id') {
-    targetEl = document.getElementById(attributeValue);
-  } else {
-    console.log('Error: unknown attribute name provided.');
-    return; // Exit the function if an invalid attributeName is provided
-  }
-
-  if (targetEl) {
-    const rect = targetEl.getBoundingClientRect();
-    const scrollTop = window.scrollY || document.documentElement.scrollTop;
-    window.scrollTo({
-      top: rect.top + scrollTop,
-      behavior: 'smooth' // Optional: for smooth scrolling
-    });
-  }
-}
-
-/**
  * Generalized function to update pagination for a list.
  * @param {string} itemName - The name displayed in the counter
  * @param {string} paginationSelector - CSS selector for the pagination container.
@@ -1469,7 +1469,7 @@ document.addEventListener('DOMContentLoaded', function() {
                     </svg>
                   </button>
                 </div>
-              `
+                `
 
               domainRequestsSectionWrapper.appendChild(modal);
             }
@@ -1507,13 +1507,10 @@ document.addEventListener('DOMContentLoaded', function() {
           modals.forEach(modal => {
             const submitButton = modal.querySelector('.usa-modal__submit');
             const closeButton = modal.querySelector('.usa-modal__close');
-            
-            // Clone the submit button to remove all existing event listeners
-            const newSubmitButton = submitButton.cloneNode(true);
-            submitButton.parentNode.replaceChild(newSubmitButton, submitButton);
 
-            newSubmitButton.addEventListener('click', function() {
-              pk = newSubmitButton.getAttribute('data-pk');
+
+            submitButton.addEventListener('click', function() {
+              pk = submitButton.getAttribute('data-pk');
               // Close the modal to remove the USWDS UI local classes
               closeButton.click();
               // If we're deleting the last item on a page that is not page 1, we'll need to refresh the display to the previous page

--- a/src/registrar/assets/js/get-gov.js
+++ b/src/registrar/assets/js/get-gov.js
@@ -1353,7 +1353,7 @@ document.addEventListener('DOMContentLoaded', function() {
           tbody.innerHTML = '';
 
           // Unload modals will re-inject the DOM with the initial placeholders to allow for .on() in regular use cases
-          // We do NOT want that as it will cause multiple placeholders and therfore multiple inits on delete,
+          // We do NOT want that as it will cause multiple placeholders and therefore multiple inits on delete,
           // which will cause bad delete requests to be sent.
           const preExistingModalPlaceholders = document.querySelectorAll('[data-placeholder-for^="toggle-delete-domain-alert"]');
           preExistingModalPlaceholders.forEach(element => {

--- a/src/registrar/assets/js/get-gov.js
+++ b/src/registrar/assets/js/get-gov.js
@@ -1357,7 +1357,6 @@ document.addEventListener('DOMContentLoaded', function() {
           // which will cause bad delete requests to be sent.
           const preExistingModalPlaceholders = document.querySelectorAll('[data-placeholder-for^="toggle-delete-domain-alert"]');
           preExistingModalPlaceholders.forEach(element => {
-              console.log('found one');
               element.remove();
           });
 

--- a/src/registrar/assets/js/get-gov.js
+++ b/src/registrar/assets/js/get-gov.js
@@ -1507,8 +1507,13 @@ document.addEventListener('DOMContentLoaded', function() {
           modals.forEach(modal => {
             const submitButton = modal.querySelector('.usa-modal__submit');
             const closeButton = modal.querySelector('.usa-modal__close');
-            submitButton.addEventListener('click', function() {
-              pk = submitButton.getAttribute('data-pk');
+            
+            // Clone the submit button to remove all existing event listeners
+            const newSubmitButton = submitButton.cloneNode(true);
+            submitButton.parentNode.replaceChild(newSubmitButton, submitButton);
+
+            newSubmitButton.addEventListener('click', function() {
+              pk = newSubmitButton.getAttribute('data-pk');
               // Close the modal to remove the USWDS UI local classes
               closeButton.click();
               // If we're deleting the last item on a page that is not page 1, we'll need to refresh the display to the previous page

--- a/src/registrar/assets/js/get-gov.js
+++ b/src/registrar/assets/js/get-gov.js
@@ -1520,8 +1520,6 @@ document.addEventListener('DOMContentLoaded', function() {
           modals.forEach(modal => {
             const submitButton = modal.querySelector('.usa-modal__submit');
             const closeButton = modal.querySelector('.usa-modal__close');
-
-
             submitButton.addEventListener('click', function() {
               pk = submitButton.getAttribute('data-pk');
               // Close the modal to remove the USWDS UI local classes

--- a/src/registrar/assets/js/get-gov.js
+++ b/src/registrar/assets/js/get-gov.js
@@ -1294,6 +1294,10 @@ document.addEventListener('DOMContentLoaded', function() {
      * @param {*} pageToDisplay - If we're deleting the last item on a page that is not page 1, we'll need to display the previous page
     */
     function deleteDomainRequest(domainRequestPk,pageToDisplay) {
+      
+      // Use to debug uswds modal issues
+      //console.log('deleteDomainRequest')
+      
       // Get csrf token
       const csrfToken = getCsrfToken();
       // Create FormData object and append the CSRF token
@@ -1347,6 +1351,15 @@ document.addEventListener('DOMContentLoaded', function() {
           // identify the DOM element where the domain request list will be inserted into the DOM
           const tbody = document.querySelector('.domain-requests__table tbody');
           tbody.innerHTML = '';
+
+          // Unload modals will re-inject the DOM with the initial placeholders to allow for .on() in regular use cases
+          // We do NOT want that as it will cause multiple placeholders and therfore multiple inits on delete,
+          // which will cause bad delete requests to be sent.
+          const preExistingModalPlaceholders = document.querySelectorAll('[data-placeholder-for^="toggle-delete-domain-alert"]');
+          preExistingModalPlaceholders.forEach(element => {
+              console.log('found one');
+              element.remove();
+          });
 
           // remove any existing modal elements from the DOM so they can be properly re-initialized
           // after the DOM content changes and there are new delete modal buttons added

--- a/src/registrar/assets/js/uswds-edited.js
+++ b/src/registrar/assets/js/uswds-edited.js
@@ -5311,17 +5311,14 @@ const cleanUpModal = baseComponent => {
   const modalID = modalWrapper.getAttribute("id");
   const originalLocationPlaceHolder = document.querySelector(`[data-placeholder-for="${modalID}"]`);
   if (originalLocationPlaceHolder) {
-    // DOTGOV
-    // Why is this line here? It seems to be recreating the original placeholder and then adding a
-    // copy of it after that first placeholder, which is netralizing our call of off()
-    // for (let attributeIndex = 0; attributeIndex < originalLocationPlaceHolder.attributes.length; attributeIndex += 1) {
-    //   const attribute = originalLocationPlaceHolder.attributes[attributeIndex];
-    //   if (attribute.name.startsWith('data-original-')) {
-    //     // data-original- is 14 long
-    //     modalContent.setAttribute(attribute.name.substr(14), attribute.value);
-    //   }
-    // }
-    //originalLocationPlaceHolder.after(modalContent);
+    for (let attributeIndex = 0; attributeIndex < originalLocationPlaceHolder.attributes.length; attributeIndex += 1) {
+      const attribute = originalLocationPlaceHolder.attributes[attributeIndex];
+      if (attribute.name.startsWith('data-original-')) {
+        // data-original- is 14 long
+        modalContent.setAttribute(attribute.name.substr(14), attribute.value);
+      }
+    }
+    originalLocationPlaceHolder.after(modalContent);
     originalLocationPlaceHolder.parentElement.removeChild(originalLocationPlaceHolder);
   }
   modalWrapper.parentElement.removeChild(modalWrapper);

--- a/src/registrar/assets/js/uswds-edited.js
+++ b/src/registrar/assets/js/uswds-edited.js
@@ -5311,14 +5311,17 @@ const cleanUpModal = baseComponent => {
   const modalID = modalWrapper.getAttribute("id");
   const originalLocationPlaceHolder = document.querySelector(`[data-placeholder-for="${modalID}"]`);
   if (originalLocationPlaceHolder) {
-    for (let attributeIndex = 0; attributeIndex < originalLocationPlaceHolder.attributes.length; attributeIndex += 1) {
-      const attribute = originalLocationPlaceHolder.attributes[attributeIndex];
-      if (attribute.name.startsWith('data-original-')) {
-        // data-original- is 14 long
-        modalContent.setAttribute(attribute.name.substr(14), attribute.value);
-      }
-    }
-    originalLocationPlaceHolder.after(modalContent);
+    // DOTGOV
+    // Why is this line here? It seems to be recreating the original placeholder and then adding a
+    // copy of it after that first placeholder, which is netralizing our call of off()
+    // for (let attributeIndex = 0; attributeIndex < originalLocationPlaceHolder.attributes.length; attributeIndex += 1) {
+    //   const attribute = originalLocationPlaceHolder.attributes[attributeIndex];
+    //   if (attribute.name.startsWith('data-original-')) {
+    //     // data-original- is 14 long
+    //     modalContent.setAttribute(attribute.name.substr(14), attribute.value);
+    //   }
+    // }
+    //originalLocationPlaceHolder.after(modalContent);
     originalLocationPlaceHolder.parentElement.removeChild(originalLocationPlaceHolder);
   }
   modalWrapper.parentElement.removeChild(modalWrapper);


### PR DESCRIPTION
## Ticket

Resolves #2329 
<!--Reminder, when a code change is made that is user facing, beyond content updates, then the following are required:
- Clone the delete buttons in the forEach loop before attaching event listeners to ensure that we do not attach multiple listeners which will then cause ugly console errors and performance issues when the backend chokes on bad requests.

All other changes require just a single approving review.-->

## Changes

<!-- What was added, updated, or removed in this PR. -->
- The USWDS unload modals will re-inject the DOM with the initial placeholders to allow for .on() in regular use cases. We do NOT want that as it will cause multiple placeholders and therefore multiple inits on delete, which will cause bad delete requests to be sent. To fix this, we remove the placeholders that `cleanUpModal` will look for before we call it from our end (through `unloadModals`).

Note, I left in a commented out console log in the delete function for easy testing and debugging.

<!--
    Please add/remove/edit any of the template below to fit the needs
    of this specific PR.
--->

## Context for reviewers

<!--Background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers.  -->

## Setup

<!--  Add any steps or code to run in this section to help others run your code.
    
    Example 1:
    ```sh
    echo "Code goes here"
    ``` 
    
    Example 2: If the PR was to add a new link with a redirect, this section could simply be:
    -go to /path/to/start/page
    -click the blue link in the <insert location>
    -notice user is redirected to <proper end location>
-->

## Code Review Verification Steps

### As the original developer, I have

#### Satisfied acceptance criteria and met development standards

- [ ] Met the acceptance criteria, or will meet them in a subsequent PR
- [ ] Created/modified automated tests
- [ ] Added at least 2 developers as PR reviewers (only 1 will need to approve)
- [ ] Messaged on Slack or in standup to notify the team that a PR is ready for review
- [ ] Changes to “how we do things” are documented in READMEs and or onboarding guide
- [ ] If any model was updated to modify/add/delete columns, makemigrations was ran and the associated migrations file has been commited.

#### Ensured code standards are met (Original Developer)

- [ ] All new functions and methods are commented using plain language
- [ ] Did dependency updates in Pipfile also get changed in requirements.txt?
- [ ] Interactions with external systems are wrapped in try/except
- [ ] Error handling exists for unusual or missing values

#### Validated user-facing changes (if applicable)

- [ ] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Checked keyboard navigability
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)
- [ ] Add at least 1 designer as PR reviewer

### As a code reviewer, I have

#### Reviewed, tested, and left feedback about the changes

- [ ] Pulled this branch locally and tested it
- [ ] Reviewed this code and left comments
- [ ] Checked that all code is adequately covered by tests
- [ ] Made it clear which comments need to be addressed before this work is merged
- [ ] If any model was updated to modify/add/delete columns, makemigrations was ran and the associated migrations file has been commited.

#### Ensured code standards are met (Code reviewer)

- [ ] All new functions and methods are commented using plain language
- [ ] Interactions with external systems are wrapped in try/except
- [ ] Error handling exists for unusual or missing values
- [ ] (Rarely needed) Did dependency updates in Pipfile also get changed in requirements.txt?

#### Validated user-facing changes as a developer

- [ ] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Checked keyboard navigability
- [ ] Meets all designs and user flows provided by design/product
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)

- [ ] Tested with multiple browsers, the suggestion is to use ones that the developer didn't (check off which ones were used)
  - [ ] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari

- [ ] (Rarely needed) Tested as both an analyst and applicant user

**Note:** Multiple code reviewers can share the checklists above, a second reviewers should not make a duplicate checklist

### As a designer reviewer, I have

#### Verified that the changes match the design intention

- [ ] Checked that the design translated visually
- [ ] Checked behavior
- [ ] Checked different states (empty, one, some, error)
- [ ] Checked for landmarks, page heading structure, and links
- [ ] Tried to break the intended flow

#### Validated user-facing changes as a designer

- [ ] Checked keyboard navigability
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)

- [ ] Tested with multiple browsers (check off which ones were used)
  - [ ] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari

- [ ] (Rarely needed) Tested as both an analyst and applicant user

## Screenshots

<!-- If this PR makes visible interface changes, an image of the finished interface can help reviewers
and casual observers understand the context of the changes.
A before image is optional and can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow.
You may want to use [GIPHY Capture](https://giphy.com/apps/giphycapture) for this! 📸

_Please frame images to show useful context but also highlight the affected regions._
--->
