### PR TITLE
Add Github action to notify users by labels added to issues

### DIFF
--- a/.github/workflows/issue-label-notifier.yaml
+++ b/.github/workflows/issue-label-notifier.yaml
@@ -15,3 +15,4 @@ jobs:
           recipients: |
             design-review=@Katherine-Osos
           message: 'cc/ {recipients} — adding you to this **{label}** issue!'
+          

--- a/.github/workflows/issue-label-notifier.yaml
+++ b/.github/workflows/issue-label-notifier.yaml
@@ -1,0 +1,15 @@
+name: Notify users based on issue labels
+
+on:
+  issues:
+    types: [labeled]
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: jenschelkopf/issue-label-notification-action@1.3
+        with:
+          recipients: |
+            design-review=@Katherine-Osos
+          message: 'cc/ {recipients} — adding you to this **{label}** issue!'

--- a/.github/workflows/issue-label-notifier.yaml
+++ b/.github/workflows/issue-label-notifier.yaml
@@ -3,6 +3,8 @@ name: Notify users based on issue labels
 on:
   issues:
     types: [labeled]
+  pull_request:
+    types: [labeled]
 
 jobs:
   notify:


### PR DESCRIPTION


## Ticket

Resolves #2263 

## Changes

<!-- What was added, updated, or removed in this PR. -->
- Added the Github Action for notifying users based on label
- Added a notification for Katherine to be notified/added to an issue when the `design-review` label is added.


## Code Review Verification Steps

This code should only impact Github actions, and generally cannot be tested until merged to `main`.
