### PR TITLE
Issue #2717: Domain table filtering for portfolio user with VIEW_MANAGED_DOMAINS

### DIFF
--- a/src/registrar/tests/test_views_domains_json.py
+++ b/src/registrar/tests/test_views_domains_json.py
@@ -1,9 +1,13 @@
 from registrar.models import UserDomainRole, Domain, DomainInformation, Portfolio
 from django.urls import reverse
+
+from registrar.models.user_portfolio_permission import UserPortfolioPermission
+from registrar.models.utility.portfolio_helper import UserPortfolioPermissionChoices, UserPortfolioRoleChoices
 from .test_views import TestWithUser
 from django_webtest import WebTest  # type: ignore
 from django.utils.dateparse import parse_date
 from api.tests.common import less_console_noise_decorator
+from waffle.testutils import override_flag
 
 
 class GetDomainsJsonTest(TestWithUser, WebTest):
@@ -31,6 +35,7 @@ class GetDomainsJsonTest(TestWithUser, WebTest):
 
     def tearDown(self):
         UserDomainRole.objects.all().delete()
+        UserPortfolioPermission.objects.all().delete()
         DomainInformation.objects.all().delete()
         Portfolio.objects.all().delete()
         super().tearDown()
@@ -115,8 +120,105 @@ class GetDomainsJsonTest(TestWithUser, WebTest):
             self.assertEqual(svg_icon_expected, svg_icons[i])
 
     @less_console_noise_decorator
-    def test_get_domains_json_with_portfolio(self):
-        """Test that an authenticated user gets the list of 2 domains for portfolio."""
+    @override_flag("organization_feature", active=True)
+    def test_get_domains_json_with_portfolio_view_managed_domains(self):
+        """Test that an authenticated user gets the list of 1 domain for portfolio. The 1 domain
+        is the domain that they manage within the portfolio."""
+
+        UserPortfolioPermission.objects.get_or_create(
+            user=self.user,
+            portfolio=self.portfolio,
+            roles=[UserPortfolioRoleChoices.ORGANIZATION_MEMBER],
+            additional_permissions=[UserPortfolioPermissionChoices.VIEW_MANAGED_DOMAINS],
+        )
+
+        response = self.app.get(reverse("get_domains_json"), {"portfolio": self.portfolio.id})
+        self.assertEqual(response.status_code, 200)
+        data = response.json
+
+        # Check pagination info
+        self.assertEqual(data["page"], 1)
+        self.assertFalse(data["has_next"])
+        self.assertFalse(data["has_previous"])
+        self.assertEqual(data["num_pages"], 1)
+
+        # Check the number of domains
+        self.assertEqual(len(data["domains"]), 1)
+
+        # Expected domains
+        expected_domains = [self.domain3]
+
+        # Extract fields from response
+        domain_ids = [domain["id"] for domain in data["domains"]]
+        names = [domain["name"] for domain in data["domains"]]
+        expiration_dates = [domain["expiration_date"] for domain in data["domains"]]
+        states = [domain["state"] for domain in data["domains"]]
+        state_displays = [domain["state_display"] for domain in data["domains"]]
+        get_state_help_texts = [domain["get_state_help_text"] for domain in data["domains"]]
+        action_urls = [domain["action_url"] for domain in data["domains"]]
+        action_labels = [domain["action_label"] for domain in data["domains"]]
+        svg_icons = [domain["svg_icon"] for domain in data["domains"]]
+
+        # Check fields for each domain
+        for i, expected_domain in enumerate(expected_domains):
+            self.assertEqual(expected_domain.id, domain_ids[i])
+            self.assertEqual(expected_domain.name, names[i])
+            self.assertEqual(expected_domain.expiration_date, expiration_dates[i])
+            self.assertEqual(expected_domain.state, states[i])
+
+            # Parsing the expiration date from string to date
+            parsed_expiration_date = parse_date(expiration_dates[i])
+            expected_domain.expiration_date = parsed_expiration_date
+
+            # Check state_display and get_state_help_text
+            self.assertEqual(expected_domain.state_display(), state_displays[i])
+            self.assertEqual(expected_domain.get_state_help_text(), get_state_help_texts[i])
+
+            self.assertEqual(reverse("domain", kwargs={"pk": expected_domain.id}), action_urls[i])
+
+            # Check action_label
+            user_domain_role_exists = UserDomainRole.objects.filter(
+                domain_id=expected_domains[i].id, user=self.user
+            ).exists()
+            action_label_expected = (
+                "View"
+                if not user_domain_role_exists
+                or expected_domains[i].state
+                in [
+                    Domain.State.DELETED,
+                    Domain.State.ON_HOLD,
+                ]
+                else "Manage"
+            )
+            self.assertEqual(action_label_expected, action_labels[i])
+
+            # Check svg_icon
+            svg_icon_expected = (
+                "visibility"
+                if not user_domain_role_exists
+                or expected_domains[i].state
+                in [
+                    Domain.State.DELETED,
+                    Domain.State.ON_HOLD,
+                ]
+                else "settings"
+            )
+            self.assertEqual(svg_icon_expected, svg_icons[i])
+
+    @less_console_noise_decorator
+    @override_flag("organization_feature", active=True)
+    def test_get_domains_json_with_portfolio_view_all_domains(self):
+        """Test that an authenticated user gets the list of 2 domains for portfolio. One is a domain which
+        they manage within the portfolio. The other is a domain which they don't manage within the
+        portfolio."""
+
+        UserPortfolioPermission.objects.get_or_create(
+            user=self.user,
+            portfolio=self.portfolio,
+            roles=[UserPortfolioRoleChoices.ORGANIZATION_MEMBER],
+            additional_permissions=[UserPortfolioPermissionChoices.VIEW_ALL_DOMAINS],
+        )
+        # self.app.set_user(self.user.username)
 
         response = self.app.get(reverse("get_domains_json"), {"portfolio": self.portfolio.id})
         self.assertEqual(response.status_code, 200)

--- a/src/registrar/tests/test_views_domains_json.py
+++ b/src/registrar/tests/test_views_domains_json.py
@@ -218,7 +218,6 @@ class GetDomainsJsonTest(TestWithUser, WebTest):
             roles=[UserPortfolioRoleChoices.ORGANIZATION_MEMBER],
             additional_permissions=[UserPortfolioPermissionChoices.VIEW_ALL_DOMAINS],
         )
-        # self.app.set_user(self.user.username)
 
         response = self.app.get(reverse("get_domains_json"), {"portfolio": self.portfolio.id})
         self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
## Ticket

Resolves #2717 
<!--Reminder, when a code change is made that is user facing, beyond content updates, then the following are required:
- a developer approves the PR
- a designer approves the PR or checks off all relevant items in this checklist.

All other changes require just a single approving review.-->

## Changes

<!-- What was added, updated, or removed in this PR. -->
- Portfolio user with VIEW_MANAGED_DOMAINS permission, when viewing the domains table in portfolio view, is limited to only those domains that they manage which are in the portfolio

<!--
    Please add/remove/edit any of the template below to fit the needs
    of this specific PR.
--->

## Context for reviewers

<!--Background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers.  -->

## Setup

<!--  Add any steps or code to run in this section to help others run your code.
    
    Example 1:
    ```sh
    echo "Code goes here"
    ``` 
    
    Example 2: If the PR was to add a new link with a redirect, this section could simply be:
    -go to /path/to/start/page
    -click the blue link in the <insert location>
    -notice user is redirected to <proper end location>
-->

Add a portfolio and make sure the organization_feature waffle flag is on
Add two domains to the portfolio
Give your user Portfolio permissions to the portfolio, with role of Member and additional permission of View managed domains
Give your user Manager role for one of the two domains
Navigate to the home page.  You should only see the domain for which you are a manager and it is in the portfolio

## Code Review Verification Steps

### As the original developer, I have

#### Satisfied acceptance criteria and met development standards

- [ ] Met the acceptance criteria, or will meet them in a subsequent PR
- [ ] Created/modified automated tests
- [ ] Added at least 2 developers as PR reviewers (only 1 will need to approve)
- [ ] Messaged on Slack or in standup to notify the team that a PR is ready for review
- [ ] Changes to “how we do things” are documented in READMEs and or onboarding guide
- [ ] If any model was updated to modify/add/delete columns, makemigrations was ran and the associated migrations file has been commited.

#### Ensured code standards are met (Original Developer)

- [ ] All new functions and methods are commented using plain language
- [ ] Did dependency updates in Pipfile also get changed in requirements.txt?
- [ ] Interactions with external systems are wrapped in try/except
- [ ] Error handling exists for unusual or missing values

#### Validated user-facing changes (if applicable)

- [ ] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Checked keyboard navigability
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)
- [ ] Add at least 1 designer as PR reviewer

### As a code reviewer, I have

#### Reviewed, tested, and left feedback about the changes

- [ ] Pulled this branch locally and tested it
- [ ] Reviewed this code and left comments
- [ ] Checked that all code is adequately covered by tests
- [ ] Made it clear which comments need to be addressed before this work is merged
- [ ] If any model was updated to modify/add/delete columns, makemigrations was ran and the associated migrations file has been commited.

#### Ensured code standards are met (Code reviewer)

- [ ] All new functions and methods are commented using plain language
- [ ] Interactions with external systems are wrapped in try/except
- [ ] Error handling exists for unusual or missing values
- [ ] (Rarely needed) Did dependency updates in Pipfile also get changed in requirements.txt?

#### Validated user-facing changes as a developer

- [ ] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Checked keyboard navigability
- [ ] Meets all designs and user flows provided by design/product
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)

- [ ] Tested with multiple browsers, the suggestion is to use ones that the developer didn't (check off which ones were used)
  - [ ] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari

- [ ] (Rarely needed) Tested as both an analyst and applicant user

**Note:** Multiple code reviewers can share the checklists above, a second reviewers should not make a duplicate checklist

### As a designer reviewer, I have

#### Verified that the changes match the design intention

- [ ] Checked that the design translated visually
- [ ] Checked behavior
- [ ] Checked different states (empty, one, some, error)
- [ ] Checked for landmarks, page heading structure, and links
- [ ] Tried to break the intended flow

#### Validated user-facing changes as a designer

- [ ] Checked keyboard navigability
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)

- [ ] Tested with multiple browsers (check off which ones were used)
  - [ ] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari

- [ ] (Rarely needed) Tested as both an analyst and applicant user

## Screenshots

<!-- If this PR makes visible interface changes, an image of the finished interface can help reviewers
and casual observers understand the context of the changes.
A before image is optional and can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow.
You may want to use [GIPHY Capture](https://giphy.com/apps/giphycapture) for this! 📸

_Please frame images to show useful context but also highlight the affected regions._
--->
