### PR TITLE
Add screenreader descriptive text to DS and nameserver inputs

### DIFF
--- a/src/registrar/templates/django/forms/widgets/input.html
+++ b/src/registrar/templates/django/forms/widgets/input.html
@@ -4,6 +4,7 @@
     {# hint: spacing in the class string matters #}
     class="{{ uswds_input_class }}{% if classes %} {{ classes }}{% endif %}"
     {% if widget.value != None %}value="{{ widget.value|stringformat:'s' }}"{% endif %}
+    {% if aria_label %}aria-label="{{ aria_label }} {{ label }}"{% endif %}
     {% if sublabel_text %}aria-describedby="{{ widget.attrs.id }}__sublabel"{% endif %}
     {% include "django/forms/widgets/attrs.html" %}
 />

--- a/src/registrar/templates/domain_dsdata.html
+++ b/src/registrar/templates/domain_dsdata.html
@@ -63,11 +63,12 @@
 
       <div class="grid-row margin-top-1">
         <div class="grid-col">
-          <button type="button" class="usa-button usa-button--unstyled usa-button--with-icon float-right-tablet delete-record text-secondary line-height-sans-5">
-            <svg class="usa-icon" aria-hidden="true" focusable="false" role="img" width="24" height="24">
-              <use xlink:href="{%static 'img/sprite.svg'%}#delete"></use>
-            </svg>Delete
-          </button>
+            <button type="button" id="button label" class="usa-button usa-button--unstyled usa-button--with-icon float-right-tablet delete-record text-secondary line-height-sans-5">
+              <svg class="usa-icon" aria-hidden="true" focusable="false" role="img" width="24" height="24">
+                <use xlink:href="{%static 'img/sprite.svg'%}#delete"></use>
+              </svg>Delete
+              <span class="sr-only">DS data record {{forloop.counter}}</span>
+            </button>
         </div>
       </div>
 

--- a/src/registrar/templates/domain_nameservers.html
+++ b/src/registrar/templates/domain_nameservers.html
@@ -47,7 +47,7 @@
           {% endwith %}
         </div>
         <div class="tablet:grid-col-5">
-          {% with sublabel_text="Example: 86.124.49.54 or 2001:db8::1234:5678" add_group_class="usa-form-group--unstyled-error" %}
+          {% with label_text=form.ip.label sublabel_text="Example: 86.124.49.54 or 2001:db8::1234:5678" add_group_class="usa-form-group--unstyled-error" add_aria_label="Name server "|concat:forloop.counter|concat:" "|concat:form.ip.label %}
             {% input_with_errors form.ip %}
           {% endwith %}
         </div>
@@ -56,6 +56,7 @@
             <svg class="usa-icon" aria-hidden="true" focusable="false" role="img" width="24" height="24">
               <use xlink:href="{%static 'img/sprite.svg'%}#delete"></use>
             </svg>Delete
+            <span class="sr-only">Name server {{forloop.counter}}</span>
           </button>
         </div>
       </div>

--- a/src/registrar/templates/includes/input_with_errors.html
+++ b/src/registrar/templates/includes/input_with_errors.html
@@ -66,7 +66,7 @@ error messages, if necessary.
   {% if toggleable_input %}
     {% include "includes/toggleable_input.html" %}
   {% endif %}
-
+  
   {# this is the input field, itself #}
   {% include widget.template_name %}
 

--- a/src/registrar/templates/includes/input_with_errors.html
+++ b/src/registrar/templates/includes/input_with_errors.html
@@ -66,7 +66,7 @@ error messages, if necessary.
   {% if toggleable_input %}
     {% include "includes/toggleable_input.html" %}
   {% endif %}
-  
+
   {# this is the input field, itself #}
   {% include widget.template_name %}
 

--- a/src/registrar/templatetags/field_helpers.py
+++ b/src/registrar/templatetags/field_helpers.py
@@ -24,6 +24,7 @@ def input_with_errors(context, field=None):  # noqa: C901
         add_label_class: append to input element's label's `class` attribute
         add_legend_class: append to input element's legend's `class` attribute
         add_group_class: append to input element's surrounding tag's `class` attribute
+        add_aria_label: append to input element's `aria_label` attribute
         attr_* - adds or replaces any single html attribute for the input
         add_error_attr_* - like `attr_*` but only if field.errors is not empty
         toggleable_input: shows a simple edit button, and adds display-none to the input field.
@@ -55,6 +56,7 @@ def input_with_errors(context, field=None):  # noqa: C901
     label_classes = []
     legend_classes = []
     group_classes = []
+    aria_labels = []
 
     # this will be converted to an attribute string
     described_by = []
@@ -97,6 +99,9 @@ def input_with_errors(context, field=None):  # noqa: C901
             # Used such that we can toggle it with JS
             if "display-none" not in classes:
                 classes.append("display-none")
+
+        elif key == "add_aria_label":
+            aria_labels.append(value)
 
     attrs["id"] = field.auto_id
 
@@ -151,7 +156,10 @@ def input_with_errors(context, field=None):  # noqa: C901
         # ensure we don't overwrite existing attribute value
         if "aria-describedby" in attrs:
             described_by.append(attrs["aria-describedby"])
-        attrs["aria-describedby"] = " ".join(described_by)
+        attrs["aria_describedby"] = " ".join(described_by)
+
+    if aria_labels:
+        context["aria_label"] = " ".join(aria_labels)
 
     # ask Django to give us the widget dict
     # see Widget.get_context() on


### PR DESCRIPTION
## Ticket

<!-- PR title format: `#issue_number: Descriptive name ideally matching ticket name - [sandbox]`-->
Resolves #2773 

## Changes

<!-- What was added, updated, or removed in this PR. -->
- Adds screenreader text to Nameserver and DS delete buttons indicating which nameserver and DS record a user is deleting
- Adds aria-label option to input to adjust aria label for screen readers

<!--
    Please add/remove/edit any of the template below to fit the needs
    of this specific PR.
--->

## Context for reviewers

<!--Background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers.  -->

## Setup

<!--  Add any steps or code to run in this section to help others run your code.
    
    Example 1:
    ```sh
    echo "Code goes here"
    ``` 
    
    Example 2: If the PR was to add a new link with a redirect, this section could simply be:
    -go to /path/to/start/page
    -click the blue link in the <insert location>
    -notice user is redirected to <proper end location>
-->
Prerequisite: Install the [ANDI extension](https://www.ssa.gov/accessibility/andi/help/install.html)
Go to any domain and access the DNS page. 

1. On the nameservers page, run ANDI and verify that the input text fields and delete button's ANDI outputs include their respective Nameserver number 
<img width="1371" alt="image" src="https://github.com/user-attachments/assets/d9b3f8d7-2dde-4ab5-9b77-1055b94b3d33">
<img width="1354" alt="image" src="https://github.com/user-attachments/assets/7e435593-1a55-45b8-948f-78fdf5ba8170">
2. On the DNSSEC page, run ANDI and verify the delete button's ANDI output includes its respective DS record number
<img width="1366" alt="image" src="https://github.com/user-attachments/assets/1d9c3954-5719-4f9d-8f97-7295f51e2c7d">



## Code Review Verification Steps

### As the original developer, I have

#### Satisfied acceptance criteria and met development standards

- [x] Met the acceptance criteria, or will meet them in a subsequent PR
- [x] Created/modified automated tests - NA
- [x] Update documentation in READMEs and/or onboarding guide - NA

#### Ensured code standards are met (Original Developer)
<!-- Mark "- N/A" and check at the end of each check that is not applicable to your PR -->
- [x] If any updated dependencies on Pipfile, also update dependencies in requirements.txt. - NA
- [x] Interactions with external systems are wrapped in try/except - NA
- [x] Error handling exists for unusual or missing values - NA

#### Validated user-facing changes (if applicable)

- [x] Tag @dotgov-designers in this PR's Reviewers for design review. If code is not user-facing, delete design reviewer checklist
- [x] Verify new pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing  - NA
- [x] Checked keyboard navigability - NA
- [x] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)

### As a code reviewer, I have

#### Reviewed, tested, and left feedback about the changes

- [x] Pulled this branch locally and tested it
- [x] Verified code meets all checks above. Address any checks that are not satisfied
- [x] Reviewed this code and left comments. Indicate if comments must be addressed before code is merged
- [x] Checked that all code is adequately covered by tests
- [x] Verify migrations are valid and do not conflict with existing migrations

#### Validated user-facing changes as a developer
**Note:** Multiple code reviewers can share the checklists above, a second reviewer should not make a duplicate checklist. All checks should be checked before approving, even those labeled N/A. 

- [ ] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Checked keyboard navigability
- [ ] Meets all designs and user flows provided by design/product
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)
- [ ] (Rarely needed) Tested as both an analyst and applicant user

### As a designer reviewer, I have

#### Verified that the changes match the design intention

- [ ] Checked that the design translated visually
- [ ] Checked behavior. Comment any found issues or broken flows.
- [ ] Checked different states (empty, one, some, error)
- [ ] Checked for landmarks, page heading structure, and links

#### Validated user-facing changes as a designer

- [ ] Checked keyboard navigability
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)
- [ ] Tested with multiple browsers (check off which ones were used)
  - [ ] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari
- [ ] (Rarely needed) Tested as both an analyst and applicant user

### References
- [Code review best practices](../docs/dev-practices/code_review.md)

## Screenshots

<!-- If this PR makes visible interface changes, an image of the finished interface can help reviewers
and casual observers understand the context of the changes.
A before image is optional and can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow.
You may want to use [GIPHY Capture](https://giphy.com/apps/giphycapture) for this! 📸

_Please frame images to show useful context but also highlight the affected regions._
--->
