### PR TITLE
Issue #2274: removed data calculation from renew_domain DJA function

### DIFF
--- a/src/registrar/admin.py
+++ b/src/registrar/admin.py
@@ -2194,6 +2194,9 @@ class DomainAdmin(ListHeaderAdmin, ImportExportModelAdmin):
 
             extra_context["state_help_message"] = Domain.State.get_admin_help_text(domain.state)
             extra_context["domain_state"] = domain.get_state_display()
+            extra_context["curr_exp_date"] = (
+                domain.expiration_date if domain.expiration_date is not None else self._get_current_date()
+            )
 
         return super().changeform_view(request, object_id, form_url, extra_context)
 

--- a/src/registrar/templates/django/admin/domain_change_form.html
+++ b/src/registrar/templates/django/admin/domain_change_form.html
@@ -76,6 +76,9 @@
                     </p>
                     <p>
                         Domain: <b>{{ original.name }}</b>
+                        {# Acts as a <br> #}
+                        <div class="display-inline"></div>
+                        Current expiration date: <b>{{ curr_exp_date }}</b>
                         {{test}}
                     </p>
                 </div>

--- a/src/registrar/templates/django/admin/domain_change_form.html
+++ b/src/registrar/templates/django/admin/domain_change_form.html
@@ -69,16 +69,13 @@
                 </h2>
                 <div class="usa-prose">
                     <p>
-                        This will extend the expiration date by one year.
+                        This will extend the expiration date by one year from today.
                         {# Acts as a <br> #}
                         <div class="display-inline"></div>
                         This action cannot be undone.
                     </p>
                     <p>
                         Domain: <b>{{ original.name }}</b>
-                        {# Acts as a <br> #}
-                        <div class="display-inline"></div>
-                        New expiration date: <b>{{ extended_expiration_date }}</b>
                         {{test}}
                     </p>
                 </div>

--- a/src/registrar/tests/common.py
+++ b/src/registrar/tests/common.py
@@ -1543,8 +1543,6 @@ class MockEppLib(TestCase):
     def mockInfoDomainCommands(self, _request, cleaned):
         request_name = getattr(_request, "name", None).lower()
 
-        print(request_name)
-
         # Define a dictionary to map request names to data and extension values
         request_mappings = {
             "security.gov": (self.infoDomainNoContact, None),

--- a/src/registrar/tests/test_admin.py
+++ b/src/registrar/tests/test_admin.py
@@ -374,9 +374,9 @@ class TestDomainAdmin(MockEppLib, WebTest):
 
         # Create a ready domain with a preset expiration date
         domain, _ = Domain.objects.get_or_create(name="fake.gov", state=Domain.State.READY)
-
         response = self.app.get(reverse("admin:registrar_domain_change", args=[domain.pk]))
-
+        # load expiration date into cache and registrar with below command
+        domain.registry_expiration_date
         # Make sure the ex date is what we expect it to be
         domain_ex_date = Domain.objects.get(id=domain.id).expiration_date
         self.assertEqual(domain_ex_date, date(2023, 5, 25))
@@ -400,7 +400,6 @@ class TestDomainAdmin(MockEppLib, WebTest):
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, domain.name)
         self.assertContains(response, "Extend expiration date")
-        self.assertContains(response, "New expiration date: <b>May 25, 2025</b>")
 
         # Ensure the message we recieve is in line with what we expect
         expected_message = "Successfully extended the expiration date."

--- a/src/registrar/tests/test_admin.py
+++ b/src/registrar/tests/test_admin.py
@@ -518,70 +518,10 @@ class TestDomainAdmin(MockEppLib, WebTest):
                 # Follow the response
                 response = response.follow()
 
-        # This value is based off of the current year - the expiration date.
-        # We "freeze" time to 2024, so 2024 - 2023 will always result in an
-        # "extension" of 2, as that will be one year of extension from that date.
-        extension_length = 2
-
-        # Assert that it is calling the function with the right extension length.
+        # Assert that it is calling the function with the default extension length.
         # We only need to test the value that EPP sends, as we can assume the other
         # test cases cover the "renew" function.
-        renew_mock.assert_has_calls([call(length=extension_length)], any_order=False)
-
-        # We should not make duplicate calls
-        self.assertEqual(renew_mock.call_count, 1)
-
-        # Assert that everything on the page looks correct
-        self.assertEqual(response.status_code, 200)
-        self.assertContains(response, domain.name)
-        self.assertContains(response, "Extend expiration date")
-
-        # Ensure the message we recieve is in line with what we expect
-        expected_message = "Successfully extended the expiration date."
-        expected_call = call(
-            # The WGSI request doesn't need to be tested
-            ANY,
-            messages.INFO,
-            expected_message,
-            extra_tags="",
-            fail_silently=False,
-        )
-        mock_add_message.assert_has_calls([expected_call], 1)
-
-    @patch("registrar.admin.DomainAdmin._get_current_date", return_value=date(2023, 1, 1))
-    def test_extend_expiration_date_button_date_matches_epp(self, mock_date_today):
-        """
-        Tests if extend_expiration_date button sends the right epp command
-        when the current year matches the expiration date
-        """
-
-        # Create a ready domain with a preset expiration date
-        domain, _ = Domain.objects.get_or_create(name="fake.gov", state=Domain.State.READY)
-
-        response = self.app.get(reverse("admin:registrar_domain_change", args=[domain.pk]))
-
-        # Make sure that the page is loading as expected
-        self.assertEqual(response.status_code, 200)
-        self.assertContains(response, domain.name)
-        self.assertContains(response, "Extend expiration date")
-
-        # Grab the form to submit
-        form = response.forms["domain_form"]
-
-        with patch("django.contrib.messages.add_message") as mock_add_message:
-            with patch("registrar.models.Domain.renew_domain") as renew_mock:
-                # Submit the form
-                response = form.submit("_extend_expiration_date")
-
-                # Follow the response
-                response = response.follow()
-
-        extension_length = 1
-
-        # Assert that it is calling the function with the right extension length.
-        # We only need to test the value that EPP sends, as we can assume the other
-        # test cases cover the "renew" function.
-        renew_mock.assert_has_calls([call(length=extension_length)], any_order=False)
+        renew_mock.assert_has_calls([call()], any_order=False)
 
         # We should not make duplicate calls
         self.assertEqual(renew_mock.call_count, 1)

--- a/src/registrar/tests/test_reports.py
+++ b/src/registrar/tests/test_reports.py
@@ -735,7 +735,6 @@ class ExportDataTest(MockDb, MockEppLib):
         csv_file.seek(0)
         # Read the content into a variable
         csv_content = csv_file.read()
-        print(csv_content)
         self.maxDiff = None
         expected_content = (
             # Header


### PR DESCRIPTION
## Ticket

Resolves #2274 
<!--Reminder, when a code change is made that is user facing, beyond content updates, then the following are required:
- a developer approves the PR
- a designer approves the PR or checks off all relevant items in this checklist.

All other changes require just a single approving review.-->

## Changes

<!-- What was added, updated, or removed in this PR. -->
- Removed date calculation on renew_domain function in django admin
- Set renew_domain to renew domain 1 year from today
- Updated modal to not display an estimated renew date

<!--
    Please add/remove/edit any of the template below to fit the needs
    of this specific PR.
--->

## Context for reviewers

<!--Background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers.  -->
Navigate to django admin.  Select a domain.  Click the Extend expiration date link in the upper right of the change form.  Confirm the update.  Verify that the new expiration date is one year from today

## Setup

<!--  Add any steps or code to run in this section to help others run your code.
    
    Example 1:
    ```sh
    echo "Code goes here"
    ``` 
    
    Example 2: If the PR was to add a new link with a redirect, this section could simply be:
    -go to /path/to/start/page
    -click the blue link in the <insert location>
    -notice user is redirected to <proper end location>
-->

## Code Review Verification Steps

### As the original developer, I have

#### Satisfied acceptance criteria and met development standards

- [x] Met the acceptance criteria, or will meet them in a subsequent PR
- [x] Created/modified automated tests
- [x] Added at least 2 developers as PR reviewers (only 1 will need to approve)
- [x] Messaged on Slack or in standup to notify the team that a PR is ready for review
- [ ] Changes to “how we do things” are documented in READMEs and or onboarding guide
- [ ] If any model was updated to modify/add/delete columns, makemigrations was ran and the associated migrations file has been commited.

#### Ensured code standards are met (Original Developer)

- [ ] All new functions and methods are commented using plain language
- [ ] Did dependency updates in Pipfile also get changed in requirements.txt?
- [ ] Interactions with external systems are wrapped in try/except
- [ ] Error handling exists for unusual or missing values

#### Validated user-facing changes (if applicable)

- [ ] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Checked keyboard navigability
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)
- [ ] Add at least 1 designer as PR reviewer

### As a code reviewer, I have

#### Reviewed, tested, and left feedback about the changes

- [ ] Pulled this branch locally and tested it
- [ ] Reviewed this code and left comments
- [ ] Checked that all code is adequately covered by tests
- [ ] Made it clear which comments need to be addressed before this work is merged
- [ ] If any model was updated to modify/add/delete columns, makemigrations was ran and the associated migrations file has been commited.

#### Ensured code standards are met (Code reviewer)

- [ ] All new functions and methods are commented using plain language
- [ ] Interactions with external systems are wrapped in try/except
- [ ] Error handling exists for unusual or missing values
- [ ] (Rarely needed) Did dependency updates in Pipfile also get changed in requirements.txt?

#### Validated user-facing changes as a developer

- [ ] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Checked keyboard navigability
- [ ] Meets all designs and user flows provided by design/product
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)

- [ ] Tested with multiple browsers, the suggestion is to use ones that the developer didn't (check off which ones were used)
  - [ ] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari

- [ ] (Rarely needed) Tested as both an analyst and applicant user

**Note:** Multiple code reviewers can share the checklists above, a second reviewers should not make a duplicate checklist

### As a designer reviewer, I have

#### Verified that the changes match the design intention

- [ ] Checked that the design translated visually
- [ ] Checked behavior
- [ ] Checked different states (empty, one, some, error)
- [ ] Checked for landmarks, page heading structure, and links
- [ ] Tried to break the intended flow

#### Validated user-facing changes as a designer

- [ ] Checked keyboard navigability
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)

- [ ] Tested with multiple browsers (check off which ones were used)
  - [ ] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari

- [ ] (Rarely needed) Tested as both an analyst and applicant user

## Screenshots

<!-- If this PR makes visible interface changes, an image of the finished interface can help reviewers
and casual observers understand the context of the changes.
A before image is optional and can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow.
You may want to use [GIPHY Capture](https://giphy.com/apps/giphycapture) for this! 📸

_Please frame images to show useful context but also highlight the affected regions._
--->
