### PR TITLE
#2772 - update portfolio additional details and domains page - [AD]

### DIFF
--- a/src/registrar/templates/domain_request_dotgov_domain.html
+++ b/src/registrar/templates/domain_request_dotgov_domain.html
@@ -6,7 +6,11 @@
     <ul class="usa-list">
       <li>Be available </li>
       <li>Relate to your organization’s name, location, and/or services </li>
+      {% if has_organization_feature_flag %}
       <li>Be clear to the general public. Your domain name must not be easily confused with other organizations.</li>
+      {% else %}
+      <li>Be unlikely to mislead or confuse the general public (even if your domain is only intended for a specific audience) </li>
+      {% end %}
     </ul>
   </p>
 
@@ -19,6 +23,12 @@
 
   <p>Note that <strong>only federal agencies can request generic terms</strong> like
   vote.gov.</p>
+  {% if not has_organization_feature_flag%}
+  <h2 class="margin-top-3">Domain examples for your type of organization</h2>
+  <div class="domain_example">
+    {% include "includes/domain_example.html" %}
+  </div>
+  {% endif %}
 {% endblock %}
 
 

--- a/src/registrar/templates/domain_request_dotgov_domain.html
+++ b/src/registrar/templates/domain_request_dotgov_domain.html
@@ -10,7 +10,7 @@
       <li>Be clear to the general public. Your domain name must not be easily confused with other organizations.</li>
       {% else %}
       <li>Be unlikely to mislead or confuse the general public (even if your domain is only intended for a specific audience) </li>
-      {% end %}
+      {% endif %}
     </ul>
   </p>
 

--- a/src/registrar/templates/domain_request_dotgov_domain.html
+++ b/src/registrar/templates/domain_request_dotgov_domain.html
@@ -6,7 +6,7 @@
     <ul class="usa-list">
       <li>Be available </li>
       <li>Relate to your organization’s name, location, and/or services </li>
-      <li>Be unlikely to mislead or confuse the general public (even if your domain is only intended for a specific audience) </li>
+      <li>Be clear to the general public. Your domain name must not be easily confused with other organizations.</li>
     </ul>
   </p>
 
@@ -19,11 +19,6 @@
 
   <p>Note that <strong>only federal agencies can request generic terms</strong> like
   vote.gov.</p>
-
-  <h2 class="margin-top-3">Domain examples for your type of organization</h2>
-  <div class="domain_example">
-    {% include "includes/domain_example.html" %}
-  </div>
 {% endblock %}
 
 

--- a/src/registrar/templates/domain_request_dotgov_domain.html
+++ b/src/registrar/templates/domain_request_dotgov_domain.html
@@ -6,7 +6,7 @@
     <ul class="usa-list">
       <li>Be available </li>
       <li>Relate to your organization’s name, location, and/or services </li>
-      {% if has_organization_feature_flag %}
+      {% if portfolio %}
       <li>Be clear to the general public. Your domain name must not be easily confused with other organizations.</li>
       {% else %}
       <li>Be unlikely to mislead or confuse the general public (even if your domain is only intended for a specific audience) </li>
@@ -23,7 +23,7 @@
 
   <p>Note that <strong>only federal agencies can request generic terms</strong> like
   vote.gov.</p>
-  {% if not has_organization_feature_flag%}
+  {% if not portfolio %}
   <h2 class="margin-top-3">Domain examples for your type of organization</h2>
   <div class="domain_example">
     {% include "includes/domain_example.html" %}

--- a/src/registrar/templates/portfolio_domain_request_additional_details.html
+++ b/src/registrar/templates/portfolio_domain_request_additional_details.html
@@ -7,10 +7,7 @@
 
 {% block form_fields %}
 
-    <fieldset class="usa-fieldset margin-top-2"> 
-        {% if has_organization_feature_flag %}
-        <p><em>Required fields are marked with an asterisk <abbr class="usa-hint usa-hint--required" title="required">(*)</abbr>.</em></p>
-        {% endif %}           
+    <fieldset class="usa-fieldset margin-top-2">          
             <h2>Is there anything else you’d like us to know about your domain request?</h2> 
         </legend>
     </fieldset>

--- a/src/registrar/templates/portfolio_domain_request_additional_details.html
+++ b/src/registrar/templates/portfolio_domain_request_additional_details.html
@@ -9,12 +9,13 @@
 
     <fieldset class="usa-fieldset margin-top-2">
         <legend>
+            <p><em>Required fields are marked with an asterisk <abbr class="usa-hint usa-hint--required" title="required">(*)</abbr>.</em></p>
             <h2>Is there anything else you’d like us to know about your domain request?</h2> 
         </legend>
     </fieldset>
 
     <div class="margin-top-3" id="anything-else">
-        <p>Provide details below. <abbr class="usa-hint usa-hint--required" title="required">*</abbr></p>
+        <p><em>Provide details below. <abbr class="usa-hint usa-hint--required" title="required">*</abbr></em></p>
         {% with attr_maxlength=2000 add_label_class="usa-sr-only" %}
             {% input_with_errors forms.0.anything_else %}
         {% endwith %}

--- a/src/registrar/templates/portfolio_domain_request_additional_details.html
+++ b/src/registrar/templates/portfolio_domain_request_additional_details.html
@@ -16,11 +16,7 @@
     </fieldset>
 
     <div class="margin-top-3" id="anything-else">
-        {% if has_organization_feature_flag %}
         <p><em>Provide details below. <abbr class="usa-hint usa-hint--required" title="required">*</abbr></em></p>
-        {% else %}
-        <p>Provide details below. <abbr class="usa-hint usa-hint--required" title="required">*</abbr></p>
-        {% end %}
         {% with attr_maxlength=2000 add_label_class="usa-sr-only" %}
             {% input_with_errors forms.0.anything_else %}
         {% endwith %}

--- a/src/registrar/templates/portfolio_domain_request_additional_details.html
+++ b/src/registrar/templates/portfolio_domain_request_additional_details.html
@@ -7,15 +7,20 @@
 
 {% block form_fields %}
 
-    <fieldset class="usa-fieldset margin-top-2">
-        <legend>
-            <p><em>Required fields are marked with an asterisk <abbr class="usa-hint usa-hint--required" title="required">(*)</abbr>.</em></p>
+    <fieldset class="usa-fieldset margin-top-2"> 
+        {% if has_organization_feature_flag %}
+        <p><em>Required fields are marked with an asterisk <abbr class="usa-hint usa-hint--required" title="required">(*)</abbr>.</em></p>
+        {% endif %}           
             <h2>Is there anything else you’d like us to know about your domain request?</h2> 
         </legend>
     </fieldset>
 
     <div class="margin-top-3" id="anything-else">
+        {% if has_organization_feature_flag %}
         <p><em>Provide details below. <abbr class="usa-hint usa-hint--required" title="required">*</abbr></em></p>
+        {% else %}
+        <p>Provide details below. <abbr class="usa-hint usa-hint--required" title="required">*</abbr></p>
+        {% end %}
         {% with attr_maxlength=2000 add_label_class="usa-sr-only" %}
             {% input_with_errors forms.0.anything_else %}
         {% endwith %}


### PR DESCRIPTION
## Ticket

<!-- PR title format: `#issue_number: Descriptive name ideally matching ticket name - [sandbox]`-->
Resolves #2772 

## Changes

<!-- What was added, updated, or removed in this PR. -->
- Updating the text, and a little bit of style for the org model view on the domain request steps ( "additional details", and ".gov domain" page
- This should look like the copies below

[Additional Details figma](https://www.figma.com/design/xFtGLHVrhp0lvwh0gYWnbx/.gov-registar?node-id=7998-65108&node-type=frame&t=JdQg7AL0KGnMkZ3L-0)
[Domain page figma](https://www.figma.com/design/xFtGLHVrhp0lvwh0gYWnbx/.gov-registar?node-id=7631-35476&node-type=frame&t=EGXIAX7jfkwhnanK-0)

## Setup

- have the org model feature turned on the sandbox to check for the text changes
- have the org model feature turned off to check for no changes

## Code Review Verification Steps

### As the original developer, I have

#### Satisfied acceptance criteria and met development standards

- [ ] Met the acceptance criteria, or will meet them in a subsequent PR
- [ ] Created/modified automated tests
- [ ] Update documentation in READMEs and/or onboarding guide

#### Ensured code standards are met (Original Developer)
<!-- Mark "- N/A" and check at the end of each check that is not applicable to your PR -->
- [ ] If any updated dependencies on Pipfile, also update dependencies in requirements.txt.
- [ ] Interactions with external systems are wrapped in try/except
- [ ] Error handling exists for unusual or missing values

#### Validated user-facing changes (if applicable)

- [ ] Tag @dotgov-designers in this PR's Reviewers for design review. If code is not user-facing, delete design reviewer checklist
- [ ] Verify new pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Checked keyboard navigability
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)

### As a code reviewer, I have

#### Reviewed, tested, and left feedback about the changes

- [ ] Pulled this branch locally and tested it
- [ ] Verified code meets all checks above. Address any checks that are not satisfied
- [ ] Reviewed this code and left comments. Indicate if comments must be addressed before code is merged
- [ ] Checked that all code is adequately covered by tests
- [ ] Verify migrations are valid and do not conflict with existing migrations

#### Validated user-facing changes as a developer
**Note:** Multiple code reviewers can share the checklists above, a second reviewer should not make a duplicate checklist. All checks should be checked before approving, even those labeled N/A. 

- [ ] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Checked keyboard navigability
- [ ] Meets all designs and user flows provided by design/product
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)
- [ ] (Rarely needed) Tested as both an analyst and applicant user

### As a designer reviewer, I have

#### Verified that the changes match the design intention

- [ ] Checked that the design translated visually
- [ ] Checked behavior. Comment any found issues or broken flows.
- [ ] Checked different states (empty, one, some, error)
- [ ] Checked for landmarks, page heading structure, and links

#### Validated user-facing changes as a designer

- [ ] Checked keyboard navigability
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)
- [ ] Tested with multiple browsers (check off which ones were used)
  - [ ] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari
- [ ] (Rarely needed) Tested as both an analyst and applicant user

### References
- [Code review best practices](../docs/dev-practices/code_review.md)

## Screenshots

<!-- If this PR makes visible interface changes, an image of the finished interface can help reviewers
and casual observers understand the context of the changes.
A before image is optional and can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow.
You may want to use [GIPHY Capture](https://giphy.com/apps/giphycapture) for this! 📸

_Please frame images to show useful context but also highlight the affected regions._
--->
