### PR TITLE
Update issue-default.yml

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue-default.yml
+++ b/.github/ISSUE_TEMPLATE/issue-default.yml
@@ -32,7 +32,7 @@ body:
       label: Links to other issues
       description: |
         "With a `-` to start the line, add issue #numbers this relates to and how (e.g., 🚧 [construction] Blocks, ⛔️ [no_entry] Is blocked by, 🔄 [arrows_counterclockwise] Relates to)."
-      placeholder: "- 🔄 Relates to...
+      placeholder: "- 🔄 Relates to..."
   - type: markdown
     id: note
     attributes:


### PR DESCRIPTION
An error in #2385 (missing `"`) borked our issue template. This incredibly small change brings the template back to life.