### PR TITLE
ISSUE #2358: Update submitter check with profile_flag logic

### DIFF
--- a/src/registrar/models/domain_request.py
+++ b/src/registrar/models/domain_request.py
@@ -1174,6 +1174,7 @@ class DomainRequest(TimeStampedModel):
             and self._is_authorizing_official_complete()
             and self._is_requested_domain_complete()
             and self._is_purpose_complete()
+            # NOTE: This flag leaves submitter as empty (request wont submt) hence preset to True
             and (self._is_submitter_complete() if not has_profile_feature_flag else True)
             and self._is_other_contacts_complete()
             and self._is_additional_details_complete()

--- a/src/registrar/models/domain_request.py
+++ b/src/registrar/models/domain_request.py
@@ -17,6 +17,8 @@ from .utility.time_stamped_model import TimeStampedModel
 from ..utility.email import send_templated_email, EmailSendingError
 from itertools import chain
 
+from waffle.decorators import flag_is_active
+
 logger = logging.getLogger(__name__)
 
 
@@ -1165,19 +1167,20 @@ class DomainRequest(TimeStampedModel):
     def _is_policy_acknowledgement_complete(self):
         return self.is_policy_acknowledged is not None
 
-    def _is_general_form_complete(self):
+    def _is_general_form_complete(self, request):
+        has_profile_feature_flag = flag_is_active(request, "profile_feature")
         return (
             self._is_organization_name_and_address_complete()
             and self._is_authorizing_official_complete()
             and self._is_requested_domain_complete()
             and self._is_purpose_complete()
-            and self._is_submitter_complete()
+            and (self._is_submitter_complete() if not has_profile_feature_flag else True)
             and self._is_other_contacts_complete()
             and self._is_additional_details_complete()
             and self._is_policy_acknowledgement_complete()
         )
 
-    def _form_complete(self):
+    def _form_complete(self, request):
         match self.generic_org_type:
             case DomainRequest.OrganizationChoices.FEDERAL:
                 is_complete = self._is_federal_complete()
@@ -1198,8 +1201,6 @@ class DomainRequest(TimeStampedModel):
             case _:
                 # NOTE: Shouldn't happen, this is only if somehow they didn't choose an org type
                 is_complete = False
-
-        if not is_complete or not self._is_general_form_complete():
+        if not is_complete or not self._is_general_form_complete(request):
             return False
-
         return True

--- a/src/registrar/models/domain_request.py
+++ b/src/registrar/models/domain_request.py
@@ -1174,7 +1174,7 @@ class DomainRequest(TimeStampedModel):
             and self._is_authorizing_official_complete()
             and self._is_requested_domain_complete()
             and self._is_purpose_complete()
-            # NOTE: This flag leaves submitter as empty (request wont submt) hence preset to True
+            # NOTE: This flag leaves submitter as empty (request wont submit) hence preset to True
             and (self._is_submitter_complete() if not has_profile_feature_flag else True)
             and self._is_other_contacts_complete()
             and self._is_additional_details_complete()

--- a/src/registrar/tests/test_models.py
+++ b/src/registrar/tests/test_models.py
@@ -2012,8 +2012,8 @@ class TestDomainRequestIncomplete(TestCase):
         self.domain_request.is_policy_acknowledged = None
         self.assertFalse(self.domain_request._is_policy_acknowledgement_complete())
 
-    def test_form_complete(self):
-        self.assertTrue(self.domain_request._form_complete())
+    def test_form_complete(self, request):
+        self.assertTrue(self.domain_request._form_complete(request))
         self.domain_request.generic_org_type = None
         self.domain_request.save()
-        self.assertFalse(self.domain_request._form_complete())
+        self.assertFalse(self.domain_request._form_complete(request))

--- a/src/registrar/tests/test_models.py
+++ b/src/registrar/tests/test_models.py
@@ -3,6 +3,8 @@ from django.db.utils import IntegrityError
 from unittest.mock import patch
 from django.contrib.auth import get_user_model
 
+from django.test import RequestFactory
+
 from registrar.models import (
     Contact,
     DomainRequest,
@@ -1610,6 +1612,7 @@ class TestDomainInformationCustomSave(TestCase):
 class TestDomainRequestIncomplete(TestCase):
     def setUp(self):
         super().setUp()
+        self.factory = RequestFactory()
         username = "test_user"
         first_name = "First"
         last_name = "Last"
@@ -2012,7 +2015,10 @@ class TestDomainRequestIncomplete(TestCase):
         self.domain_request.is_policy_acknowledged = None
         self.assertFalse(self.domain_request._is_policy_acknowledgement_complete())
 
-    def test_form_complete(self, request):
+    def test_form_complete(self):
+        request = self.factory.get("/")
+        request.user = self.user
+
         self.assertTrue(self.domain_request._form_complete(request))
         self.domain_request.generic_org_type = None
         self.domain_request.save()

--- a/src/registrar/views/domain_request.py
+++ b/src/registrar/views/domain_request.py
@@ -383,7 +383,7 @@ class DomainRequestWizard(DomainRequestWizardPermissionView, TemplateView):
         has_profile_flag = flag_is_active(self.request, "profile_feature")
 
         context_stuff = {}
-        if DomainRequest._form_complete(self.domain_request):
+        if DomainRequest._form_complete(self.domain_request, self.request):
             modal_button = '<button type="submit" ' 'class="usa-button" ' ">Submit request</button>"
             context_stuff = {
                 "not_form": False,
@@ -695,7 +695,7 @@ class Review(DomainRequestWizard):
     forms = []  # type: ignore
 
     def get_context_data(self):
-        if DomainRequest._form_complete(self.domain_request) is False:
+        if DomainRequest._form_complete(self.domain_request, self.request) is False:
             logger.warning("User arrived at review page with an incomplete form.")
         context = super().get_context_data()
         context["Step"] = Step.__members__


### PR DESCRIPTION
## Ticket

Resolves #2358 


## Changes

* When the `profile_flag` flag is turned on, we can ignore the submitter section so a user can submit a request.

## Context for reviewers

Beforehand when the `profile_flag` was turned on, the request even if filled out correctly would continue to be marked as incomplete due to the `_is_submitter_complete` check being empty (but not displayed)

## Setup

1. Go to my sandbox
2. Go to `/admin/registrar/waffleflag/` and turn the `profile_flag` feature on
<img width="385" alt="Screenshot 2024-06-24 at 12 49 48 PM" src="https://github.com/cisagov/manage.get.gov/assets/13954664/3adba5d7-8f01-4008-9b8b-a4633996aa22">

3. Create a new request and fill everything out correctly
4. You should now be able to submit a request

See [Slack thread](https://cisa-corp.slack.com/archives/C05BGB4L5NF/p1719239546980979) for error that was displaying before 

## Code Review Verification Steps

### As the original developer, I have

#### Satisfied acceptance criteria and met development standards

- [ ] Met the acceptance criteria, or will meet them in a subsequent PR
- [ ] Created/modified automated tests
- [ ] Added at least 2 developers as PR reviewers (only 1 will need to approve)
- [ ] Messaged on Slack or in standup to notify the team that a PR is ready for review
- [ ] Changes to “how we do things” are documented in READMEs and or onboarding guide
- [ ] If any model was updated to modify/add/delete columns, makemigrations was ran and the associated migrations file has been commited.

#### Ensured code standards are met (Original Developer)

- [ ] All new functions and methods are commented using plain language
- [ ] Did dependency updates in Pipfile also get changed in requirements.txt?
- [ ] Interactions with external systems are wrapped in try/except
- [ ] Error handling exists for unusual or missing values

#### Validated user-facing changes (if applicable)

- [ ] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Checked keyboard navigability
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)
- [ ] Add at least 1 designer as PR reviewer

### As a code reviewer, I have

#### Reviewed, tested, and left feedback about the changes

- [ ] Pulled this branch locally and tested it
- [ ] Reviewed this code and left comments
- [ ] Checked that all code is adequately covered by tests
- [ ] Made it clear which comments need to be addressed before this work is merged
- [ ] If any model was updated to modify/add/delete columns, makemigrations was ran and the associated migrations file has been commited.

#### Ensured code standards are met (Code reviewer)

- [ ] All new functions and methods are commented using plain language
- [ ] Interactions with external systems are wrapped in try/except
- [ ] Error handling exists for unusual or missing values
- [ ] (Rarely needed) Did dependency updates in Pipfile also get changed in requirements.txt?

#### Validated user-facing changes as a developer

- [ ] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Checked keyboard navigability
- [ ] Meets all designs and user flows provided by design/product
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)

- [ ] Tested with multiple browsers, the suggestion is to use ones that the developer didn't (check off which ones were used)
  - [ ] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari

- [ ] (Rarely needed) Tested as both an analyst and applicant user

**Note:** Multiple code reviewers can share the checklists above, a second reviewers should not make a duplicate checklist

### As a designer reviewer, I have

#### Verified that the changes match the design intention

- [ ] Checked that the design translated visually
- [ ] Checked behavior
- [ ] Checked different states (empty, one, some, error)
- [ ] Checked for landmarks, page heading structure, and links
- [ ] Tried to break the intended flow

#### Validated user-facing changes as a designer

- [ ] Checked keyboard navigability
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)

- [ ] Tested with multiple browsers (check off which ones were used)
  - [ ] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari

- [ ] (Rarely needed) Tested as both an analyst and applicant user

## Screenshots

<!-- If this PR makes visible interface changes, an image of the finished interface can help reviewers
and casual observers understand the context of the changes.
A before image is optional and can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow.
You may want to use [GIPHY Capture](https://giphy.com/apps/giphycapture) for this! 📸

_Please frame images to show useful context but also highlight the affected regions._
--->
