### PR TITLE
#2016: Text wrapping to next line for an overflow in domain name - [RH]

### DIFF
--- a/src/registrar/assets/sass/_theme/_admin.scss
+++ b/src/registrar/assets/sass/_theme/_admin.scss
@@ -932,9 +932,9 @@ ul.add-list-reset {
 }
 
 .domain-name-wrap {
-    white-space: normal; /* Allows wrapping */
-    word-wrap: break-word; /* Ensures that long words or URLs will break and wrap */
-    overflow: visible; /* Ensures no truncation */
-    word-break: break-all; /* Breaks words at any point if needed */
-    max-width: 100%; /* Adjust as necessary to limit the width */
+    white-space: normal;
+    word-wrap: break-word;
+    overflow: visible; 
+    word-break: break-all;
+    max-width: 100%; 
   }

--- a/src/registrar/assets/sass/_theme/_admin.scss
+++ b/src/registrar/assets/sass/_theme/_admin.scss
@@ -930,3 +930,10 @@ ul.add-list-reset {
 .dl-dja dt {
     font-size: 14px;
 }
+
+.domain-name-truncate {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 100%;
+}

--- a/src/registrar/assets/sass/_theme/_admin.scss
+++ b/src/registrar/assets/sass/_theme/_admin.scss
@@ -931,9 +931,10 @@ ul.add-list-reset {
     font-size: 14px;
 }
 
-.domain-name-truncate {
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    max-width: 100%;
-}
+.domain-name-wrap {
+    white-space: normal; /* Allows wrapping */
+    word-wrap: break-word; /* Ensures that long words or URLs will break and wrap */
+    overflow: visible; /* Ensures no truncation */
+    word-break: break-all; /* Breaks words at any point if needed */
+    max-width: 100%; /* Adjust as necessary to limit the width */
+  }

--- a/src/registrar/templates/domain_base.html
+++ b/src/registrar/templates/domain_base.html
@@ -9,7 +9,7 @@
   <div class="grid-row grid-gap">
     <div class="tablet:grid-col-3">
       <p class="font-body-md margin-top-0 margin-bottom-2
-                text-primary-darker text-semibold domain-name-truncate"
+                text-primary-darker text-semibold domain-name-wrap"
       >
         <span class="usa-sr-only"> Domain name:</span> {{ domain.name }}
       </p>

--- a/src/registrar/templates/domain_base.html
+++ b/src/registrar/templates/domain_base.html
@@ -9,7 +9,7 @@
   <div class="grid-row grid-gap">
     <div class="tablet:grid-col-3">
       <p class="font-body-md margin-top-0 margin-bottom-2
-                text-primary-darker text-semibold"
+                text-primary-darker text-semibold domain-name-truncate"
       >
         <span class="usa-sr-only"> Domain name:</span> {{ domain.name }}
       </p>

--- a/src/registrar/templates/domain_detail.html
+++ b/src/registrar/templates/domain_detail.html
@@ -5,7 +5,7 @@
 {% block domain_content %}
   {{ block.super }}
   <div class="margin-top-4 tablet:grid-col-10">
-    <h2 class="text-bold text-primary-dark">{{ domain.name }}</h2>
+    <h2 class="text-bold text-primary-dark domain-name-wrap">{{ domain.name }}</h2>
     <div
         class="usa-summary-box dotgov-status-box padding-bottom-0 margin-top-3 padding-left-2{% if not domain.is_expired %}{% if domain.state == domain.State.UNKNOWN or domain.state == domain.State.DNS_NEEDED %} dotgov-status-box--action-need{% endif %}{% endif %}"
         role="region"


### PR DESCRIPTION
## Ticket

Resolves #2016

## Changes

* Make sure that the domain name in the sidebar does not overflow onto the "main" section and wraps
* And the domain name in the "main" section doesn't overflow and instead wraps

## Context for reviewers

See ticket for original state

## Setup

1. Create a domain request with a very length domain name ie `wordswordswordswordswordswordswordswordswordswordswordswords` and submit it
2. Go through `/admin` to do the steps to approve it
3. Click "Manage" 
4. Should see wrapping of the text since the domain name is so long (see screenshot for reference)

## Code Review Verification Steps

### As the original developer, I have

#### Satisfied acceptance criteria and met development standards

- [ ] Met the acceptance criteria, or will meet them in a subsequent PR
- [ ] Created/modified automated tests
- [ ] Added at least 2 developers as PR reviewers (only 1 will need to approve)
- [ ] Messaged on Slack or in standup to notify the team that a PR is ready for review
- [ ] Changes to “how we do things” are documented in READMEs and or onboarding guide
- [ ] If any model was updated to modify/add/delete columns, makemigrations was ran and the associated migrations file has been commited.

#### Ensured code standards are met (Original Developer)

- [ ] All new functions and methods are commented using plain language
- [ ] Did dependency updates in Pipfile also get changed in requirements.txt?
- [ ] Interactions with external systems are wrapped in try/except
- [ ] Error handling exists for unusual or missing values

#### Validated user-facing changes (if applicable)

- [ ] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Checked keyboard navigability
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)
- [ ] Add at least 1 designer as PR reviewer

### As a code reviewer, I have

#### Reviewed, tested, and left feedback about the changes

- [ ] Pulled this branch locally and tested it
- [ ] Reviewed this code and left comments
- [ ] Checked that all code is adequately covered by tests
- [ ] Made it clear which comments need to be addressed before this work is merged
- [ ] If any model was updated to modify/add/delete columns, makemigrations was ran and the associated migrations file has been commited.

#### Ensured code standards are met (Code reviewer)

- [ ] All new functions and methods are commented using plain language
- [ ] Interactions with external systems are wrapped in try/except
- [ ] Error handling exists for unusual or missing values
- [ ] (Rarely needed) Did dependency updates in Pipfile also get changed in requirements.txt?

#### Validated user-facing changes as a developer

- [ ] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Checked keyboard navigability
- [ ] Meets all designs and user flows provided by design/product
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)

- [ ] Tested with multiple browsers, the suggestion is to use ones that the developer didn't (check off which ones were used)
  - [ ] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari

- [ ] (Rarely needed) Tested as both an analyst and applicant user

**Note:** Multiple code reviewers can share the checklists above, a second reviewers should not make a duplicate checklist

### As a designer reviewer, I have

#### Verified that the changes match the design intention

- [ ] Checked that the design translated visually
- [ ] Checked behavior
- [ ] Checked different states (empty, one, some, error)
- [ ] Checked for landmarks, page heading structure, and links
- [ ] Tried to break the intended flow

#### Validated user-facing changes as a designer

- [ ] Checked keyboard navigability
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)

- [ ] Tested with multiple browsers (check off which ones were used)
  - [ ] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari

- [ ] (Rarely needed) Tested as both an analyst and applicant user

## Screenshots
<img width="881" alt="Screenshot 2024-09-20 at 10 07 43 AM" src="https://github.com/user-attachments/assets/7345bef6-902c-4d1b-853b-27b5a0bd27fb">


