### PR TITLE
Update issue-default.yml to use * in links to other issues section

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue-default.yml
+++ b/.github/ISSUE_TEMPLATE/issue-default.yml
@@ -31,8 +31,8 @@ body:
     attributes:
       label: Links to other issues
       description: |
-        "Add issue #numbers this relates to and how (e.g., 🚧 [construction] Blocks, ⛔️ [no_entry] Is blocked by, 🔄 [arrows_counterclockwise] Relates to)."
-      placeholder: 🔄 Relates to... 
+        "With a `*` to start, add issue #numbers this relates to and how (e.g., 🚧 [construction] Blocks, ⛔️ [no_entry] Is blocked by, 🔄 [arrows_counterclockwise] Relates to)."
+      placeholder: * 🔄 Relates to... 
   - type: markdown
     id: note
     attributes:

--- a/.github/ISSUE_TEMPLATE/issue-default.yml
+++ b/.github/ISSUE_TEMPLATE/issue-default.yml
@@ -31,8 +31,8 @@ body:
     attributes:
       label: Links to other issues
       description: |
-        "With a `*` to start, add issue #numbers this relates to and how (e.g., 🚧 [construction] Blocks, ⛔️ [no_entry] Is blocked by, 🔄 [arrows_counterclockwise] Relates to)."
-      placeholder: * 🔄 Relates to... 
+        "With a `-` to start the line, add issue #numbers this relates to and how (e.g., 🚧 [construction] Blocks, ⛔️ [no_entry] Is blocked by, 🔄 [arrows_counterclockwise] Relates to)."
+      placeholder: "- 🔄 Relates to...
   - type: markdown
     id: note
     attributes:


### PR DESCRIPTION
Using a `*` before an issue makes GitHub display the issue details and whether it's open or closed. We like this! This change encourages its use in the issue template.