### PR TITLE
Issue #2608: Portfolio admin - dynamic federal type and portfolio type

### DIFF
--- a/src/registrar/admin.py
+++ b/src/registrar/admin.py
@@ -2982,6 +2982,7 @@ class PortfolioAdmin(ListHeaderAdmin):
         "domain_requests",
         "suborganizations",
         "portfolio_type",
+        "creator",
     ]
 
     def federal_type(self, obj: models.Portfolio):

--- a/src/registrar/assets/js/get-gov-admin.js
+++ b/src/registrar/assets/js/get-gov-admin.js
@@ -837,6 +837,8 @@ function initializeWidgetOnList(list, parentId) {
         // If we can update the contact information, it'll be shown again.
         hideElement(contactList.parentElement);
 
+        // Determine if any changes are necessary to the display of portfolio type or federal type
+        // based on changes to the Federal Agency
         let federalPortfolioApi = document.getElementById("federal_and_portfolio_types_from_agency_json_url").value;
         fetch(`${federalPortfolioApi}?organization_type=${organizationType.value}&agency_name=${selectedText}`)
         .then(response => {
@@ -851,8 +853,6 @@ function initializeWidgetOnList(list, parentId) {
 
             let federal_type = data.federal_type;
             let portfolio_type = data.portfolio_type;
-            console.log("portfolio type: " + portfolio_type);
-            console.log("federal type: " + federal_type);
             updateFederalType(data.federal_type);
             updatePortfolioType(data.portfolio_type);
         })
@@ -912,22 +912,25 @@ function initializeWidgetOnList(list, parentId) {
         }
     }
 
+    /**
+     * Dynamically update the portfolio type text in the dom to portfolioType
+     */
     function updatePortfolioType(portfolioType) {
-        console.log("attempting to update portfolioType");
         // Find the div with class 'field-portfolio_type'
         const portfolioTypeDiv = document.querySelector('.field-portfolio_type');
         if (portfolioTypeDiv) {
-            console.log("found portfoliotype");
             // Find the nested div with class 'readonly' inside 'field-portfolio_type'
             const readonlyDiv = portfolioTypeDiv.querySelector('.readonly');
             if (readonlyDiv) {
-                console.log("found readonly div");
                 // Update the text content of the readonly div
                 readonlyDiv.textContent = portfolioType !== null ? portfolioType : '-';
             }
         }
     }
 
+    /**
+     * Dynamically update the federal type text in the dom to federalType
+     */
     function updateFederalType(federalType) {
         // Find the div with class 'field-federal_type'
         const federalTypeDiv = document.querySelector('.field-federal_type');

--- a/src/registrar/assets/js/get-gov-admin.js
+++ b/src/registrar/assets/js/get-gov-admin.js
@@ -837,6 +837,27 @@ function initializeWidgetOnList(list, parentId) {
         // If we can update the contact information, it'll be shown again.
         hideElement(contactList.parentElement);
 
+        let federalPortfolioApi = document.getElementById("federal_and_portfolio_types_from_agency_json_url").value;
+        fetch(`${federalPortfolioApi}?organization_type=${organizationType.value}&agency_name=${selectedText}`)
+        .then(response => {
+            const statusCode = response.status;
+            return response.json().then(data => ({ statusCode, data }));
+        })
+        .then(({ statusCode, data }) => {
+            if (data.error) {
+                console.error("Error in AJAX call: " + data.error);
+                return;
+            }
+
+            let federal_type = data.federal_type;
+            let portfolio_type = data.portfolio_type;
+            console.log("portfolio type: " + portfolio_type);
+            console.log("federal type: " + federal_type);
+            updateFederalType(data.federal_type);
+            updatePortfolioType(data.portfolio_type);
+        })
+        .catch(error => console.error("Error fetching federal and portfolio types: ", error));
+
         let seniorOfficialApi = document.getElementById("senior_official_from_agency_json_url").value;
         fetch(`${seniorOfficialApi}?agency_name=${selectedText}`)
         .then(response => {
@@ -879,6 +900,7 @@ function initializeWidgetOnList(list, parentId) {
             }
         })
         .catch(error => console.error("Error fetching senior official: ", error));
+
     }
 
     function handleStateTerritoryChange(stateTerritory, urbanizationField) {
@@ -887,6 +909,35 @@ function initializeWidgetOnList(list, parentId) {
             showElement(urbanizationField)
         } else {
             hideElement(urbanizationField)
+        }
+    }
+
+    function updatePortfolioType(portfolioType) {
+        console.log("attempting to update portfolioType");
+        // Find the div with class 'field-portfolio_type'
+        const portfolioTypeDiv = document.querySelector('.field-portfolio_type');
+        if (portfolioTypeDiv) {
+            console.log("found portfoliotype");
+            // Find the nested div with class 'readonly' inside 'field-portfolio_type'
+            const readonlyDiv = portfolioTypeDiv.querySelector('.readonly');
+            if (readonlyDiv) {
+                console.log("found readonly div");
+                // Update the text content of the readonly div
+                readonlyDiv.textContent = portfolioType !== null ? portfolioType : '-';
+            }
+        }
+    }
+
+    function updateFederalType(federalType) {
+        // Find the div with class 'field-federal_type'
+        const federalTypeDiv = document.querySelector('.field-federal_type');
+        if (federalTypeDiv) {
+            // Find the nested div with class 'readonly' inside 'field-federal_type'
+            const readonlyDiv = federalTypeDiv.querySelector('.readonly');
+            if (readonlyDiv) {
+                // Update the text content of the readonly div
+                readonlyDiv.textContent = federalType !== null ? federalType : '-';
+            }
         }
     }
 

--- a/src/registrar/assets/js/get-gov-admin.js
+++ b/src/registrar/assets/js/get-gov-admin.js
@@ -908,10 +908,6 @@ function initializeWidgetOnList(list, parentId) {
             return;
         }
 
-        // Hide the contactList initially. 
-        // If we can update the contact information, it'll be shown again.
-        hideElement(contactList.parentElement);
-
         // Determine if any changes are necessary to the display of portfolio type or federal type
         // based on changes to the Federal Agency
         let federalPortfolioApi = document.getElementById("federal_and_portfolio_types_from_agency_json_url").value;
@@ -925,14 +921,15 @@ function initializeWidgetOnList(list, parentId) {
                 console.error("Error in AJAX call: " + data.error);
                 return;
             }
-
-            let federal_type = data.federal_type;
-            let portfolio_type = data.portfolio_type;
-            updateFederalType(data.federal_type);
-            updatePortfolioType(data.portfolio_type);
+            updateReadOnly(data.federal_type, '.field-federal_type');
+            updateReadOnly(data.portfolio_type, '.field-portfolio_type');
         })
         .catch(error => console.error("Error fetching federal and portfolio types: ", error));
 
+        // Hide the contactList initially. 
+        // If we can update the contact information, it'll be shown again.
+        hideElement(contactList.parentElement);
+        
         let seniorOfficialApi = document.getElementById("senior_official_from_agency_json_url").value;
         fetch(`${seniorOfficialApi}?agency_name=${selectedText}`)
         .then(response => {
@@ -988,33 +985,21 @@ function initializeWidgetOnList(list, parentId) {
     }
 
     /**
-     * Dynamically update the portfolio type text in the dom to portfolioType
+     * Utility that selects a div from the DOM using selectorString,
+     * and updates a div within that div which has class of 'readonly'
+     * so that the text of the div is updated to updateText
+     * @param {*} updateText 
+     * @param {*} selectorString 
      */
-    function updatePortfolioType(portfolioType) {
-        // Find the div with class 'field-portfolio_type'
-        const portfolioTypeDiv = document.querySelector('.field-portfolio_type');
-        if (portfolioTypeDiv) {
-            // Find the nested div with class 'readonly' inside 'field-portfolio_type'
-            const readonlyDiv = portfolioTypeDiv.querySelector('.readonly');
+    function updateReadOnly(updateText, selectorString) {
+        // find the div by selectorString
+        const selectedDiv = document.querySelector(selectorString);
+        if (selectedDiv) {
+            // find the nested div with class 'readonly' inside the selectorString div
+            const readonlyDiv = selectedDiv.querySelector('.readonly');
             if (readonlyDiv) {
                 // Update the text content of the readonly div
-                readonlyDiv.textContent = portfolioType !== null ? portfolioType : '-';
-            }
-        }
-    }
-
-    /**
-     * Dynamically update the federal type text in the dom to federalType
-     */
-    function updateFederalType(federalType) {
-        // Find the div with class 'field-federal_type'
-        const federalTypeDiv = document.querySelector('.field-federal_type');
-        if (federalTypeDiv) {
-            // Find the nested div with class 'readonly' inside 'field-federal_type'
-            const readonlyDiv = federalTypeDiv.querySelector('.readonly');
-            if (readonlyDiv) {
-                // Update the text content of the readonly div
-                readonlyDiv.textContent = federalType !== null ? federalType : '-';
+                readonlyDiv.textContent = updateText !== null ? updateText : '-';
             }
         }
     }

--- a/src/registrar/config/urls.py
+++ b/src/registrar/config/urls.py
@@ -24,7 +24,10 @@ from registrar.views.report_views import (
 
 from registrar.views.domain_request import Step
 from registrar.views.domain_requests_json import get_domain_requests_json
-from registrar.views.utility.api_views import get_senior_official_from_federal_agency_json
+from registrar.views.utility.api_views import (
+    get_senior_official_from_federal_agency_json,
+    get_federal_and_portfolio_types_from_federal_agency_json
+)
 from registrar.views.domains_json import get_domains_json
 from registrar.views.utility import always_404
 from api.views import available, get_current_federal, get_current_full
@@ -138,6 +141,11 @@ urlpatterns = [
         "admin/api/get-senior-official-from-federal-agency-json/",
         get_senior_official_from_federal_agency_json,
         name="get-senior-official-from-federal-agency-json",
+    ),
+    path(
+        "admin/api/get-federal-and-portfolio-types-from-federal-agency-json/",
+        get_federal_and_portfolio_types_from_federal_agency_json,
+        name="get-federal-and-portfolio-types-from-federal-agency-json",
     ),
     path("admin/", admin.site.urls),
     path(

--- a/src/registrar/config/urls.py
+++ b/src/registrar/config/urls.py
@@ -26,7 +26,7 @@ from registrar.views.domain_request import Step
 from registrar.views.domain_requests_json import get_domain_requests_json
 from registrar.views.utility.api_views import (
     get_senior_official_from_federal_agency_json,
-    get_federal_and_portfolio_types_from_federal_agency_json
+    get_federal_and_portfolio_types_from_federal_agency_json,
 )
 from registrar.views.domains_json import get_domains_json
 from registrar.views.utility import always_404

--- a/src/registrar/models/portfolio.py
+++ b/src/registrar/models/portfolio.py
@@ -150,7 +150,7 @@ class Portfolio(TimeStampedModel):
     @classmethod
     def get_federal_type(cls, federal_agency):
         return federal_agency.federal_type if federal_agency else None
-    
+
     # == Getters for domains == #
     def get_domains(self):
         """Returns all DomainInformations associated with this portfolio"""

--- a/src/registrar/models/portfolio.py
+++ b/src/registrar/models/portfolio.py
@@ -131,9 +131,13 @@ class Portfolio(TimeStampedModel):
         Returns a combination of organization_type / federal_type, seperated by ' - '.
         If no federal_type is found, we just return the org type.
         """
-        org_type_label = self.OrganizationChoices.get_org_label(self.organization_type)
-        agency_type_label = BranchChoices.get_branch_label(self.federal_type)
-        if self.organization_type == self.OrganizationChoices.FEDERAL and agency_type_label:
+        return self.get_portfolio_type(self.organization_type, self.federal_type)
+
+    @classmethod
+    def get_portfolio_type(cls, organization_type, federal_type):
+        org_type_label = cls.OrganizationChoices.get_org_label(organization_type)
+        agency_type_label = BranchChoices.get_branch_label(federal_type)
+        if organization_type == cls.OrganizationChoices.FEDERAL and agency_type_label:
             return " - ".join([org_type_label, agency_type_label])
         else:
             return org_type_label
@@ -141,8 +145,12 @@ class Portfolio(TimeStampedModel):
     @property
     def federal_type(self):
         """Returns the federal_type value on the underlying federal_agency field"""
-        return self.federal_agency.federal_type if self.federal_agency else None
+        return self.get_federal_type(self.federal_agency)
 
+    @classmethod
+    def get_federal_type(cls, federal_agency):
+        return federal_agency.federal_type if federal_agency else None
+    
     # == Getters for domains == #
     def get_domains(self):
         """Returns all DomainInformations associated with this portfolio"""

--- a/src/registrar/templates/django/admin/portfolio_change_form.html
+++ b/src/registrar/templates/django/admin/portfolio_change_form.html
@@ -5,6 +5,8 @@
     {% comment %} Stores the json endpoint in a url for easier access {% endcomment %}
     {% url 'get-senior-official-from-federal-agency-json' as url %}
     <input id="senior_official_from_agency_json_url" class="display-none" value="{{url}}" />
+    {% url 'get-federal-and-portfolio-types-from-federal-agency-json' as url %}
+    <input id="federal_and_portfolio_types_from_agency_json_url" class="display-none" value="{{url}}" />
     {{ block.super }}
 {% endblock content %}
 

--- a/src/registrar/tests/test_api.py
+++ b/src/registrar/tests/test_api.py
@@ -5,6 +5,7 @@ from django.contrib.auth import get_user_model
 from registrar.tests.common import create_superuser, create_user
 
 from api.tests.common import less_console_noise_decorator
+from registrar.utility.constants import BranchChoices
 
 
 class GetSeniorOfficialJsonTest(TestCase):
@@ -82,7 +83,7 @@ class GetFederalPortfolioTypeJsonTest(TestCase):
         self.superuser = create_superuser()
         self.analyst_user = create_user()
 
-        self.agency = FederalAgency.objects.create(agency="Test Agency", federal_type="judicial")
+        self.agency = FederalAgency.objects.create(agency="Test Agency", federal_type=BranchChoices.JUDICIAL)
 
         self.api_url = reverse("get-federal-and-portfolio-types-from-federal-agency-json")
 
@@ -100,3 +101,11 @@ class GetFederalPortfolioTypeJsonTest(TestCase):
         data = response.json()
         self.assertEqual(data["federal_type"], "Judicial")
         self.assertEqual(data["portfolio_type"], "Federal - Judicial")
+
+    @less_console_noise_decorator
+    def test_get_federal_and_portfolio_types_json_authenticated_regularuser(self):
+        """Test that a regular user receives a 403 with an error message."""
+        p = "password"
+        self.client.login(username="testuser", password=p)
+        response = self.client.get(self.api_url, {"agency_name": "Test Agency", "organization_type": "federal"})
+        self.assertEqual(response.status_code, 302)

--- a/src/registrar/views/utility/api_views.py
+++ b/src/registrar/views/utility/api_views.py
@@ -37,7 +37,8 @@ def get_senior_official_from_federal_agency_json(request):
         return JsonResponse(so_dict)
     else:
         return JsonResponse({"error": "Senior Official not found"}, status=404)
-    
+
+
 @login_required
 @staff_member_required
 def get_federal_and_portfolio_types_from_federal_agency_json(request):
@@ -62,8 +63,8 @@ def get_federal_and_portfolio_types_from_federal_agency_json(request):
         federal_type = BranchChoices.get_branch_label(federal_type) if federal_type else "-"
 
     response_data = {
-        'portfolio_type': portfolio_type,
-        'federal_type': federal_type,
+        "portfolio_type": portfolio_type,
+        "federal_type": federal_type,
     }
-    
+
     return JsonResponse(response_data)

--- a/src/registrar/views/utility/api_views.py
+++ b/src/registrar/views/utility/api_views.py
@@ -5,6 +5,9 @@ from registrar.models import FederalAgency, SeniorOfficial
 from django.contrib.admin.views.decorators import staff_member_required
 from django.contrib.auth.decorators import login_required
 
+from registrar.models.portfolio import Portfolio
+from registrar.utility.constants import BranchChoices
+
 logger = logging.getLogger(__name__)
 
 
@@ -34,3 +37,33 @@ def get_senior_official_from_federal_agency_json(request):
         return JsonResponse(so_dict)
     else:
         return JsonResponse({"error": "Senior Official not found"}, status=404)
+    
+@login_required
+@staff_member_required
+def get_federal_and_portfolio_types_from_federal_agency_json(request):
+    """Returns specific portfolio information as a JSON. Request must have
+    both agency_name and organization_type."""
+
+    # This API is only accessible to admins and analysts
+    superuser_perm = request.user.has_perm("registrar.full_access_permission")
+    analyst_perm = request.user.has_perm("registrar.analyst_access_permission")
+    if not request.user.is_authenticated or not any([analyst_perm, superuser_perm]):
+        return JsonResponse({"error": "You do not have access to this resource"}, status=403)
+
+    federal_type = None
+    portfolio_type = None
+
+    agency_name = request.GET.get("agency_name")
+    organization_type = request.GET.get("organization_type")
+    agency = FederalAgency.objects.filter(agency=agency_name).first()
+    if agency:
+        federal_type = Portfolio.get_federal_type(agency)
+        portfolio_type = Portfolio.get_portfolio_type(organization_type, federal_type)
+        federal_type = BranchChoices.get_branch_label(federal_type) if federal_type else "-"
+
+    response_data = {
+        'portfolio_type': portfolio_type,
+        'federal_type': federal_type,
+    }
+    
+    return JsonResponse(response_data)


### PR DESCRIPTION
## Ticket

Resolves #2608 
<!--Reminder, when a code change is made that is user facing, beyond content updates, then the following are required:
- a developer approves the PR
- a designer approves the PR or checks off all relevant items in this checklist.

All other changes require just a single approving review.-->

## Changes

<!-- What was added, updated, or removed in this PR. -->
- New API to check for value of federal type and portfolio type for a given federal agency
- Update the django admin portfolio edit page so that the federal type and portfolio type display is updated when there are changes to the selection of the federal agency.  Note that no underlying data is updated until the user clicks Save.

<!--
    Please add/remove/edit any of the template below to fit the needs
    of this specific PR.
--->

## Context for reviewers

<!--Background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers.  -->

In addition to the changes above, verified that the user receives no error if the SO is not linked.

## Setup

<!--  Add any steps or code to run in this section to help others run your code.
    
    Example 1:
    ```sh
    echo "Code goes here"
    ``` 
    
    Example 2: If the PR was to add a new link with a redirect, this section could simply be:
    -go to /path/to/start/page
    -click the blue link in the <insert location>
    -notice user is redirected to <proper end location>
-->


## Code Review Verification Steps

Add or update a portfolio in django admin.  Note the federal type and portfolio type.  Make changes to the federal agency, and verify that the federal type and portfolio type are updated.  This may also require you to go into the federal agency and add the federal type and portfolio type.

### As the original developer, I have

#### Satisfied acceptance criteria and met development standards

- [ ] Met the acceptance criteria, or will meet them in a subsequent PR
- [ ] Created/modified automated tests
- [ ] Added at least 2 developers as PR reviewers (only 1 will need to approve)
- [ ] Messaged on Slack or in standup to notify the team that a PR is ready for review
- [ ] Changes to “how we do things” are documented in READMEs and or onboarding guide
- [ ] If any model was updated to modify/add/delete columns, makemigrations was ran and the associated migrations file has been commited.

#### Ensured code standards are met (Original Developer)

- [ ] All new functions and methods are commented using plain language
- [ ] Did dependency updates in Pipfile also get changed in requirements.txt?
- [ ] Interactions with external systems are wrapped in try/except
- [ ] Error handling exists for unusual or missing values

#### Validated user-facing changes (if applicable)

- [ ] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Checked keyboard navigability
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)
- [ ] Add at least 1 designer as PR reviewer

### As a code reviewer, I have

#### Reviewed, tested, and left feedback about the changes

- [ ] Pulled this branch locally and tested it
- [ ] Reviewed this code and left comments
- [ ] Checked that all code is adequately covered by tests
- [ ] Made it clear which comments need to be addressed before this work is merged
- [ ] If any model was updated to modify/add/delete columns, makemigrations was ran and the associated migrations file has been commited.

#### Ensured code standards are met (Code reviewer)

- [ ] All new functions and methods are commented using plain language
- [ ] Interactions with external systems are wrapped in try/except
- [ ] Error handling exists for unusual or missing values
- [ ] (Rarely needed) Did dependency updates in Pipfile also get changed in requirements.txt?

#### Validated user-facing changes as a developer

- [ ] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Checked keyboard navigability
- [ ] Meets all designs and user flows provided by design/product
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)

- [ ] Tested with multiple browsers, the suggestion is to use ones that the developer didn't (check off which ones were used)
  - [ ] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari

- [ ] (Rarely needed) Tested as both an analyst and applicant user

**Note:** Multiple code reviewers can share the checklists above, a second reviewers should not make a duplicate checklist

### As a designer reviewer, I have

#### Verified that the changes match the design intention

- [ ] Checked that the design translated visually
- [ ] Checked behavior
- [ ] Checked different states (empty, one, some, error)
- [ ] Checked for landmarks, page heading structure, and links
- [ ] Tried to break the intended flow

#### Validated user-facing changes as a designer

- [ ] Checked keyboard navigability
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)

- [ ] Tested with multiple browsers (check off which ones were used)
  - [ ] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari

- [ ] (Rarely needed) Tested as both an analyst and applicant user

## Screenshots

<!-- If this PR makes visible interface changes, an image of the finished interface can help reviewers
and casual observers understand the context of the changes.
A before image is optional and can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow.
You may want to use [GIPHY Capture](https://giphy.com/apps/giphycapture) for this! 📸

_Please frame images to show useful context but also highlight the affected regions._
--->
