### PR TITLE
Update email signature to use HTTPS for cisa.gov

### DIFF
--- a/src/registrar/templates/emails/action_needed_reasons/already_has_domains.txt
+++ b/src/registrar/templates/emails/action_needed_reasons/already_has_domains.txt
@@ -47,5 +47,5 @@ The .gov team
 Contact us: <https://get.gov/contact/>
 Learn about .gov <https://get.gov>
 
-The .gov registry is a part of the Cybersecurity and Infrastructure Security Agency (CISA) <http://cisa.gov/>
+The .gov registry is a part of the Cybersecurity and Infrastructure Security Agency (CISA) <https://cisa.gov/>
 {% endautoescape %}

--- a/src/registrar/templates/emails/action_needed_reasons/bad_name.txt
+++ b/src/registrar/templates/emails/action_needed_reasons/bad_name.txt
@@ -30,5 +30,5 @@ The .gov team
 Contact us: <https://get.gov/contact/>
 Learn about .gov <https://get.gov>
 
-The .gov registry is a part of the Cybersecurity and Infrastructure Security Agency (CISA) <http://cisa.gov/>
+The .gov registry is a part of the Cybersecurity and Infrastructure Security Agency (CISA) <https://cisa.gov/>
 {% endautoescape %}

--- a/src/registrar/templates/emails/action_needed_reasons/eligibility_unclear.txt
+++ b/src/registrar/templates/emails/action_needed_reasons/eligibility_unclear.txt
@@ -31,5 +31,5 @@ The .gov team
 Contact us: <https://get.gov/contact/>
 Learn about .gov <https://get.gov>
 
-The .gov registry is a part of the Cybersecurity and Infrastructure Security Agency (CISA) <http://cisa.gov/>
+The .gov registry is a part of the Cybersecurity and Infrastructure Security Agency (CISA) <https://cisa.gov/>
 {% endautoescape %}

--- a/src/registrar/templates/emails/action_needed_reasons/questionable_senior_official.txt
+++ b/src/registrar/templates/emails/action_needed_reasons/questionable_senior_official.txt
@@ -32,5 +32,5 @@ The .gov team
 Contact us: <https://get.gov/contact/>
 Learn about .gov <https://get.gov>
 
-The .gov registry is a part of the Cybersecurity and Infrastructure Security Agency (CISA) <http://cisa.gov/>
+The .gov registry is a part of the Cybersecurity and Infrastructure Security Agency (CISA) <https://cisa.gov/>
 {% endautoescape %}

--- a/src/registrar/templates/emails/domain_invitation.txt
+++ b/src/registrar/templates/emails/domain_invitation.txt
@@ -38,5 +38,5 @@ The .gov team
 Contact us: <https://get.gov/contact/>
 Learn about .gov <https://get.gov>
 
-The .gov registry is a part of the Cybersecurity and Infrastructure Security Agency (CISA) <http://cisa.gov/>
+The .gov registry is a part of the Cybersecurity and Infrastructure Security Agency (CISA) <https://cisa.gov/>
 {% endautoescape %}

--- a/src/registrar/templates/emails/domain_request_withdrawn.txt
+++ b/src/registrar/templates/emails/domain_request_withdrawn.txt
@@ -26,5 +26,5 @@ The .gov team
 Contact us: <https://get.gov/contact/>
 Learn about .gov <https://get.gov>
 
-The .gov registry is a part of the Cybersecurity and Infrastructure Security Agency (CISA) <http://cisa.gov/>
+The .gov registry is a part of the Cybersecurity and Infrastructure Security Agency (CISA) <https://cisa.gov/>
 {% endautoescape %}

--- a/src/registrar/templates/emails/status_change_approved.txt
+++ b/src/registrar/templates/emails/status_change_approved.txt
@@ -49,5 +49,5 @@ The .gov team
 Contact us: <https://get.gov/contact/>
 Learn about .gov <https://get.gov>
 
-The .gov registry is a part of the Cybersecurity and Infrastructure Security Agency (CISA) <http://cisa.gov/>
+The .gov registry is a part of the Cybersecurity and Infrastructure Security Agency (CISA) <https://cisa.gov/>
 {% endautoescape %}

--- a/src/registrar/templates/emails/status_change_rejected.txt
+++ b/src/registrar/templates/emails/status_change_rejected.txt
@@ -77,5 +77,5 @@ The .gov team
 Contact us: <https://get.gov/contact/>
 Learn about .gov <https://get.gov>
 
-The .gov registry is a part of the Cybersecurity and Infrastructure Security Agency (CISA) <http://cisa.gov/>
+The .gov registry is a part of the Cybersecurity and Infrastructure Security Agency (CISA) <https://cisa.gov/>
 {% endautoescape %}

--- a/src/registrar/templates/emails/submission_confirmation.txt
+++ b/src/registrar/templates/emails/submission_confirmation.txt
@@ -38,5 +38,5 @@ The .gov team
 Contact us: <https://get.gov/contact/>
 Learn about .gov <https://get.gov>
 
-The .gov registry is a part of the Cybersecurity and Infrastructure Security Agency (CISA) <http://cisa.gov/>
+The .gov registry is a part of the Cybersecurity and Infrastructure Security Agency (CISA) <https://cisa.gov/>
 {% endautoescape %}

--- a/src/registrar/templates/emails/transition_domain_invitation.txt
+++ b/src/registrar/templates/emails/transition_domain_invitation.txt
@@ -60,5 +60,5 @@ The .gov team
 Domain management <https://manage.get.gov>
 Get.gov <https://get.gov>
 
-The .gov registry is a part of the Cybersecurity and Infrastructure Security Agency (CISA) <http://cisa.gov/>
+The .gov registry is a part of the Cybersecurity and Infrastructure Security Agency (CISA) <https://cisa.gov/>
 {% endautoescape %}


### PR DESCRIPTION
This change updates the cisa.gov hyperlink in our emails to use https://. 

...that's it!