### PR TITLE
ISSUE #2388: Fix show detail section

### DIFF
--- a/src/registrar/admin.py
+++ b/src/registrar/admin.py
@@ -1383,7 +1383,7 @@ class DomainInformationAdmin(ListHeaderAdmin, ImportExportModelAdmin):
             for name, data in fieldsets:
                 fields = data.get("fields", [])
                 fields = tuple(field for field in fields if field not in DomainInformationAdmin.superuser_only_fields)
-                modified_fieldsets.append((name, {"fields": fields}))
+                modified_fieldsets.append((name, {**data, "fields": fields}))
             return modified_fieldsets
         return fieldsets
 

--- a/src/registrar/admin.py
+++ b/src/registrar/admin.py
@@ -2814,7 +2814,6 @@ admin.site.register(models.DomainGroup, DomainGroupAdmin)
 admin.site.register(models.Suborganization, SuborganizationAdmin)
 admin.site.register(models.SeniorOfficial, SeniorOfficialAdmin)
 
-
 # Register our custom waffle implementations
 admin.site.register(models.WaffleFlag, WaffleFlagAdmin)
 

--- a/src/registrar/admin.py
+++ b/src/registrar/admin.py
@@ -1043,6 +1043,19 @@ class ContactAdmin(ListHeaderAdmin, ImportExportModelAdmin):
         return super().changelist_view(request, extra_context=extra_context)
 
 
+class SeniorOfficialAdmin(ListHeaderAdmin):
+    """Custom Senior Official Admin class."""
+
+    # NOTE: these are just placeholders.  Not part of ACs (haven't been defined yet).  Update in future tickets.
+    search_fields = ["first_name", "last_name", "email"]
+    search_help_text = "Search by first name, last name or email."
+    list_display = ["first_name", "last_name", "email"]
+
+    # this ordering effects the ordering of results
+    # in autocomplete_fields for Senior Official
+    ordering = ["first_name", "last_name"]
+
+
 class WebsiteResource(resources.ModelResource):
     """defines how each field in the referenced model should be mapped to the corresponding fields in the
     import/export file"""
@@ -2798,6 +2811,7 @@ admin.site.register(models.TransitionDomain, TransitionDomainAdmin)
 admin.site.register(models.VerifiedByStaff, VerifiedByStaffAdmin)
 admin.site.register(models.Portfolio, PortfolioAdmin)
 admin.site.register(models.DomainGroup, DomainGroupAdmin)
+admin.site.register(models.SeniorOfficial, SeniorOfficialAdmin)
 admin.site.register(models.Suborganization, SuborganizationAdmin)
 
 # Register our custom waffle implementations

--- a/src/registrar/admin.py
+++ b/src/registrar/admin.py
@@ -2811,8 +2811,9 @@ admin.site.register(models.TransitionDomain, TransitionDomainAdmin)
 admin.site.register(models.VerifiedByStaff, VerifiedByStaffAdmin)
 admin.site.register(models.Portfolio, PortfolioAdmin)
 admin.site.register(models.DomainGroup, DomainGroupAdmin)
-admin.site.register(models.SeniorOfficial, SeniorOfficialAdmin)
 admin.site.register(models.Suborganization, SuborganizationAdmin)
+admin.site.register(models.SeniorOfficial, SeniorOfficialAdmin)
+
 
 # Register our custom waffle implementations
 admin.site.register(models.WaffleFlag, WaffleFlagAdmin)

--- a/src/registrar/admin.py
+++ b/src/registrar/admin.py
@@ -1698,8 +1698,34 @@ class DomainRequestAdmin(ListHeaderAdmin, ImportExportModelAdmin):
             for name, data in fieldsets:
                 fields = data.get("fields", [])
                 fields = tuple(field for field in fields if field not in self.superuser_only_fields)
-                modified_fieldsets.append((name, {"fields": fields}))
+
+                # Handle Type of organization and its Show details
+                if name == "Type of organization":
+                    show_details_fields = (
+                        "federal_type",
+                        "federal_agency",
+                        "tribe_name",
+                        "federally_recognized_tribe",
+                        "state_recognized_tribe",
+                        "about_your_organization",
+                    )
+                    fields = tuple(field for field in fields if field not in show_details_fields)
+                    modified_fieldsets.append((name, {"fields": fields + show_details_fields}))
+                # Handle Organization name and mailing address and its Show details
+                elif name == "Organization name and mailing address":
+                    show_details_address_fields = (
+                        "address_line1",
+                        "address_line2",
+                        "city",
+                        "zipcode",
+                        "urbanization",
+                    )
+                    fields = tuple(field for field in fields if field not in show_details_address_fields)
+                    modified_fieldsets.append((name, {"fields": fields + show_details_address_fields}))
+                else:
+                    modified_fieldsets.append((name, {"fields": fields}))
             return modified_fieldsets
+
         return fieldsets
 
     # Table ordering


### PR DESCRIPTION
## Ticket

Resolves #2388 

<!--Reminder, when a code change is made that is user facing, beyond content updates, then the following are required:
- a developer approves the PR
- a designer approves the PR or checks off all relevant items in this checklist.

All other changes require just a single approving review.-->

## Changes

* When an Analyst comes in, the "show details" is nested under the `Type of organization` and `Organization name and mailing address` section


## Context for reviewers

Previously when an Analyst logged in, the show details seem to be separated/un-nested for those two sections

## Setup

1. Log in as an Analyst
2. Go to `/admin` in my sandbox
3. Click on `Domain requests` and click on any domain request you'd like
4. Check that `Show details` is nested under `Type of organization` and `Organization name and mailing address` and clickable

## Code Review Verification Steps

### As the original developer, I have

#### Satisfied acceptance criteria and met development standards

- [ ] Met the acceptance criteria, or will meet them in a subsequent PR
- [ ] Created/modified automated tests
- [ ] Added at least 2 developers as PR reviewers (only 1 will need to approve)
- [ ] Messaged on Slack or in standup to notify the team that a PR is ready for review
- [ ] Changes to “how we do things” are documented in READMEs and or onboarding guide
- [ ] If any model was updated to modify/add/delete columns, makemigrations was ran and the associated migrations file has been commited.

#### Ensured code standards are met (Original Developer)

- [ ] All new functions and methods are commented using plain language
- [ ] Did dependency updates in Pipfile also get changed in requirements.txt?
- [ ] Interactions with external systems are wrapped in try/except
- [ ] Error handling exists for unusual or missing values

#### Validated user-facing changes (if applicable)

- [ ] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Checked keyboard navigability
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)
- [ ] Add at least 1 designer as PR reviewer

### As a code reviewer, I have

#### Reviewed, tested, and left feedback about the changes

- [ ] Pulled this branch locally and tested it
- [ ] Reviewed this code and left comments
- [ ] Checked that all code is adequately covered by tests
- [ ] Made it clear which comments need to be addressed before this work is merged
- [ ] If any model was updated to modify/add/delete columns, makemigrations was ran and the associated migrations file has been commited.

#### Ensured code standards are met (Code reviewer)

- [ ] All new functions and methods are commented using plain language
- [ ] Interactions with external systems are wrapped in try/except
- [ ] Error handling exists for unusual or missing values
- [ ] (Rarely needed) Did dependency updates in Pipfile also get changed in requirements.txt?

#### Validated user-facing changes as a developer

- [ ] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Checked keyboard navigability
- [ ] Meets all designs and user flows provided by design/product
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)

- [ ] Tested with multiple browsers, the suggestion is to use ones that the developer didn't (check off which ones were used)
  - [ ] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari

- [ ] (Rarely needed) Tested as both an analyst and applicant user

**Note:** Multiple code reviewers can share the checklists above, a second reviewers should not make a duplicate checklist

### As a designer reviewer, I have

#### Verified that the changes match the design intention

- [ ] Checked that the design translated visually
- [ ] Checked behavior
- [ ] Checked different states (empty, one, some, error)
- [ ] Checked for landmarks, page heading structure, and links
- [ ] Tried to break the intended flow

#### Validated user-facing changes as a designer

- [ ] Checked keyboard navigability
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)

- [ ] Tested with multiple browsers (check off which ones were used)
  - [ ] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari

- [ ] (Rarely needed) Tested as both an analyst and applicant user

## Screenshots

<!-- If this PR makes visible interface changes, an image of the finished interface can help reviewers
and casual observers understand the context of the changes.
A before image is optional and can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow.
You may want to use [GIPHY Capture](https://giphy.com/apps/giphycapture) for this! 📸

_Please frame images to show useful context but also highlight the affected regions._
--->
