### PR TITLE
Issues #2377 #2501: Portfolio org page - [RJM]

### DIFF
--- a/src/registrar/forms/__init__.py
+++ b/src/registrar/forms/__init__.py
@@ -10,3 +10,6 @@ from .domain import (
     DomainDsdataFormset,
     DomainDsdataForm,
 )
+from .portfolio import (
+    PortfolioOrgAddressForm,
+)

--- a/src/registrar/forms/domain.py
+++ b/src/registrar/forms/domain.py
@@ -458,7 +458,7 @@ class DomainOrgNameAddressForm(forms.ModelForm):
     # the database fields have blank=True so ModelForm doesn't create
     # required fields by default. Use this list in __init__ to mark each
     # of these fields as required
-    required = ["organization_name", "address_line1", "city", "zipcode"]
+    required = ["organization_name", "address_line1", "city", "state_territory", "zipcode"]
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/src/registrar/forms/portfolio.py
+++ b/src/registrar/forms/portfolio.py
@@ -67,39 +67,3 @@ class PortfolioOrgAddressForm(forms.ModelForm):
             self.fields[field_name].required = True
         self.fields["state_territory"].widget.attrs.pop("maxlength", None)
         self.fields["zipcode"].widget.attrs.pop("maxlength", None)
-
-        # self.is_federal = self.instance.generic_org_type == DomainRequest.OrganizationChoices.FEDERAL
-        # self.is_tribal = self.instance.generic_org_type == DomainRequest.OrganizationChoices.TRIBAL
-
-        # field_to_disable = None
-        # if self.is_federal:
-        #     field_to_disable = "federal_agency"
-        # elif self.is_tribal:
-        #     field_to_disable = "organization_name"
-
-        # if field_to_disable is not None:
-        #     DomainHelper.disable_field(self.fields[field_to_disable], disable_required=True)
-
-    # def save(self, commit=True):
-    #     """Override the save() method of the BaseModelForm."""
-    #     if self.has_changed():
-
-    #         if self.is_federal and not self._field_unchanged("federal_agency"):
-    #             raise ValueError("federal_agency cannot be modified when the generic_org_type is federal")
-    #         elif self.is_tribal and not self._field_unchanged("organization_name"):
-    #             raise ValueError("organization_name cannot be modified when the generic_org_type is tribal")
-
-    #     else:
-    #         super().save()
-
-    # def _field_unchanged(self, field_name) -> bool:
-    #     """
-    #     Checks if a specified field has not changed between the old value
-    #     and the new value.
-
-    #     The old value is grabbed from self.initial.
-    #     The new value is grabbed from self.cleaned_data.
-    #     """
-    #     old_value = self.initial.get(field_name, None)
-    #     new_value = self.cleaned_data.get(field_name, None)
-    #     return old_value == new_value

--- a/src/registrar/forms/portfolio.py
+++ b/src/registrar/forms/portfolio.py
@@ -1,0 +1,105 @@
+"""Forms for portfolio."""
+
+import logging
+from django import forms
+from django.core.validators import RegexValidator
+
+from ..models import DomainInformation, Portfolio
+
+logger = logging.getLogger(__name__)
+
+
+class PortfolioOrgAddressForm(forms.ModelForm):
+    """Form for updating the portfolio org mailing address."""
+
+    zipcode = forms.CharField(
+        label="Zip code",
+        validators=[
+            RegexValidator(
+                "^[0-9]{5}(?:-[0-9]{4})?$|^$",
+                message="Enter a zip code in the required format, like 12345 or 12345-6789.",
+            )
+        ],
+    )
+
+    class Meta:
+        model = Portfolio
+        fields = [
+            "address_line1",
+            "address_line2",
+            "city",
+            "state_territory",
+            "zipcode",
+            # "urbanization",
+        ]
+        error_messages = {
+            "address_line1": {"required": "Enter the street address of your organization."},
+            "city": {"required": "Enter the city where your organization is located."},
+            "state_territory": {
+                "required": "Select the state, territory, or military post where your organization is located."
+            },
+        }
+        widgets = {
+            # We need to set the required attributed for State/territory
+            # because for this fields we are creating an individual
+            # instance of the Select. For the other fields we use the for loop to set
+            # the class's required attribute to true.
+            "address_line1": forms.TextInput,
+            "address_line2": forms.TextInput,
+            "city": forms.TextInput,
+            "state_territory": forms.Select(
+                attrs={
+                    "required": True,
+                },
+                choices=DomainInformation.StateTerritoryChoices.choices,
+            ),
+            # "urbanization": forms.TextInput,
+        }
+
+    # the database fields have blank=True so ModelForm doesn't create
+    # required fields by default. Use this list in __init__ to mark each
+    # of these fields as required
+    required = ["address_line1", "city", "state_territory", "zipcode"]
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        for field_name in self.required:
+            self.fields[field_name].required = True
+        self.fields["state_territory"].widget.attrs.pop("maxlength", None)
+        self.fields["zipcode"].widget.attrs.pop("maxlength", None)
+
+        # self.is_federal = self.instance.generic_org_type == DomainRequest.OrganizationChoices.FEDERAL
+        # self.is_tribal = self.instance.generic_org_type == DomainRequest.OrganizationChoices.TRIBAL
+
+        # field_to_disable = None
+        # if self.is_federal:
+        #     field_to_disable = "federal_agency"
+        # elif self.is_tribal:
+        #     field_to_disable = "organization_name"
+
+        # if field_to_disable is not None:
+        #     DomainHelper.disable_field(self.fields[field_to_disable], disable_required=True)
+
+    # def save(self, commit=True):
+    #     """Override the save() method of the BaseModelForm."""
+    #     if self.has_changed():
+
+    #         if self.is_federal and not self._field_unchanged("federal_agency"):
+    #             raise ValueError("federal_agency cannot be modified when the generic_org_type is federal")
+    #         elif self.is_tribal and not self._field_unchanged("organization_name"):
+    #             raise ValueError("organization_name cannot be modified when the generic_org_type is tribal")
+
+    #     else:
+    #         super().save()
+
+    # def _field_unchanged(self, field_name) -> bool:
+    #     """
+    #     Checks if a specified field has not changed between the old value
+    #     and the new value.
+
+    #     The old value is grabbed from self.initial.
+    #     The new value is grabbed from self.cleaned_data.
+    #     """
+    #     old_value = self.initial.get(field_name, None)
+    #     new_value = self.cleaned_data.get(field_name, None)
+    #     return old_value == new_value

--- a/src/registrar/models/portfolio.py
+++ b/src/registrar/models/portfolio.py
@@ -6,11 +6,6 @@ from registrar.models.federal_agency import FederalAgency
 from .utility.time_stamped_model import TimeStampedModel
 
 
-# def get_default_federal_agency():
-#     """returns non-federal agency"""
-#     return FederalAgency.objects.filter(agency="Non-Federal Agency").first()
-
-
 class Portfolio(TimeStampedModel):
     """
     Portfolio is used for organizing domains/domain-requests into

--- a/src/registrar/templates/portfolio_organization.html
+++ b/src/registrar/templates/portfolio_organization.html
@@ -1,8 +1,64 @@
 {% extends 'portfolio_base.html' %}
+{% load static field_helpers%}
+
+{% block title %}Organization mailing address | {{ portfolio.name }} | {% endblock %}
 
 {% load static %}
 
 {% block portfolio_content %}
-    <h1>Organization</h1>
+<div class="grid-row grid-gap">
+    <div class="tablet:grid-col-3">
+        <p class="font-body-md margin-top-0 margin-bottom-2
+                    text-primary-darker text-semibold"
+        >
+            <span class="usa-sr-only"> Portfolio name:</span> {{ portfolio }}
+        </p>
 
+        {% include 'portfolio_organization_sidebar.html' %}
+    </div>
+
+    <div class="tablet:grid-col-9">
+
+        <h1>Organization</h1>
+
+        <p>The name of your federal agency will be publicly listed as the domain registrant.</p>
+
+        <p>
+            The federal agency for your organization can’t be updated here.
+            To suggest an update, email <a href="mailto:help@get.gov" class="usa-link">help@get.gov</a>.
+        </p>
+
+        {% include "includes/form_errors.html" with form=form %}
+
+        {% include "includes/required_fields.html" %}
+
+        <form class="usa-form usa-form--large" method="post" novalidate id="form-container">
+            {% csrf_token %}
+
+            <p>
+                <strong class="text-primary display-block margin-bottom-1">Federal agency</strong>
+                {{ portfolio }}
+            </p>
+
+            {% input_with_errors form.address_line1 %}
+
+            {% input_with_errors form.address_line2 %}
+
+            {% input_with_errors form.city %}
+
+            {% input_with_errors form.state_territory %}
+
+            {% with add_class="usa-input--small" %}
+            {% input_with_errors form.zipcode %}
+            {% endwith %}
+
+            <button
+            type="submit"
+            class="usa-button"
+            >
+            Save
+            </button>
+        </form>
+    </div>
+</div>
 {% endblock %}

--- a/src/registrar/templates/portfolio_organization_sidebar.html
+++ b/src/registrar/templates/portfolio_organization_sidebar.html
@@ -1,0 +1,23 @@
+{% load static url_helpers %}
+
+<div class="margin-bottom-4 tablet:margin-bottom-0">
+  <nav aria-label="Domain sections">
+    <ul class="usa-sidenav">
+      <li class="usa-sidenav__item">
+        {% url 'portfolio-organization' portfolio_id=portfolio.id as url %} 
+        <a href="{{ url }}" 
+          {% if request.path == url %}class="usa-current"{% endif %}
+        >
+          Organization
+        </a>
+      </li>
+
+      <li class="usa-sidenav__item">
+        <a href="#"
+        >
+            Senior official
+        </a>
+      </li>
+    </ul>
+  </nav>
+</div>

--- a/src/registrar/tests/test_views_portfolio.py
+++ b/src/registrar/tests/test_views_portfolio.py
@@ -10,7 +10,6 @@ from registrar.models import (
     UserDomainRole,
     User,
 )
-from registrar.tests.test_views import TestWithUser
 from .common import create_test_user
 from waffle.testutils import override_flag
 

--- a/src/registrar/tests/test_views_portfolio.py
+++ b/src/registrar/tests/test_views_portfolio.py
@@ -1,5 +1,6 @@
 from django.urls import reverse
 from api.tests.common import less_console_noise_decorator
+from registrar.config import settings
 from registrar.models.portfolio import Portfolio
 from django_webtest import WebTest  # type: ignore
 from registrar.models import (
@@ -17,7 +18,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-class TestPortfolioViews(TestWithUser, WebTest):
+class TestPortfolio(TestWithUser, WebTest):
     def setUp(self):
         super().setUp()
         self.domain, _ = Domain.objects.get_or_create(name="igorville.gov")
@@ -190,3 +191,70 @@ class TestPortfolioViews(TestWithUser, WebTest):
         DomainInformation.objects.all().delete()
         Domain.objects.all().delete()
         super().tearDown()
+
+
+class TestPortfolioOrganization(TestPortfolio):
+
+    def test_portfolio_org_name(self):
+        """Can load portfolio's org name page."""
+        with override_flag("organization_feature", active=True):
+            self.app.set_user(self.user.username)
+            self.user.portfolio = self.portfolio
+            self.user.portfolio_additional_permissions = [
+                User.UserPortfolioPermissionChoices.VIEW_PORTFOLIO,
+                User.UserPortfolioPermissionChoices.EDIT_PORTFOLIO,
+            ]
+            self.user.save()
+            self.user.refresh_from_db()
+
+            page = self.app.get(reverse("portfolio-organization", kwargs={"portfolio_id": self.portfolio.pk}))
+            self.assertContains(
+                page, "The name of your federal agency will be publicly listed as the domain registrant."
+            )
+
+    def test_domain_org_name_address_content(self):
+        """Org name and address information appears on the page."""
+        with override_flag("organization_feature", active=True):
+            self.app.set_user(self.user.username)
+            self.user.portfolio = self.portfolio
+            self.user.portfolio_additional_permissions = [
+                User.UserPortfolioPermissionChoices.VIEW_PORTFOLIO,
+                User.UserPortfolioPermissionChoices.EDIT_PORTFOLIO,
+            ]
+            self.user.save()
+            self.user.refresh_from_db()
+
+            self.portfolio.organization_name = "Hotel California"
+            self.portfolio.save()
+            page = self.app.get(reverse("portfolio-organization", kwargs={"portfolio_id": self.portfolio.pk}))
+            # Once in the sidenav, once in the main nav, once in the form
+            self.assertContains(page, "Hotel California", count=3)
+
+    def test_domain_org_name_address_form(self):
+        """Submitting changes works on the org name address page."""
+        with override_flag("organization_feature", active=True):
+            self.app.set_user(self.user.username)
+            self.user.portfolio = self.portfolio
+            self.user.portfolio_additional_permissions = [
+                User.UserPortfolioPermissionChoices.VIEW_PORTFOLIO,
+                User.UserPortfolioPermissionChoices.EDIT_PORTFOLIO,
+            ]
+            self.user.save()
+            self.user.refresh_from_db()
+
+            self.portfolio.address_line1 = "1600 Penn Ave"
+            self.portfolio.save()
+            portfolio_org_name_page = self.app.get(
+                reverse("portfolio-organization", kwargs={"portfolio_id": self.portfolio.pk})
+            )
+            session_id = self.app.cookies[settings.SESSION_COOKIE_NAME]
+
+            portfolio_org_name_page.form["address_line1"] = "6 Downing st"
+            portfolio_org_name_page.form["city"] = "London"
+
+            self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
+            success_result_page = portfolio_org_name_page.form.submit()
+            self.assertEqual(success_result_page.status_code, 200)
+
+            self.assertContains(success_result_page, "6 Downing st")
+            self.assertContains(success_result_page, "London")

--- a/src/registrar/views/portfolios.py
+++ b/src/registrar/views/portfolios.py
@@ -1,4 +1,8 @@
+import logging
 from django.shortcuts import get_object_or_404, render
+from django.urls import reverse
+from django.contrib import messages
+from registrar.forms.portfolio import PortfolioOrgAddressForm
 from registrar.models.portfolio import Portfolio
 from registrar.views.utility.permission_views import (
     PortfolioDomainRequestsPermissionView,
@@ -7,6 +11,10 @@ from registrar.views.utility.permission_views import (
 )
 from waffle.decorators import flag_is_active
 from django.views.generic import View
+from django.views.generic.edit import FormMixin
+
+
+logger = logging.getLogger(__name__)
 
 
 class PortfolioDomainsView(PortfolioDomainsPermissionView, View):
@@ -42,17 +50,60 @@ class PortfolioDomainRequestsView(PortfolioDomainRequestsPermissionView, View):
         return render(request, "portfolio_requests.html", context)
 
 
-class PortfolioOrganizationView(PortfolioBasePermissionView, View):
+class PortfolioOrganizationView(PortfolioBasePermissionView, FormMixin):
+    """
+    View to handle displaying and updating the portfolio's organization details.
+    """
 
+    model = Portfolio
     template_name = "portfolio_organization.html"
+    form_class = PortfolioOrgAddressForm
+    context_object_name = "portfolio"
 
-    def get(self, request, portfolio_id):
-        context = {}
+    def get_context_data(self, **kwargs):
+        """Add additional context data to the template."""
+        context = super().get_context_data(**kwargs)
+        context["has_profile_feature_flag"] = flag_is_active(self.request, "profile_feature")
+        context["has_organization_feature_flag"] = flag_is_active(self.request, "organization_feature")
+        return context
 
-        if self.request.user.is_authenticated:
-            context["has_profile_feature_flag"] = flag_is_active(request, "profile_feature")
-            context["has_organization_feature_flag"] = flag_is_active(request, "organization_feature")
-            portfolio = get_object_or_404(Portfolio, id=portfolio_id)
-            context["portfolio"] = portfolio
+    def get_object(self, queryset=None):
+        """Get the portfolio object based on the URL parameter."""
+        return get_object_or_404(Portfolio, id=self.kwargs.get("portfolio_id"))
+    
+    def get_form_kwargs(self):
+        """Include the instance in the form kwargs."""
+        kwargs = super().get_form_kwargs()
+        kwargs['instance'] = self.get_object()
+        return kwargs
 
-        return render(request, "portfolio_organization.html", context)
+    def get(self, request, *args, **kwargs):
+        """Handle GET requests to display the form."""
+        self.object = self.get_object()
+        form = self.get_form()
+        return self.render_to_response(self.get_context_data(form=form))
+
+    def post(self, request, *args, **kwargs):
+        """Handle POST requests to process form submission."""
+        self.object = self.get_object()
+        form = self.get_form()
+        if form.is_valid():
+            return self.form_valid(form)
+        else:
+            return self.form_invalid(form)
+
+    def form_valid(self, form):
+        """Handle the case when the form is valid."""
+        self.object = form.save(commit=False)
+        self.object.creator = self.request.user
+        self.object.save()
+        messages.success(self.request, "The organization information for this portfolio has been updated.")
+        return super().form_valid(form)
+
+    def form_invalid(self, form):
+        """Handle the case when the form is invalid."""
+        return self.render_to_response(self.get_context_data(form=form))
+
+    def get_success_url(self):
+        """Redirect to the overview page for the portfolio."""
+        return reverse("portfolio-organization", kwargs={"portfolio_id": self.object.pk})

--- a/src/registrar/views/portfolios.py
+++ b/src/registrar/views/portfolios.py
@@ -63,6 +63,7 @@ class PortfolioOrganizationView(PortfolioBasePermissionView, FormMixin):
     def get_context_data(self, **kwargs):
         """Add additional context data to the template."""
         context = super().get_context_data(**kwargs)
+        # no need to add portfolio to request context here
         context["has_profile_feature_flag"] = flag_is_active(self.request, "profile_feature")
         context["has_organization_feature_flag"] = flag_is_active(self.request, "organization_feature")
         return context
@@ -70,11 +71,11 @@ class PortfolioOrganizationView(PortfolioBasePermissionView, FormMixin):
     def get_object(self, queryset=None):
         """Get the portfolio object based on the URL parameter."""
         return get_object_or_404(Portfolio, id=self.kwargs.get("portfolio_id"))
-    
+
     def get_form_kwargs(self):
         """Include the instance in the form kwargs."""
         kwargs = super().get_form_kwargs()
-        kwargs['instance'] = self.get_object()
+        kwargs["instance"] = self.get_object()
         return kwargs
 
     def get(self, request, *args, **kwargs):


### PR DESCRIPTION
## Ticket

Resolves #2377 
Resolves #2501 
<!--Reminder, when a code change is made that is user facing, beyond content updates, then the following are required:
- a developer approves the PR
- a designer approves the PR or checks off all relevant items in this checklist.

All other changes require just a single approving review.-->

## Changes

<!-- What was added, updated, or removed in this PR. -->
- Form, view, template, tests
- Note 1: I did not think it was a good idea to try and reuse a single template between org and portfolio org
- Note 2: Kept the sidenav template to the portfolio org pages
- Note 3: We need to handle view vs edit permissions on this page. For view, design question: Do we use view only or disabled inputs? Or plain text similar to org name on this PR?
-- The markup needs thinking through. Would those be a definition list? Headers/paragraphs? Or as I have it now, paragraph with strong text?
- 2501 is a simple bug fix to make state_territory required on the domain management org form

<!--
    Please add/remove/edit any of the template below to fit the needs
    of this specific PR.
--->

## Context for reviewers

<!--Background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers.  -->

There is a bug in our State field on org. It shows as required but is not defined as required in the form. That bug was fixed in the portfolio org form adaptation, but we still need to fix it on regular org. It's a quick fix.

## Setup

<!--  Add any steps or code to run in this section to help others run your code.
    
    Example 1:
    ```sh
    echo "Code goes here"
    ``` 
    
    Example 2: If the PR was to add a new link with a redirect, this section could simply be:
    -go to /path/to/start/page
    -click the blue link in the <insert location>
    -notice user is redirected to <proper end location>
-->

Make sure flag is on, set your user up with a portfolio and portfolio role/permissions (view_portfolio is the base on and is all that's needed for this page).

## Code Review Verification Steps

### As the original developer, I have

#### Satisfied acceptance criteria and met development standards

- [x] Met the acceptance criteria, or will meet them in a subsequent PR
- [x] Created/modified automated tests
- [x] Added at least 2 developers as PR reviewers (only 1 will need to approve)
- [x] Messaged on Slack or in standup to notify the team that a PR is ready for review
- [ ] Changes to “how we do things” are documented in READMEs and or onboarding guide
- [ ] If any model was updated to modify/add/delete columns, makemigrations was ran and the associated migrations file has been commited.

#### Ensured code standards are met (Original Developer)

- [x] All new functions and methods are commented using plain language
- [ ] Did dependency updates in Pipfile also get changed in requirements.txt?
- [ ] Interactions with external systems are wrapped in try/except
- [x] Error handling exists for unusual or missing values

#### Validated user-facing changes (if applicable)

- [ ] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Checked keyboard navigability
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)
- [ ] Add at least 1 designer as PR reviewer

### As a code reviewer, I have

#### Reviewed, tested, and left feedback about the changes

- [ ] Pulled this branch locally and tested it
- [ ] Reviewed this code and left comments
- [ ] Checked that all code is adequately covered by tests
- [ ] Made it clear which comments need to be addressed before this work is merged
- [ ] If any model was updated to modify/add/delete columns, makemigrations was ran and the associated migrations file has been commited.

#### Ensured code standards are met (Code reviewer)

- [ ] All new functions and methods are commented using plain language
- [ ] Interactions with external systems are wrapped in try/except
- [ ] Error handling exists for unusual or missing values
- [ ] (Rarely needed) Did dependency updates in Pipfile also get changed in requirements.txt?

#### Validated user-facing changes as a developer

- [ ] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Checked keyboard navigability
- [ ] Meets all designs and user flows provided by design/product
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)

- [ ] Tested with multiple browsers, the suggestion is to use ones that the developer didn't (check off which ones were used)
  - [ ] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari

- [ ] (Rarely needed) Tested as both an analyst and applicant user

**Note:** Multiple code reviewers can share the checklists above, a second reviewers should not make a duplicate checklist

### As a designer reviewer, I have

#### Verified that the changes match the design intention

- [ ] Checked that the design translated visually
- [ ] Checked behavior
- [ ] Checked different states (empty, one, some, error)
- [ ] Checked for landmarks, page heading structure, and links
- [ ] Tried to break the intended flow

#### Validated user-facing changes as a designer

- [ ] Checked keyboard navigability
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)

- [ ] Tested with multiple browsers (check off which ones were used)
  - [ ] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari

- [ ] (Rarely needed) Tested as both an analyst and applicant user

## Screenshots

<!-- If this PR makes visible interface changes, an image of the finished interface can help reviewers
and casual observers understand the context of the changes.
A before image is optional and can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow.
You may want to use [GIPHY Capture](https://giphy.com/apps/giphycapture) for this! 📸

_Please frame images to show useful context but also highlight the affected regions._
--->
