### PR TITLE
Issue #2561: format logs as json (on getgov-ms)

### DIFF
--- a/src/epplibwrapper/cert.py
+++ b/src/epplibwrapper/cert.py
@@ -1,7 +1,7 @@
 import os
 import tempfile
 
-from django.conf import settings
+from django.conf import settings  # type: ignore
 
 
 class Cert:
@@ -12,7 +12,7 @@ class Cert:
     variable but Python's ssl library requires a file.
     """
 
-    def __init__(self, data=settings.SECRET_REGISTRY_CERT) -> None:
+    def __init__(self, data = settings.SECRET_REGISTRY_CERT) -> None:  # type: ignore
         self.filename = self._write(data)
 
     def __del__(self):
@@ -31,4 +31,4 @@ class Key(Cert):
     """Location of private key as written to disk."""
 
     def __init__(self) -> None:
-        super().__init__(data=settings.SECRET_REGISTRY_KEY)
+        super().__init__(data=settings.SECRET_REGISTRY_KEY)  # type: ignore

--- a/src/epplibwrapper/cert.py
+++ b/src/epplibwrapper/cert.py
@@ -12,7 +12,7 @@ class Cert:
     variable but Python's ssl library requires a file.
     """
 
-    def __init__(self, data = settings.SECRET_REGISTRY_CERT) -> None:  # type: ignore
+    def __init__(self, data=settings.SECRET_REGISTRY_CERT) -> None:  # type: ignore
         self.filename = self._write(data)
 
     def __del__(self):

--- a/src/registrar/config/settings.py
+++ b/src/registrar/config/settings.py
@@ -448,21 +448,8 @@ PHONENUMBER_DEFAULT_REGION = "US"
 #   logger.error("Can't do this important task. Something is very wrong.")
 #   logger.critical("Going to crash now.")
 
-class JsonFormatter(logging.Formatter):
-    def __init__(self):
-        super().__init__(datefmt="%d/%b/%Y %H:%M:%S")
-
-    def format(self, record):
-        log_record = {
-            "timestamp": self.formatTime(record, self.datefmt),
-            "level": record.levelname,
-            "name": record.name,
-            "lineno": record.lineno,
-            "message": record.getMessage(),
-        }
-        return json.dumps(log_record)
-
 class JsonServerFormatter(ServerFormatter):
+    """Formats logs into JSON for easier and more accurate processing."""
     def format(self, record):
         formatted_record = super().format(record)
         log_entry = {
@@ -489,9 +476,6 @@ LOGGING = {
         "json.server": {
             "()": JsonServerFormatter,
         },
-        "json": {
-            "()": JsonFormatter,
-        },
     },
     # define where log messages will be sent;
     # each logger can have one or more handlers
@@ -499,7 +483,7 @@ LOGGING = {
         "console": {
             "level": env_log_level,
             "class": "logging.StreamHandler",
-            "formatter": "json",
+            "formatter": "verbose",
         },
         "django.server": {
             "level": "INFO",

--- a/src/registrar/config/settings.py
+++ b/src/registrar/config/settings.py
@@ -24,7 +24,6 @@ from pathlib import Path
 from typing import Final
 from botocore.config import Config
 import json
-import logging
 from django.utils.log import ServerFormatter
 
 # # #                          ###
@@ -448,6 +447,7 @@ PHONENUMBER_DEFAULT_REGION = "US"
 #   logger.error("Can't do this important task. Something is very wrong.")
 #   logger.critical("Going to crash now.")
 
+
 class JsonServerFormatter(ServerFormatter):
     """Formats logs into JSON for easier and more accurate processing."""
     def format(self, record):
@@ -458,6 +458,7 @@ class JsonServerFormatter(ServerFormatter):
             "message": formatted_record
         }
         return json.dumps(log_entry)
+
 
 LOGGING = {
     "version": 1,

--- a/src/registrar/config/settings.py
+++ b/src/registrar/config/settings.py
@@ -451,6 +451,7 @@ PHONENUMBER_DEFAULT_REGION = "US"
 
 class JsonFormatter(logging.Formatter):
     """Formats logs into JSON for better parsing"""
+
     def __init__(self):
         super().__init__(datefmt="%d/%b/%Y %H:%M:%S")
 
@@ -467,21 +468,19 @@ class JsonFormatter(logging.Formatter):
 
 class JsonServerFormatter(ServerFormatter):
     """Formats server logs into JSON for better parsing"""
+
     def format(self, record):
         formatted_record = super().format(record)
-        log_entry = {
-            "server_time": record.server_time,
-            "level": record.levelname,
-            "message": formatted_record
-        }
+        log_entry = {"server_time": record.server_time, "level": record.levelname, "message": formatted_record}
         return json.dumps(log_entry)
 
+
 # default to json formatted logs
-server_formatter, console_formatter = 'json.server', 'json'
+server_formatter, console_formatter = "json.server", "json"
 
 # don't use json format locally, it makes logs hard to read in console
 if "localhost" in env_base_url:
-    server_formatter, console_formatter = 'django.server', 'verbose'
+    server_formatter, console_formatter = "django.server", "verbose"
 
 LOGGING = {
     "version": 1,

--- a/src/registrar/config/settings.py
+++ b/src/registrar/config/settings.py
@@ -24,6 +24,7 @@ from pathlib import Path
 from typing import Final
 from botocore.config import Config
 import json
+import logging
 from django.utils.log import ServerFormatter
 
 # # #                          ###

--- a/src/registrar/models/domain_request.py
+++ b/src/registrar/models/domain_request.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+import traceback
 from typing import Union
 import logging
 from django.apps import apps
@@ -643,6 +644,8 @@ class DomainRequest(TimeStampedModel):
         """Save override for custom properties"""
         self.sync_organization_type()
         self.sync_yes_no_form_fields()
+
+        logger.error(traceback.print_stack())
 
         if self._cached_status != self.status:
             self.last_status_update = timezone.now().date()

--- a/src/registrar/models/domain_request.py
+++ b/src/registrar/models/domain_request.py
@@ -644,10 +644,6 @@ class DomainRequest(TimeStampedModel):
         """Save override for custom properties"""
         self.sync_organization_type()
         self.sync_yes_no_form_fields()
-        try:
-            raise Exception("TEST TEST TEST")
-        except Exception:
-            logger.error(traceback.format_exc())
 
         if self._cached_status != self.status:
             self.last_status_update = timezone.now().date()

--- a/src/registrar/models/domain_request.py
+++ b/src/registrar/models/domain_request.py
@@ -647,7 +647,7 @@ class DomainRequest(TimeStampedModel):
         try:
             raise Exception("TEST TEST TEST")
         except Exception:
-            logger.error(traceback.format_exc)
+            logger.error(traceback.format_exc())
 
         if self._cached_status != self.status:
             self.last_status_update = timezone.now().date()

--- a/src/registrar/models/domain_request.py
+++ b/src/registrar/models/domain_request.py
@@ -645,9 +645,9 @@ class DomainRequest(TimeStampedModel):
         self.sync_organization_type()
         self.sync_yes_no_form_fields()
         try:
-            raise ValueError("TEST TEST TEST")
-        except Exception as e:
-            logger.error(e)
+            raise Exception("TEST TEST TEST")
+        except Exception:
+            logger.error(traceback.format_exc)
 
         if self._cached_status != self.status:
             self.last_status_update = timezone.now().date()

--- a/src/registrar/models/domain_request.py
+++ b/src/registrar/models/domain_request.py
@@ -644,8 +644,10 @@ class DomainRequest(TimeStampedModel):
         """Save override for custom properties"""
         self.sync_organization_type()
         self.sync_yes_no_form_fields()
-
-        logger.error(traceback.print_stack())
+        try:
+            raise ValueError("TEST TEST TEST")
+        except Exception as e:
+            logger.error(e)
 
         if self._cached_status != self.status:
             self.last_status_update = timezone.now().date()

--- a/src/registrar/models/domain_request.py
+++ b/src/registrar/models/domain_request.py
@@ -1,5 +1,4 @@
 from __future__ import annotations
-import traceback
 from typing import Union
 import logging
 from django.apps import apps


### PR DESCRIPTION
## Ticket

Resolves #2561 
<!--Reminder, when a code change is made that is user facing, beyond content updates, then the following are required:
- a developer approves the PR
- a designer approves the PR or checks off all relevant items in this checklist.

All other changes require just a single approving review.-->

## Changes

<!-- What was added, updated, or removed in this PR. -->
- Adds two new logger formatters, one for normal logs and one for django server logs
- swaps out the old server and verbose formatters for the new json and json.server formatters.
- Added a dummy exception that triggers when saving anything on a domain request, just to make it easy to test.

<!--
    Please add/remove/edit any of the template below to fit the needs
    of this specific PR.
--->

## Context for reviewers
Right now logs are janky in that multi-line logs get read into kibana as a new log for each new line, which is especially painful for tracebacks. This PR fixes that by formatting all logs as json objects, which kibana is configured to parse correctly.

<!--Background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers.  -->

## Setup

<!--  Add any steps or code to run in this section to help others run your code.
    
    Example 1:
    ```sh
    echo "Code goes here"
    ``` 
    
    Example 2: If the PR was to add a new link with a redirect, this section could simply be:
    -go to /path/to/start/page
    -click the blue link in the <insert location>
    -notice user is redirected to <proper end location>
-->

## Code Review Verification Steps
- Open getgov-ms and do some stuff that will trigger logs, especially but not limited to saving a few elements of a domain request (a fake error log has been placed there for review purposes).
- go to logs.fr.cloud.gov and filter by space for ms plus whatever log type you want to see
- observe that logs are still functioning properly
- Filter for error logs and check that tracebacks are printing as a singular message
- Make sure Matthew removes the fake exception so that it doesn't accidentally end up in prod :)

### As the original developer, I have

#### Satisfied acceptance criteria and met development standards

- [ ] Met the acceptance criteria, or will meet them in a subsequent PR
- [ ] Created/modified automated tests
- [ ] Added at least 2 developers as PR reviewers (only 1 will need to approve)
- [ ] Messaged on Slack or in standup to notify the team that a PR is ready for review
- [ ] Changes to “how we do things” are documented in READMEs and or onboarding guide
- [ ] If any model was updated to modify/add/delete columns, makemigrations was ran and the associated migrations file has been commited.

#### Ensured code standards are met (Original Developer)

- [ ] All new functions and methods are commented using plain language
- [ ] Did dependency updates in Pipfile also get changed in requirements.txt?
- [ ] Interactions with external systems are wrapped in try/except
- [ ] Error handling exists for unusual or missing values

#### Validated user-facing changes (if applicable)

- [ ] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Checked keyboard navigability
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)
- [ ] Add at least 1 designer as PR reviewer

### As a code reviewer, I have

#### Reviewed, tested, and left feedback about the changes

- [ ] Pulled this branch locally and tested it
- [ ] Reviewed this code and left comments
- [ ] Checked that all code is adequately covered by tests
- [ ] Made it clear which comments need to be addressed before this work is merged
- [ ] If any model was updated to modify/add/delete columns, makemigrations was ran and the associated migrations file has been commited.

#### Ensured code standards are met (Code reviewer)

- [ ] All new functions and methods are commented using plain language
- [ ] Interactions with external systems are wrapped in try/except
- [ ] Error handling exists for unusual or missing values
- [ ] (Rarely needed) Did dependency updates in Pipfile also get changed in requirements.txt?

#### Validated user-facing changes as a developer

- [ ] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Checked keyboard navigability
- [ ] Meets all designs and user flows provided by design/product
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)

- [ ] Tested with multiple browsers, the suggestion is to use ones that the developer didn't (check off which ones were used)
  - [ ] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari

- [ ] (Rarely needed) Tested as both an analyst and applicant user

**Note:** Multiple code reviewers can share the checklists above, a second reviewers should not make a duplicate checklist

### As a designer reviewer, I have

#### Verified that the changes match the design intention

- [ ] Checked that the design translated visually
- [ ] Checked behavior
- [ ] Checked different states (empty, one, some, error)
- [ ] Checked for landmarks, page heading structure, and links
- [ ] Tried to break the intended flow

#### Validated user-facing changes as a designer

- [ ] Checked keyboard navigability
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)

- [ ] Tested with multiple browsers (check off which ones were used)
  - [ ] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari

- [ ] (Rarely needed) Tested as both an analyst and applicant user

## Screenshots

<!-- If this PR makes visible interface changes, an image of the finished interface can help reviewers
and casual observers understand the context of the changes.
A before image is optional and can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow.
You may want to use [GIPHY Capture](https://giphy.com/apps/giphycapture) for this! 📸

_Please frame images to show useful context but also highlight the affected regions._
--->
