### PR TITLE
 #2883: Non Federal Agency Update - [RH] 

### DIFF
--- a/src/registrar/admin.py
+++ b/src/registrar/admin.py
@@ -2464,14 +2464,9 @@ class DomainAdmin(ListHeaderAdmin, ImportExportModelAdmin):
     generic_org_type.admin_order_field = "domain_info__generic_org_type"  # type: ignore
 
     def federal_agency(self, obj):
-        # Print the state of obj and obj.domain_info for troubleshooting
-        print(f"federal_agency method called for: {obj}")
         if obj.domain_info:
-            print(f"Domain info exists: {obj.domain_info}")
-            print(f"Federal agency value: {obj.domain_info.federal_agency}")
             return obj.domain_info.federal_agency
         else:
-            print("Domain info does not exist")
             return None
 
     federal_agency.admin_order_field = "domain_info__federal_agency"  # type: ignore

--- a/src/registrar/admin.py
+++ b/src/registrar/admin.py
@@ -2464,7 +2464,15 @@ class DomainAdmin(ListHeaderAdmin, ImportExportModelAdmin):
     generic_org_type.admin_order_field = "domain_info__generic_org_type"  # type: ignore
 
     def federal_agency(self, obj):
-        return obj.domain_info.federal_agency if obj.domain_info else None
+        # Print the state of obj and obj.domain_info for troubleshooting
+        print(f"federal_agency method called for: {obj}")
+        if obj.domain_info:
+            print(f"Domain info exists: {obj.domain_info}")
+            print(f"Federal agency value: {obj.domain_info.federal_agency}")
+            return obj.domain_info.federal_agency
+        else:
+            print("Domain info does not exist")
+            return None
 
     federal_agency.admin_order_field = "domain_info__federal_agency"  # type: ignore
 

--- a/src/registrar/forms/domain.py
+++ b/src/registrar/forms/domain.py
@@ -527,40 +527,10 @@ class DomainOrgNameAddressForm(forms.ModelForm):
         if field_to_disable is not None:
             DomainHelper.disable_field(self.fields[field_to_disable], disable_required=True)
 
-    # def save(self, commit=True):
-    #     """Override the save() method of the BaseModelForm."""
-    #     if self.has_changed():
-
-    #         # This action should be blocked by the UI, as the text fields are readonly.
-    #         # If they get past this point, we forbid it this way.
-    #         # This could be malicious, so lets reserve information for the backend only.
-    #         if self.is_federal and not self._field_unchanged("federal_agency"):
-    #             raise ValueError("federal_agency cannot be modified when the generic_org_type is federal")
-    #         elif self.is_tribal and not self._field_unchanged("organization_name"):
-    #             raise ValueError("organization_name cannot be modified when the generic_org_type is tribal")
-
-    #     super().save()
-
     def save(self, commit=True):
         """Override the save() method of the BaseModelForm."""
 
-        # print("Save method called")
         if self.has_changed():
-            # print("Form has changed")
-            # print("Generic org type:", self.instance.generic_org_type)
-            # print("Federal agency:", self.instance.federal_agency)
-
-            # address_fields = [
-            #     "address_line1",
-            #     "address_line2",
-            #     "city",
-            #     "state_territory",
-            #     "zipcode",
-            #     "urbanization",
-            # ]
-
-            # if any(field in self.changed_data for field in address_fields):
-            #     print("Address fields have changed")
 
             # This action should be blocked by the UI, as the text fields are readonly.
             # If they get past this point, we forbid it this way.


### PR DESCRIPTION
## Ticket

Resolves #2883 

## Changes

- Making sure we set the Federal Agency field to Non-Federal Agency and not set it to None every time we make a change in Organization in the Domain Overview

## Context for reviewers

- When we changed any fields in the Organization for the first time in Domain Overview, it'd also set our Federal Agency to None

## Setup
1. Go to my sandbox and create a new Domain Request and then go through the process of approving it
2. Once approved, go to your Domain and update the address or any other field in the Organization fields and hit save
3. Go to Log Entries in /admin and the Federal Agency should NOT be changed (there should be no change in federal_agency field just the change you made to whichever field you decided to update)  -- see screenshot

## Code Review Verification Steps

### As the original developer, I have

#### Satisfied acceptance criteria and met development standards

- [ ] Met the acceptance criteria, or will meet them in a subsequent PR
- [ ] Created/modified automated tests
- [ ] Added at least 2 developers as PR reviewers (only 1 will need to approve)
- [ ] Messaged on Slack or in standup to notify the team that a PR is ready for review
- [ ] Changes to “how we do things” are documented in READMEs and or onboarding guide
- [ ] If any model was updated to modify/add/delete columns, makemigrations was ran and the associated migrations file has been commited.

#### Ensured code standards are met (Original Developer)

- [ ] All new functions and methods are commented using plain language
- [ ] Did dependency updates in Pipfile also get changed in requirements.txt?
- [ ] Interactions with external systems are wrapped in try/except
- [ ] Error handling exists for unusual or missing values

#### Validated user-facing changes (if applicable)

- [ ] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Checked keyboard navigability
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)
- [ ] Add at least 1 designer as PR reviewer

### As a code reviewer, I have

#### Reviewed, tested, and left feedback about the changes

- [ ] Pulled this branch locally and tested it
- [ ] Reviewed this code and left comments
- [ ] Checked that all code is adequately covered by tests
- [ ] Made it clear which comments need to be addressed before this work is merged
- [ ] If any model was updated to modify/add/delete columns, makemigrations was ran and the associated migrations file has been commited.

#### Ensured code standards are met (Code reviewer)

- [ ] All new functions and methods are commented using plain language
- [ ] Interactions with external systems are wrapped in try/except
- [ ] Error handling exists for unusual or missing values
- [ ] (Rarely needed) Did dependency updates in Pipfile also get changed in requirements.txt?

#### Validated user-facing changes as a developer

- [ ] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Checked keyboard navigability
- [ ] Meets all designs and user flows provided by design/product
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)

- [ ] Tested with multiple browsers, the suggestion is to use ones that the developer didn't (check off which ones were used)
  - [ ] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari

- [ ] (Rarely needed) Tested as both an analyst and applicant user

**Note:** Multiple code reviewers can share the checklists above, a second reviewers should not make a duplicate checklist

### As a designer reviewer, I have

#### Verified that the changes match the design intention

- [ ] Checked that the design translated visually
- [ ] Checked behavior
- [ ] Checked different states (empty, one, some, error)
- [ ] Checked for landmarks, page heading structure, and links
- [ ] Tried to break the intended flow

#### Validated user-facing changes as a designer

- [ ] Checked keyboard navigability
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)

- [ ] Tested with multiple browsers (check off which ones were used)
  - [ ] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari

- [ ] (Rarely needed) Tested as both an analyst and applicant user

## Screenshots
![Screenshot 2024-10-07 at 2 38 24 PM](https://github.com/user-attachments/assets/a0a19e9d-9e04-46a7-8561-830fbd7c831a)


