### PR TITLE
#2322 Stop Election Office from unlocking early

### DIFF
--- a/src/registrar/models/utility/generic_helper.py
+++ b/src/registrar/models/utility/generic_helper.py
@@ -245,7 +245,8 @@ class CreateOrUpdateOrganizationTypeHelper:
             if election_board_mismatch or org_type_mismatch:
                 message = (
                     "Cannot add organization_type and generic_org_type simultaneously "
-                    "when generic_org_type, is_election_board, and organization_type values do not match."
+                    "when generic_org_type ({}), is_election_board ({}), and organization_type ({}) values do not match."
+                    .format(generic_org_type, self.instance.is_election_board, organization_type)
                 )
                 logger.error("_validate_new_instance: %s", message)
                 raise ValueError(message)

--- a/src/registrar/models/utility/generic_helper.py
+++ b/src/registrar/models/utility/generic_helper.py
@@ -84,7 +84,6 @@ class CreateOrUpdateOrganizationTypeHelper:
         should_proceed = self._validate_new_instance()
         if not should_proceed:
             return None
-        
         # == Program flow will halt here if there is no reason to update == #
 
         # == Update the linked values == #
@@ -104,7 +103,6 @@ class CreateOrUpdateOrganizationTypeHelper:
     def _handle_existing_instance(self, force_update_when_no_changes_are_found=False):
         # == Init variables == #
         try:
-
             # Instance is already in the database, fetch its current state
             current_instance = self.sender.objects.get(id=self.instance.id)
 

--- a/src/registrar/models/utility/generic_helper.py
+++ b/src/registrar/models/utility/generic_helper.py
@@ -240,7 +240,7 @@ class CreateOrUpdateOrganizationTypeHelper:
             is_election_type = "_election" in organization_type
             can_have_election_board = organization_type in self.generic_org_to_org_map
 
-            election_board_mismatch = (is_election_type and (not self.instance.is_election_board or self.instance.is_election_board == None)) and can_have_election_board
+            election_board_mismatch = is_election_type and not self.instance.is_election_board and can_have_election_board
             org_type_mismatch = mapped_org_type is not None and (generic_org_type != mapped_org_type)
             if election_board_mismatch or org_type_mismatch:
                 message = (

--- a/src/registrar/models/utility/generic_helper.py
+++ b/src/registrar/models/utility/generic_helper.py
@@ -240,7 +240,7 @@ class CreateOrUpdateOrganizationTypeHelper:
             is_election_type = "_election" in organization_type
             can_have_election_board = organization_type in self.generic_org_to_org_map
 
-            election_board_mismatch = (is_election_type != self.instance.is_election_board) and can_have_election_board
+            election_board_mismatch = (is_election_type and (not self.instance.is_election_board or self.instance.is_election_board == None)) and can_have_election_board
             org_type_mismatch = mapped_org_type is not None and (generic_org_type != mapped_org_type)
             if election_board_mismatch or org_type_mismatch:
                 message = (
@@ -248,6 +248,8 @@ class CreateOrUpdateOrganizationTypeHelper:
                     "when generic_org_type ({}), is_election_board ({}), and organization_type ({}) values do not match."
                     .format(generic_org_type, self.instance.is_election_board, organization_type)
                 )
+                message = "Mismatch on election board, {}".format(message) if election_board_mismatch else message
+                message = "Mistmatch on org type, {}".format(message) if org_type_mismatch else message
                 logger.error("_validate_new_instance: %s", message)
                 raise ValueError(message)
 

--- a/src/registrar/models/utility/generic_helper.py
+++ b/src/registrar/models/utility/generic_helper.py
@@ -81,11 +81,8 @@ class CreateOrUpdateOrganizationTypeHelper:
 
     def _handle_new_instance(self):
         # == Check for invalid conditions before proceeding == #
-        try:
-            should_proceed = self._validate_new_instance()
-            if not should_proceed:
-                return None
-        except ValueError:
+        should_proceed = self._validate_new_instance()
+        if not should_proceed:
             return None
         
         # == Program flow will halt here if there is no reason to update == #
@@ -177,10 +174,6 @@ class CreateOrUpdateOrganizationTypeHelper:
                 self.instance.is_election_board = None
             self.instance.organization_type = generic_org_type
         else:
-            # This can only happen with manual data tinkering, which causes these to be out of sync.
-            # if self.instance.is_election_board is None:
-            #     self.instance.is_election_board = False
-
             if self.instance.is_election_board:
                 self.instance.organization_type = self.generic_org_to_org_map[generic_org_type]
             else:

--- a/src/registrar/models/utility/generic_helper.py
+++ b/src/registrar/models/utility/generic_helper.py
@@ -221,8 +221,8 @@ class CreateOrUpdateOrganizationTypeHelper:
 
         Returns a boolean determining if execution should proceed or not.
 
-        Raises: 
-            ValueError if there is a mismatch between organization_type, generic_org_type, and is_election_board 
+        Raises:
+            ValueError if there is a mismatch between organization_type, generic_org_type, and is_election_board
         """
 
         # We conditionally accept both of these values to exist simultaneously, as long as
@@ -240,13 +240,16 @@ class CreateOrUpdateOrganizationTypeHelper:
             is_election_type = "_election" in organization_type
             can_have_election_board = organization_type in self.generic_org_to_org_map
 
-            election_board_mismatch = is_election_type and not self.instance.is_election_board and can_have_election_board
+            election_board_mismatch = (
+                is_election_type and not self.instance.is_election_board and can_have_election_board
+            )
             org_type_mismatch = mapped_org_type is not None and (generic_org_type != mapped_org_type)
             if election_board_mismatch or org_type_mismatch:
                 message = (
-                    "Cannot add organization_type and generic_org_type simultaneously "
-                    "when generic_org_type ({}), is_election_board ({}), and organization_type ({}) values do not match."
-                    .format(generic_org_type, self.instance.is_election_board, organization_type)
+                    "Cannot add organization_type and generic_org_type simultaneously when"
+                    "generic_org_type ({}), is_election_board ({}), and organization_type ({}) don't match.".format(
+                        generic_org_type, self.instance.is_election_board, organization_type
+                    )
                 )
                 message = "Mismatch on election board, {}".format(message) if election_board_mismatch else message
                 message = "Mistmatch on org type, {}".format(message) if org_type_mismatch else message

--- a/src/registrar/tests/test_models.py
+++ b/src/registrar/tests/test_models.py
@@ -1496,13 +1496,15 @@ class TestDomainRequestCustomSave(TestCase):
         self.assertEqual(domain_request.organization_type, DomainRequest.OrgChoicesElectionOffice.CITY)
 
     @less_console_noise_decorator
-    def test_create_or_update_organization_type_existing_instance_updates_election_board_to_none(self):
-        """Test create_or_update_organization_type for an existing instance."""
+    def test_existing_instance_updates_election_board_to_none(self):
+        """Test create_or_update_organization_type for an existing instance, first to True and then to None.
+        Start our with is_election_board as none to simulate a situation where the request was started, but
+        only completed to the point of filling out the generic_org_type."""
         domain_request = completed_domain_request(
             status=DomainRequest.DomainRequestStatus.STARTED,
             name="started.gov",
             generic_org_type=DomainRequest.OrganizationChoices.CITY,
-            is_election_board=False,
+            is_election_board=None,
         )
         domain_request.is_election_board = True
         domain_request.save()
@@ -1510,7 +1512,7 @@ class TestDomainRequestCustomSave(TestCase):
         self.assertEqual(domain_request.is_election_board, True)
         self.assertEqual(domain_request.organization_type, DomainRequest.OrgChoicesElectionOffice.CITY_ELECTION)
 
-        # Try reverting the election board value
+        # Try reverting the election board value.
         domain_request.is_election_board = None
         domain_request.save()
 
@@ -1670,13 +1672,15 @@ class TestDomainInformationCustomSave(TestCase):
         self.assertEqual(domain_information.organization_type, DomainRequest.OrgChoicesElectionOffice.CITY)
 
     @less_console_noise_decorator
-    def test_create_or_update_organization_type_existing_instance_updates_election_board_to_none(self):
-        """Test create_or_update_organization_type for an existing instance."""
+    def test_existing_instance_update_election_board_to_none(self):
+        """Test create_or_update_organization_type for an existing instance, first to True and then to None.
+        Start our with is_election_board as none to simulate a situation where the request was started, but
+        only completed to the point of filling out the generic_org_type."""
         domain_request = completed_domain_request(
             status=DomainRequest.DomainRequestStatus.STARTED,
             name="started.gov",
             generic_org_type=DomainRequest.OrganizationChoices.CITY,
-            is_election_board=False,
+            is_election_board=None,
         )
         domain_information = DomainInformation.create_from_da(domain_request)
         domain_information.is_election_board = True

--- a/src/registrar/tests/test_models.py
+++ b/src/registrar/tests/test_models.py
@@ -1495,13 +1495,6 @@ class TestDomainRequestCustomSave(TestCase):
         self.assertEqual(domain_request.is_election_board, False)
         self.assertEqual(domain_request.organization_type, DomainRequest.OrgChoicesElectionOffice.CITY)
 
-        # Try reverting setting an invalid value for election board (should revert to False)
-        domain_request.is_election_board = None
-        domain_request.save()
-
-        self.assertEqual(domain_request.is_election_board, False)
-        self.assertEqual(domain_request.organization_type, DomainRequest.OrgChoicesElectionOffice.CITY)
-
     @less_console_noise_decorator
     def test_create_or_update_organization_type_existing_instance_updates_generic_org_type(self):
         """Test create_or_update_organization_type when modifying generic_org_type on an existing instance."""
@@ -1650,13 +1643,6 @@ class TestDomainInformationCustomSave(TestCase):
         domain_information.is_election_board = False
         domain_information.save()
         domain_information.refresh_from_db()
-
-        self.assertEqual(domain_information.is_election_board, False)
-        self.assertEqual(domain_information.organization_type, DomainRequest.OrgChoicesElectionOffice.CITY)
-
-        # Try reverting setting an invalid value for election board (should revert to False)
-        domain_information.is_election_board = None
-        domain_information.save()
 
         self.assertEqual(domain_information.is_election_board, False)
         self.assertEqual(domain_information.organization_type, DomainRequest.OrgChoicesElectionOffice.CITY)
@@ -1858,8 +1844,7 @@ class TestDomainRequestIncomplete(TestCase):
         self.assertTrue(self.domain_request._is_state_or_territory_complete())
         self.domain_request.is_election_board = None
         self.domain_request.save()
-        # is_election_board will overwrite to False bc of _update_org_type_from_generic_org_and_election
-        self.assertTrue(self.domain_request._is_state_or_territory_complete())
+        self.assertFalse(self.domain_request._is_state_or_territory_complete())
 
     @less_console_noise_decorator
     def test_is_tribal_complete(self):
@@ -1882,8 +1867,7 @@ class TestDomainRequestIncomplete(TestCase):
         self.assertTrue(self.domain_request._is_county_complete())
         self.domain_request.is_election_board = None
         self.domain_request.save()
-        # is_election_board will overwrite to False bc of _update_org_type_from_generic_org_and_election
-        self.assertTrue(self.domain_request._is_county_complete())
+        self.assertFalse(self.domain_request._is_county_complete())
 
     @less_console_noise_decorator
     def test_is_city_complete(self):
@@ -1893,8 +1877,7 @@ class TestDomainRequestIncomplete(TestCase):
         self.assertTrue(self.domain_request._is_city_complete())
         self.domain_request.is_election_board = None
         self.domain_request.save()
-        # is_election_board will overwrite to False bc of _update_org_type_from_generic_org_and_election
-        self.assertTrue(self.domain_request._is_city_complete())
+        self.assertFalse(self.domain_request._is_city_complete())
 
     @less_console_noise_decorator
     def test_is_special_district_complete(self):

--- a/src/registrar/tests/test_views_request.py
+++ b/src/registrar/tests/test_views_request.py
@@ -2979,7 +2979,7 @@ class TestWizardUnlockingSteps(TestWithUser, WebTest):
         expected_dict = []
         self.assertEqual(unlocked_steps, expected_dict)
 
-    @less_console_noise_decorator
+    # @less_console_noise_decorator
     def test_unlocked_steps_full_domain_request(self):
         """Test when all fields in the domain request are filled."""
 

--- a/src/registrar/tests/test_views_request.py
+++ b/src/registrar/tests/test_views_request.py
@@ -2979,7 +2979,7 @@ class TestWizardUnlockingSteps(TestWithUser, WebTest):
         expected_dict = []
         self.assertEqual(unlocked_steps, expected_dict)
 
-    # @less_console_noise_decorator
+    @less_console_noise_decorator
     def test_unlocked_steps_full_domain_request(self):
         """Test when all fields in the domain request are filled."""
 


### PR DESCRIPTION
## Ticket

Resolves #2322 
<!--Reminder, when a code change is made that is user facing, beyond content updates, then the following are required:
- a developer approves the PR
- a designer approves the PR or checks off all relevant items in this checklist.

All other changes require just a single approving review.-->

## Changes
Removed a check in generic_helper that incorrectly assumes none values for is_election_board can only happen via manual tinkering. The combination of generic_org_type={Type which can be election org} + is_election_board=None can actually occur if only the generic org type was saved during the initial request creation (ie they backed out before saving the election yes/no). This normally doesn't matter much, it's effectively just a default no, but for instances like Tribal where there is a conditional form in between generic org and election org it makes election org become available early (because the None gets changed to False, which triggers the DB check that populates the sidebar with checks/locks).

<!-- What was added, updated, or removed in this PR. -->
- removed a check in generic_helper 
- Alter some tests that were built under the previous logic, and add new ones to make sure the new logic doesn't break things.

<!--
    Please add/remove/edit any of the template below to fit the needs
    of this specific PR.
--->

## Context for reviewers

Currently there is a bug that causes "Election Office" to unlock on the sidebar out of order. This is only really visible when selecting tribal for the generic org type, however. Steps to reproduce:

1. Create new request
2. Select Tribal
3. Save
4. Back out to the main page
5. Edit the request
6. Note that "Election Office" is unlocked on the sidebar even though it was not filled out.

Technically, election office is unlocking early for every org type (at least those that can have an election office). However, since it's the second step for most requests it doesn't look out of order. In practice it just looks like a default was populated and saved. However, it is noticeable on Tribal since that org type has a conditional form after saving the generic org.

## Setup

<!--  Add any steps or code to run in this section to help others run your code.
    
    Example 1:
    ```sh
    echo "Code goes here"
    ``` 
    
    Example 2: If the PR was to add a new link with a redirect, this section could simply be:
    -go to /path/to/start/page
    -click the blue link in the <insert location>
    -notice user is redirected to <proper end location>
-->

## Code Review Verification Steps

Walk through the steps to reproduce, and note that election org no longer unlocks until all previous steps have been completed.

### As the original developer, I have

#### Satisfied acceptance criteria and met development standards

- [ ] Met the acceptance criteria, or will meet them in a subsequent PR
- [ ] Created/modified automated tests
- [ ] Added at least 2 developers as PR reviewers (only 1 will need to approve)
- [ ] Messaged on Slack or in standup to notify the team that a PR is ready for review
- [ ] Changes to “how we do things” are documented in READMEs and or onboarding guide
- [ ] If any model was updated to modify/add/delete columns, makemigrations was ran and the associated migrations file has been commited.

#### Ensured code standards are met (Original Developer)

- [ ] All new functions and methods are commented using plain language
- [ ] Did dependency updates in Pipfile also get changed in requirements.txt?
- [ ] Interactions with external systems are wrapped in try/except
- [ ] Error handling exists for unusual or missing values

#### Validated user-facing changes (if applicable)

- [ ] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Checked keyboard navigability
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)
- [ ] Add at least 1 designer as PR reviewer

### As a code reviewer, I have

#### Reviewed, tested, and left feedback about the changes

- [ ] Pulled this branch locally and tested it
- [ ] Reviewed this code and left comments
- [ ] Checked that all code is adequately covered by tests
- [ ] Made it clear which comments need to be addressed before this work is merged
- [ ] If any model was updated to modify/add/delete columns, makemigrations was ran and the associated migrations file has been commited.

#### Ensured code standards are met (Code reviewer)

- [ ] All new functions and methods are commented using plain language
- [ ] Interactions with external systems are wrapped in try/except
- [ ] Error handling exists for unusual or missing values
- [ ] (Rarely needed) Did dependency updates in Pipfile also get changed in requirements.txt?

#### Validated user-facing changes as a developer

- [ ] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Checked keyboard navigability
- [ ] Meets all designs and user flows provided by design/product
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)

- [ ] Tested with multiple browsers, the suggestion is to use ones that the developer didn't (check off which ones were used)
  - [ ] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari

- [ ] (Rarely needed) Tested as both an analyst and applicant user

**Note:** Multiple code reviewers can share the checklists above, a second reviewers should not make a duplicate checklist

### As a designer reviewer, I have

#### Verified that the changes match the design intention

- [ ] Checked that the design translated visually
- [ ] Checked behavior
- [ ] Checked different states (empty, one, some, error)
- [ ] Checked for landmarks, page heading structure, and links
- [ ] Tried to break the intended flow

#### Validated user-facing changes as a designer

- [ ] Checked keyboard navigability
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)

- [ ] Tested with multiple browsers (check off which ones were used)
  - [ ] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari

- [ ] (Rarely needed) Tested as both an analyst and applicant user

## Screenshots

<!-- If this PR makes visible interface changes, an image of the finished interface can help reviewers
and casual observers understand the context of the changes.
A before image is optional and can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow.
You may want to use [GIPHY Capture](https://giphy.com/apps/giphycapture) for this! 📸

_Please frame images to show useful context but also highlight the affected regions._
--->
