### PR TITLE
#3142: Domain Expiring Filter + CTA Banner - [RH] 

### DIFF
--- a/src/Pipfile
+++ b/src/Pipfile
@@ -4,7 +4,7 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-django = "4.2.10"
+django = "4.2.17"
 cfenv = "*"
 django-cors-headers = "*"
 pycryptodomex = "*"

--- a/src/Pipfile.lock
+++ b/src/Pipfile.lock
@@ -1789,11 +1789,12 @@
         },
         "waitress": {
             "hashes": [
-                "sha256:005da479b04134cdd9dd602d1ee7c49d79de0537610d653674cc6cbde222b8a1",
-                "sha256:2a06f242f4ba0cc563444ca3d1998959447477363a2d7e9b8b4d75d35cfd1669"
+                "sha256:26cdbc593093a15119351690752c99adc13cbc6786d75f7b6341d1234a3730ac",
+                "sha256:ef0c1f020d9f12a515c4ec65c07920a702613afcad1dbfdc3bcec256b6c072b3"
             ],
-            "markers": "python_full_version >= '3.8.0'",
-            "version": "==3.0.0"
+            "index": "pypi",
+            "markers": "python_full_version >= '3.9.0'",
+            "version": "==3.0.1"
         },
         "webob": {
             "hashes": [

--- a/src/Pipfile.lock
+++ b/src/Pipfile.lock
@@ -1793,7 +1793,7 @@
                 "sha256:2a06f242f4ba0cc563444ca3d1998959447477363a2d7e9b8b4d75d35cfd1669"
             ],
             "markers": "python_full_version >= '3.8.0'",
-            "version": "==3.0.0"
+            "version": "==3.0.1"
         },
         "webob": {
             "hashes": [

--- a/src/Pipfile.lock
+++ b/src/Pipfile.lock
@@ -1793,7 +1793,7 @@
                 "sha256:2a06f242f4ba0cc563444ca3d1998959447477363a2d7e9b8b4d75d35cfd1669"
             ],
             "markers": "python_full_version >= '3.8.0'",
-            "version": "==3.0.1"
+            "version": "==3.0.0"
         },
         "webob": {
             "hashes": [

--- a/src/package.json
+++ b/src/package.json
@@ -22,5 +22,8 @@
     "sass-loader": "^12.6.0",
     "webpack": "^5.96.1",
     "webpack-stream": "^7.0.0"
+  },
+  "overrides": {
+    "semver": "^7.5.3"
   }
 }

--- a/src/registrar/admin.py
+++ b/src/registrar/admin.py
@@ -2096,6 +2096,7 @@ class DomainRequestAdmin(ListHeaderAdmin, ImportExportModelAdmin):
         ElectionOfficeFilter,
         "rejection_reason",
         InvestigatorFilter,
+        "portfolio"
     )
 
     # Search
@@ -2104,8 +2105,10 @@ class DomainRequestAdmin(ListHeaderAdmin, ImportExportModelAdmin):
         "creator__email",
         "creator__first_name",
         "creator__last_name",
+        "converted_organization_name"
+
     ]
-    search_help_text = "Search by domain or creator."
+    search_help_text = "Search by domain, creator, or organization name."
 
     fieldsets = [
         (
@@ -2271,9 +2274,6 @@ class DomainRequestAdmin(ListHeaderAdmin, ImportExportModelAdmin):
         "cisa_representative_first_name",
         "cisa_representative_last_name",
         "cisa_representative_email",
-        "requested_suborganization",
-        "suborganization_city",
-        "suborganization_state_territory",
     ]
 
     autocomplete_fields = [

--- a/src/registrar/admin.py
+++ b/src/registrar/admin.py
@@ -1980,10 +1980,8 @@ class DomainRequestAdmin(ListHeaderAdmin, ImportExportModelAdmin):
             )
 
         def queryset(self, request, queryset):
-            if self.value() == "1":
-                return queryset.filter(Q(portfolio__isnull=False))
-            if self.value() == "0":
-                return queryset.filter(Q(portfolio__isnull=True))
+            filter_for_portfolio = self.value() == "1"
+            return queryset.filter(portfolio__isnull=filter_for_portfolio)
 
     # ------ Custom fields ------
     def custom_election_board(self, obj):

--- a/src/registrar/admin.py
+++ b/src/registrar/admin.py
@@ -1993,7 +1993,7 @@ class DomainRequestAdmin(ListHeaderAdmin, ImportExportModelAdmin):
     @admin.display(description=_("Requested Domain"))
     def custom_requested_domain(self, obj):
         # Example: Show different icons based on `status`
-        url = reverse("admin:registrar_domainrequest_changelist") + f"{obj.id}"
+        url = reverse("admin:registrar_domainrequest_changelist", args=[obj.id])
         text = obj.requested_domain
         if obj.portfolio:
             return format_html('<a href="{}"><img src="/public/admin/img/icon-yes.svg"> {}</a>', url, text)

--- a/src/registrar/admin.py
+++ b/src/registrar/admin.py
@@ -1980,8 +1980,10 @@ class DomainRequestAdmin(ListHeaderAdmin, ImportExportModelAdmin):
             )
 
         def queryset(self, request, queryset):
-            filter_for_portfolio = self.value() == "1"
-            return queryset.filter(portfolio__isnull=filter_for_portfolio)
+            if self.value() == "1":
+                return queryset.filter(Q(portfolio__isnull=False))
+            if self.value() == "0":
+                return queryset.filter(Q(portfolio__isnull=True))
 
     # ------ Custom fields ------
     def custom_election_board(self, obj):
@@ -1993,7 +1995,7 @@ class DomainRequestAdmin(ListHeaderAdmin, ImportExportModelAdmin):
     @admin.display(description=_("Requested Domain"))
     def custom_requested_domain(self, obj):
         # Example: Show different icons based on `status`
-        url = reverse("admin:registrar_domainrequest_changelist", args=[obj.id])
+        url = reverse("admin:registrar_domainrequest_changelist") + f"?portfolio={obj.id}"
         text = obj.requested_domain
         if obj.portfolio:
             return format_html('<a href="{}"><img src="/public/admin/img/icon-yes.svg"> {}</a>', url, text)

--- a/src/registrar/admin.py
+++ b/src/registrar/admin.py
@@ -1971,7 +1971,7 @@ class DomainRequestAdmin(ListHeaderAdmin, ImportExportModelAdmin):
         """Define a custom filter for portfolio"""
 
         title = _("portfolio")
-        parameter_name = "portfolio"
+        parameter_name = "portfolio__isnull"
 
         def lookups(self, request, model_admin):
             return (

--- a/src/registrar/admin.py
+++ b/src/registrar/admin.py
@@ -2010,7 +2010,7 @@ class DomainRequestAdmin(ListHeaderAdmin, ImportExportModelAdmin):
             url,
             text
         )
-    custom_requested_domain.admin_order_field = "requested_domain"  # type: ignore
+    custom_requested_domain.admin_order_field = "requested_domain__name"  # type: ignore
 
     # ------ Converted fields ------
     # These fields map to @Property methods and
@@ -2146,11 +2146,11 @@ class DomainRequestAdmin(ListHeaderAdmin, ImportExportModelAdmin):
 
     # Filters
     list_filter = (
+        PortfolioFilter,
         StatusListFilter,
         GenericOrgFilter,
         FederalTypeFilter,
         ElectionOfficeFilter,
-        PortfolioFilter,
         "rejection_reason",
         InvestigatorFilter,
     )

--- a/src/registrar/admin.py
+++ b/src/registrar/admin.py
@@ -1835,7 +1835,7 @@ class DomainRequestAdmin(ListHeaderAdmin, ImportExportModelAdmin):
     class StatusListFilter(MultipleChoiceListFilter):
         """Custom status filter which is a multiple choice filter"""
 
-        title = "Status"
+        title = "status"
         parameter_name = "status__in"
 
         template = "django/admin/multiple_choice_list_filter.html"
@@ -1879,7 +1879,7 @@ class DomainRequestAdmin(ListHeaderAdmin, ImportExportModelAdmin):
         If we have a portfolio, use the portfolio's federal type.  If not, use the
         organization in the Domain Request object."""
 
-        title = "federal Type"
+        title = "federal type"
         parameter_name = "converted_federal_types"
 
         def lookups(self, request, model_admin):
@@ -1966,6 +1966,24 @@ class DomainRequestAdmin(ListHeaderAdmin, ImportExportModelAdmin):
                 return queryset.filter(is_election_board=True)
             if self.value() == "0":
                 return queryset.filter(Q(is_election_board=False) | Q(is_election_board=None))
+    
+    class PortfolioFilter(admin.SimpleListFilter):
+        """Define a custom filter for portfolio"""
+
+        title = _("portfolio")
+        parameter_name = "portfolio"
+
+        def lookups(self, request, model_admin):
+            return (
+                ("1", _("Yes")),
+                ("0", _("No")),
+            )
+        
+        def queryset(self, request, queryset):
+            if self.value() == "1":
+                return queryset.filter(Q(portfolio__isnull=False))
+            if self.value() == "0":
+                return queryset.filter(Q(portfolio__isnull=True))
 
     # ------ Custom fields ------
     def custom_election_board(self, obj):
@@ -2132,9 +2150,9 @@ class DomainRequestAdmin(ListHeaderAdmin, ImportExportModelAdmin):
         GenericOrgFilter,
         FederalTypeFilter,
         ElectionOfficeFilter,
+        PortfolioFilter,
         "rejection_reason",
         InvestigatorFilter,
-        "portfolio"
     )
 
     # Search

--- a/src/registrar/admin.py
+++ b/src/registrar/admin.py
@@ -1971,7 +1971,17 @@ class DomainRequestAdmin(ListHeaderAdmin, ImportExportModelAdmin):
 
     @admin.display(description=_("Organization Name"))
     def converted_organization_name(self, obj):
-        return obj.converted_organization_name
+        # Example: Show different icons based on `status`
+        if obj.portfolio:
+            url = reverse("admin:registrar_portfolio_changelist") + f"{obj.portfolio.id}"
+            text = obj.converted_organization_name
+            return format_html(
+                '<a href="{}">{}</a>',
+                url,
+                text
+            )
+        else:
+            return obj.converted_organization_name
 
     @admin.display(description=_("Federal Agency"))
     def converted_federal_agency(self, obj):
@@ -1988,28 +1998,6 @@ class DomainRequestAdmin(ListHeaderAdmin, ImportExportModelAdmin):
     @admin.display(description=_("State/Territory"))
     def converted_state_territory(self, obj):
         return obj.converted_state_territory
-
-    # Columns
-    list_display = [
-        "requested_domain",
-        "first_submitted_date",
-        "last_submitted_date",
-        "last_status_update",
-        "status",
-        "custom_election_board",
-        "converted_generic_org_type",
-        "converted_organization_name",
-        "converted_federal_agency",
-        "converted_federal_type",
-        "converted_city",
-        "converted_state_territory",
-        "investigator",
-    ]
-
-    orderable_fk_fields = [
-        ("requested_domain", "name"),
-        ("investigator", ["first_name", "last_name"]),
-    ]
 
     def custom_election_board(self, obj):
         return "Yes" if obj.is_election_board else "No"
@@ -2086,7 +2074,29 @@ class DomainRequestAdmin(ListHeaderAdmin, ImportExportModelAdmin):
     def status_history(self, obj):
         return "No changelog to display."
 
-    status_history.short_description = "Status History"  # type: ignore
+    status_history.short_description = "Status history"  # type: ignore
+
+    # Columns
+    list_display = [
+        "requested_domain",
+        "first_submitted_date",
+        "last_submitted_date",
+        "last_status_update",
+        "status",
+        "custom_election_board",
+        "converted_generic_org_type",
+        "converted_organization_name",
+        "converted_federal_agency",
+        "converted_federal_type",
+        "converted_city",
+        "converted_state_territory",
+        "investigator",
+    ]
+
+    orderable_fk_fields = [
+        ("requested_domain", "name"),
+        ("investigator", ["first_name", "last_name"]),
+    ]
 
     # Filters
     list_filter = (

--- a/src/registrar/admin.py
+++ b/src/registrar/admin.py
@@ -2012,7 +2012,7 @@ class DomainRequestAdmin(ListHeaderAdmin, ImportExportModelAdmin):
     def converted_organization_name(self, obj):
         # Example: Show different icons based on `status`
         if obj.portfolio:
-            url = reverse("admin:registrar_portfolio_changelist") + f"{obj.portfolio.id}"
+            url = reverse("admin:registrar_portfolio_change", args=[obj.portfolio.id])
             text = obj.converted_organization_name
             return format_html('<a href="{}">{}</a>', url, text)
         else:

--- a/src/registrar/admin.py
+++ b/src/registrar/admin.py
@@ -1829,7 +1829,7 @@ class DomainRequestAdmin(ListHeaderAdmin, ImportExportModelAdmin):
 
     form = DomainRequestAdminForm
     change_form_template = "django/admin/domain_request_change_form.html"
-    
+
     # ------ Filters ------
     # Define custom filters
     class StatusListFilter(MultipleChoiceListFilter):
@@ -1966,7 +1966,7 @@ class DomainRequestAdmin(ListHeaderAdmin, ImportExportModelAdmin):
                 return queryset.filter(is_election_board=True)
             if self.value() == "0":
                 return queryset.filter(Q(is_election_board=False) | Q(is_election_board=None))
-    
+
     class PortfolioFilter(admin.SimpleListFilter):
         """Define a custom filter for portfolio"""
 
@@ -1978,7 +1978,7 @@ class DomainRequestAdmin(ListHeaderAdmin, ImportExportModelAdmin):
                 ("1", _("Yes")),
                 ("0", _("No")),
             )
-        
+
         def queryset(self, request, queryset):
             if self.value() == "1":
                 return queryset.filter(Q(portfolio__isnull=False))
@@ -1992,24 +1992,15 @@ class DomainRequestAdmin(ListHeaderAdmin, ImportExportModelAdmin):
     custom_election_board.admin_order_field = "is_election_board"  # type: ignore
     custom_election_board.short_description = "Election office"  # type: ignore
 
-
     @admin.display(description=_("Requested Domain"))
     def custom_requested_domain(self, obj):
         # Example: Show different icons based on `status`
         url = reverse("admin:registrar_domainrequest_changelist") + f"{obj.id}"
         text = obj.requested_domain
-        icon = ''
         if obj.portfolio:
-            return format_html(
-                '<a href="{}"><img src="/public/admin/img/icon-yes.svg"> {}</a>',
-                url,
-                text
-            )
-        return format_html(
-            '<a href="{}">{}</a>',
-            url,
-            text
-        )
+            return format_html('<a href="{}"><img src="/public/admin/img/icon-yes.svg"> {}</a>', url, text)
+        return format_html('<a href="{}">{}</a>', url, text)
+
     custom_requested_domain.admin_order_field = "requested_domain__name"  # type: ignore
 
     # ------ Converted fields ------
@@ -2025,11 +2016,7 @@ class DomainRequestAdmin(ListHeaderAdmin, ImportExportModelAdmin):
         if obj.portfolio:
             url = reverse("admin:registrar_portfolio_changelist") + f"{obj.portfolio.id}"
             text = obj.converted_organization_name
-            return format_html(
-                '<a href="{}">{}</a>',
-                url,
-                text
-            )
+            return format_html('<a href="{}">{}</a>', url, text)
         else:
             return obj.converted_organization_name
 
@@ -2048,7 +2035,6 @@ class DomainRequestAdmin(ListHeaderAdmin, ImportExportModelAdmin):
     @admin.display(description=_("State/Territory"))
     def converted_state_territory(self, obj):
         return obj.converted_state_territory
-
 
     # ------ Portfolio fields ------
     # Define methods to display fields from the related portfolio
@@ -2746,7 +2732,7 @@ class DomainRequestAdmin(ListHeaderAdmin, ImportExportModelAdmin):
             # Further filter the queryset by the portfolio
             qs = qs.filter(portfolio=portfolio_id)
         return qs
-    
+
     def get_search_results(self, request, queryset, search_term):
         # Call the parent's method to apply default search logic
         base_queryset, use_distinct = super().get_search_results(request, queryset, search_term)
@@ -3822,8 +3808,7 @@ class PortfolioAdmin(ListHeaderAdmin):
 
     # Even though this is empty, I will leave it as a stub for easy changes in the future
     # rather than strip it out of our logic.
-    analyst_readonly_fields = [
-    ]
+    analyst_readonly_fields = []  # type: ignore
 
     def get_admin_users(self, obj):
         # Filter UserPortfolioPermission objects related to the portfolio

--- a/src/registrar/admin.py
+++ b/src/registrar/admin.py
@@ -3820,6 +3820,11 @@ class PortfolioAdmin(ListHeaderAdmin):
         "senior_official",
     ]
 
+    # Even though this is empty, I will leave it as a stub for easy changes in the future
+    # rather than strip it out of our logic.
+    analyst_readonly_fields = [
+    ]
+
     def get_admin_users(self, obj):
         # Filter UserPortfolioPermission objects related to the portfolio
         admin_permissions = self.get_user_portfolio_permission_admins(obj)

--- a/src/registrar/admin.py
+++ b/src/registrar/admin.py
@@ -1992,6 +1992,7 @@ class DomainRequestAdmin(ListHeaderAdmin, ImportExportModelAdmin):
             url,
             text
         )
+    custom_requested_domain.admin_order_field = "requested_domain"  # type: ignore
 
     # ------ Converted fields ------
     # These fields map to @Property methods and

--- a/src/registrar/admin.py
+++ b/src/registrar/admin.py
@@ -3746,10 +3746,6 @@ class PortfolioAdmin(ListHeaderAdmin):
         "senior_official",
     ]
 
-    analyst_readonly_fields = [
-        "organization_name",
-    ]
-
     def get_admin_users(self, obj):
         # Filter UserPortfolioPermission objects related to the portfolio
         admin_permissions = self.get_user_portfolio_permission_admins(obj)

--- a/src/registrar/admin.py
+++ b/src/registrar/admin.py
@@ -1829,7 +1829,9 @@ class DomainRequestAdmin(ListHeaderAdmin, ImportExportModelAdmin):
 
     form = DomainRequestAdminForm
     change_form_template = "django/admin/domain_request_change_form.html"
-
+    
+    # ------ Filters ------
+    # Define custom filters
     class StatusListFilter(MultipleChoiceListFilter):
         """Custom status filter which is a multiple choice filter"""
 
@@ -1965,6 +1967,35 @@ class DomainRequestAdmin(ListHeaderAdmin, ImportExportModelAdmin):
             if self.value() == "0":
                 return queryset.filter(Q(is_election_board=False) | Q(is_election_board=None))
 
+    # ------ Custom fields ------
+    def custom_election_board(self, obj):
+        return "Yes" if obj.is_election_board else "No"
+
+    custom_election_board.admin_order_field = "is_election_board"  # type: ignore
+    custom_election_board.short_description = "Election office"  # type: ignore
+
+
+    @admin.display(description=_("Requested Domain"))
+    def custom_requested_domain(self, obj):
+        # Example: Show different icons based on `status`
+        url = reverse("admin:registrar_domainrequest_changelist") + f"{obj.id}"
+        text = obj.requested_domain
+        icon = ''
+        if obj.portfolio:
+            return format_html(
+                '<a href="{}"><img src="/public/admin/img/icon-yes.svg"> {}</a>',
+                url,
+                text
+            )
+        return format_html(
+            '<a href="{}">{}</a>',
+            url,
+            text
+        )
+
+    # ------ Converted fields ------
+    # These fields map to @Property methods and
+    # require these custom definitions to work properly
     @admin.display(description=_("Generic Org Type"))
     def converted_generic_org_type(self, obj):
         return obj.converted_generic_org_type_display
@@ -1999,12 +2030,8 @@ class DomainRequestAdmin(ListHeaderAdmin, ImportExportModelAdmin):
     def converted_state_territory(self, obj):
         return obj.converted_state_territory
 
-    def custom_election_board(self, obj):
-        return "Yes" if obj.is_election_board else "No"
 
-    custom_election_board.admin_order_field = "is_election_board"  # type: ignore
-    custom_election_board.short_description = "Election office"  # type: ignore
-
+    # ------ Portfolio fields ------
     # Define methods to display fields from the related portfolio
     def portfolio_senior_official(self, obj) -> Optional[SeniorOfficial]:
         return obj.portfolio.senior_official if obj.portfolio and obj.portfolio.senior_official else None
@@ -2078,7 +2105,7 @@ class DomainRequestAdmin(ListHeaderAdmin, ImportExportModelAdmin):
 
     # Columns
     list_display = [
-        "requested_domain",
+        "custom_requested_domain",
         "first_submitted_date",
         "last_submitted_date",
         "last_status_update",
@@ -2110,13 +2137,12 @@ class DomainRequestAdmin(ListHeaderAdmin, ImportExportModelAdmin):
     )
 
     # Search
+    # NOTE: converted fields are included in the override for get_search_results
     search_fields = [
         "requested_domain__name",
         "creator__email",
         "creator__first_name",
         "creator__last_name",
-        "converted_organization_name"
-
     ]
     search_help_text = "Search by domain, creator, or organization name."
 
@@ -2701,6 +2727,25 @@ class DomainRequestAdmin(ListHeaderAdmin, ImportExportModelAdmin):
             # Further filter the queryset by the portfolio
             qs = qs.filter(portfolio=portfolio_id)
         return qs
+    
+    def get_search_results(self, request, queryset, search_term):
+        # Call the parent's method to apply default search logic
+        base_queryset, use_distinct = super().get_search_results(request, queryset, search_term)
+
+        # Add custom search logic for the annotated field
+        if search_term:
+            annotated_queryset = queryset.filter(
+                # converted_organization_name
+                Q(portfolio__organization_name__icontains=search_term)
+                | Q(portfolio__isnull=True, organization_name__icontains=search_term)
+            )
+
+            # Combine the two querysets using union
+            combined_queryset = base_queryset | annotated_queryset
+        else:
+            combined_queryset = base_queryset
+
+        return combined_queryset, use_distinct
 
 
 class TransitionDomainAdmin(ListHeaderAdmin):

--- a/src/registrar/assets/src/sass/_theme/_base.scss
+++ b/src/registrar/assets/src/sass/_theme/_base.scss
@@ -149,10 +149,6 @@ footer {
   color: color('primary');
 }
 
-.usa-footer {
-  margin-bottom: 0.5rem;
-}
-
 .usa-radio {
   margin-top: 1rem;
   font-size: 1.06rem;

--- a/src/registrar/assets/src/sass/_theme/_base.scss
+++ b/src/registrar/assets/src/sass/_theme/_base.scss
@@ -149,6 +149,14 @@ footer {
   color: color('primary');
 }
 
+.usa-footer {
+  margin-bottom: 0.5rem;
+}
+
+.usa-radio {
+  margin-top: 1rem;
+}
+
 abbr[title] {
   // workaround for underlining abbr element
   border-bottom: none;

--- a/src/registrar/assets/src/sass/_theme/_base.scss
+++ b/src/registrar/assets/src/sass/_theme/_base.scss
@@ -155,6 +155,7 @@ footer {
 
 .usa-radio {
   margin-top: 1rem;
+  font-size: 1.06rem;
 }
 
 abbr[title] {

--- a/src/registrar/assets/src/sass/_theme/_typography.scss
+++ b/src/registrar/assets/src/sass/_theme/_typography.scss
@@ -36,6 +36,7 @@ h2 {
   font-size: 1rem;
   legend em {
     font-size: 1rem;
+    margin-bottom: 0.5rem;
   }
 }
 

--- a/src/registrar/assets/src/sass/_theme/_typography.scss
+++ b/src/registrar/assets/src/sass/_theme/_typography.scss
@@ -34,6 +34,9 @@ h2 {
 .usa-form,
 .usa-form fieldset {
   font-size: 1rem;
+  legend em {
+    font-size: 1rem;
+  }
 }
 
 .p--blockquote {

--- a/src/registrar/assets/src/sass/_theme/_typography.scss
+++ b/src/registrar/assets/src/sass/_theme/_typography.scss
@@ -34,9 +34,8 @@ h2 {
 .usa-form,
 .usa-form fieldset {
   font-size: 1rem;
-  legend em {
+  .usa-legend {
     font-size: 1rem;
-    margin-bottom: 0.5rem;
   }
 }
 

--- a/src/registrar/fixtures/fixtures_users.py
+++ b/src/registrar/fixtures/fixtures_users.py
@@ -151,6 +151,27 @@ class UserFixture:
             "email": "skey@truss.works",
             "title": "Designer",
         },
+        {
+            "username": "f20b7a53-f40d-48f8-8c12-f42f35eede92",
+            "first_name": "Kimberly",
+            "last_name": "Aralar",
+            "email": "kimberly.aralar@gsa.gov",
+            "title": "Designer",
+        },
+        {
+            "username": "4aa78480-6272-42f9-ac29-a034ebdd9231",
+            "first_name": "Kaitlin",
+            "last_name": "Abbitt",
+            "email": "kaitlin.abbitt@cisa.dhs.gov",
+            "title": "Product Manager",
+        },
+        {
+            "username": "5e54fd98-6c11-4cb3-82b6-93ed8be50a61",
+            "first_name": "Gina",
+            "last_name": "Summers",
+            "email": "gina.summers@ecstech.com",
+            "title": "Scrum Master",
+        },
     ]
 
     STAFF = [
@@ -256,6 +277,18 @@ class UserFixture:
             "first_name": "Samiyah-Analyst",
             "last_name": "Key-Analyst",
             "email": "skey+1@truss.works",
+        },
+        {
+            "username": "cf2b32fe-280d-4bc0-96c2-99eec09ba4da",
+            "first_name": "Kimberly-Analyst",
+            "last_name": "Aralar-Analyst",
+            "email": "kimberly.aralar+1@gsa.gov",
+        },
+        {
+            "username": "80db923e-ac64-4128-9b6f-e54b2174a09b",
+            "first_name": "Kaitlin-Analyst",
+            "last_name": "Abbitt-Analyst",
+            "email": "kaitlin.abbitt@gwe.cisa.dhs.gov",
         },
     ]
 

--- a/src/registrar/forms/domain_request_wizard.py
+++ b/src/registrar/forms/domain_request_wizard.py
@@ -792,7 +792,12 @@ class AnythingElseForm(BaseDeletableRegistrarForm):
     anything_else = forms.CharField(
         required=True,
         label="Anything else?",
-        widget=forms.Textarea(),
+        widget=forms.Textarea(
+            attrs={
+                "aria-label": "Is there anything else you’d like us to know about your domain request? \
+                    Provide details below. You can enter up to 2000 characters"
+            }
+        ),
         validators=[
             MaxLengthValidator(
                 2000,

--- a/src/registrar/forms/domain_request_wizard.py
+++ b/src/registrar/forms/domain_request_wizard.py
@@ -736,7 +736,14 @@ class NoOtherContactsForm(BaseDeletableRegistrarForm):
         required=True,
         # label has to end in a space to get the label_suffix to show
         label=("No other employees rationale"),
-        widget=forms.Textarea(),
+        widget=forms.Textarea(
+            attrs={
+                "aria-label": "You don’t need to provide names of other employees now, \
+                but it may slow down our assessment of your eligibility. Describe \
+                why there are no other employees who can help verify your request. \
+                You can enter up to 1000 characters."
+            }
+        ),
         validators=[
             MaxLengthValidator(
                 1000,

--- a/src/registrar/forms/domain_request_wizard.py
+++ b/src/registrar/forms/domain_request_wizard.py
@@ -547,6 +547,7 @@ class OtherContactsYesNoForm(BaseYesNoForm):
     """The yes/no field for the OtherContacts form."""
 
     form_choices = ((True, "Yes, I can name other employees."), (False, "No. (We’ll ask you to explain why.)"))
+    title_label = "Are there other employees who can help verify your request?"
     field_name = "has_other_contacts"
 
     @property

--- a/src/registrar/forms/domain_request_wizard.py
+++ b/src/registrar/forms/domain_request_wizard.py
@@ -547,7 +547,6 @@ class OtherContactsYesNoForm(BaseYesNoForm):
     """The yes/no field for the OtherContacts form."""
 
     form_choices = ((True, "Yes, I can name other employees."), (False, "No. (We’ll ask you to explain why.)"))
-    title_label = "Are there other employees who can help verify your request?"
     field_name = "has_other_contacts"
 
     @property

--- a/src/registrar/forms/domain_request_wizard.py
+++ b/src/registrar/forms/domain_request_wizard.py
@@ -792,12 +792,7 @@ class AnythingElseForm(BaseDeletableRegistrarForm):
     anything_else = forms.CharField(
         required=True,
         label="Anything else?",
-        widget=forms.Textarea(
-            attrs={
-                "aria-label": "Is there anything else you’d like us to know about your domain request? Provide details below. \
-                You can enter up to 2000 characters"
-            }
-        ),
+        widget=forms.Textarea(),
         validators=[
             MaxLengthValidator(
                 2000,

--- a/src/registrar/forms/domain_request_wizard.py
+++ b/src/registrar/forms/domain_request_wizard.py
@@ -792,7 +792,12 @@ class AnythingElseForm(BaseDeletableRegistrarForm):
     anything_else = forms.CharField(
         required=True,
         label="Anything else?",
-        widget=forms.Textarea(),
+        widget=forms.Textarea(
+            attrs={
+                "aria-label": "Is there anything else you’d like us to know about your domain request? Provide details below. \
+                You can enter up to 2000 characters"
+            }
+        ),
         validators=[
             MaxLengthValidator(
                 2000,

--- a/src/registrar/forms/domain_request_wizard.py
+++ b/src/registrar/forms/domain_request_wizard.py
@@ -740,8 +740,7 @@ class NoOtherContactsForm(BaseDeletableRegistrarForm):
             attrs={
                 "aria-label": "You don’t need to provide names of other employees now, \
                 but it may slow down our assessment of your eligibility. Describe \
-                why there are no other employees who can help verify your request. \
-                You can enter up to 1000 characters."
+                why there are no other employees who can help verify your request."
             }
         ),
         validators=[

--- a/src/registrar/forms/domain_request_wizard.py
+++ b/src/registrar/forms/domain_request_wizard.py
@@ -530,7 +530,7 @@ class PurposeForm(RegistrarForm):
         widget=forms.Textarea(
             attrs={
                 "aria-label": "What is the purpose of your requested domain? Describe how you’ll use your .gov domain. \
-                Will it be used for a website, email, or something else? You can enter up to 2000 characters."
+                Will it be used for a website, email, or something else?"
             }
         ),
         validators=[

--- a/src/registrar/forms/utility/wizard_form_helper.py
+++ b/src/registrar/forms/utility/wizard_form_helper.py
@@ -239,6 +239,10 @@ class BaseYesNoForm(RegistrarForm):
     # Default form choice mapping. Default is suitable for most cases.
     form_choices = ((True, "Yes"), (False, "No"))
 
+    # Option to append question to aria label for screenreader accessibility.
+    # Not added by default.
+    aria_label = ""
+
     def __init__(self, *args, **kwargs):
         """Extend the initialization of the form from RegistrarForm __init__"""
         super().__init__(*args, **kwargs)
@@ -256,7 +260,11 @@ class BaseYesNoForm(RegistrarForm):
             coerce=lambda x: x.lower() == "true" if x is not None else None,
             choices=self.form_choices,
             initial=self.get_initial_value(),
-            widget=forms.RadioSelect,
+            widget=forms.RadioSelect(
+                attrs={
+                    "aria-label": self.aria_label
+                }
+            ),
             error_messages={
                 "required": self.required_error_message,
             },

--- a/src/registrar/forms/utility/wizard_form_helper.py
+++ b/src/registrar/forms/utility/wizard_form_helper.py
@@ -256,7 +256,7 @@ class BaseYesNoForm(RegistrarForm):
             coerce=lambda x: x.lower() == "true" if x is not None else None,
             choices=self.form_choices,
             initial=self.get_initial_value(),
-            widget=forms.RadioSelect(),
+            widget=forms.RadioSelect,
             error_messages={
                 "required": self.required_error_message,
             },

--- a/src/registrar/forms/utility/wizard_form_helper.py
+++ b/src/registrar/forms/utility/wizard_form_helper.py
@@ -241,7 +241,8 @@ class BaseYesNoForm(RegistrarForm):
 
     # Option to append question to aria label for screenreader accessibility.
     # Not added by default.
-    aria_label = ""
+    title_label = ""
+    aria_label = title_label.join("")
 
     def __init__(self, *args, **kwargs):
         """Extend the initialization of the form from RegistrarForm __init__"""
@@ -262,7 +263,7 @@ class BaseYesNoForm(RegistrarForm):
             initial=self.get_initial_value(),
             widget=forms.RadioSelect(
                 attrs={
-                    "aria-label": self.aria_label
+                    # "aria-label": self.title_label
                 }
             ),
             error_messages={

--- a/src/registrar/forms/utility/wizard_form_helper.py
+++ b/src/registrar/forms/utility/wizard_form_helper.py
@@ -239,11 +239,6 @@ class BaseYesNoForm(RegistrarForm):
     # Default form choice mapping. Default is suitable for most cases.
     form_choices = ((True, "Yes"), (False, "No"))
 
-    # Option to append question to aria label for screenreader accessibility.
-    # Not added by default.
-    title_label = ""
-    aria_label = title_label.join("")
-
     def __init__(self, *args, **kwargs):
         """Extend the initialization of the form from RegistrarForm __init__"""
         super().__init__(*args, **kwargs)
@@ -261,11 +256,7 @@ class BaseYesNoForm(RegistrarForm):
             coerce=lambda x: x.lower() == "true" if x is not None else None,
             choices=self.form_choices,
             initial=self.get_initial_value(),
-            widget=forms.RadioSelect(
-                attrs={
-                    # "aria-label": self.title_label
-                }
-            ),
+            widget=forms.RadioSelect(),
             error_messages={
                 "required": self.required_error_message,
             },

--- a/src/registrar/models/domain.py
+++ b/src/registrar/models/domain.py
@@ -1115,28 +1115,6 @@ class Domain(TimeStampedModel, DomainHelper):
         threshold_date = now + timedelta(days=60)
         return now <= self.expiration_date <= threshold_date
 
-    def get_default_expiring_date():
-        """Default to a date that's prior to our first deployment"""
-        return timezone.make_aware(datetime.now() + timedelta(days=30))
-
-    def get_default_current_date(self):
-        """Default to now()"""
-        return timezone.now(self)
-
-    def format_expiring_date(self, start_date):
-        return (
-            timezone.make_aware(datetime.strptime(start_date, "%Y-%m-%d"))
-            if start_date
-            else self.get_default_expiring_date()
-        )
-
-    def format_current_date(self, end_date):
-        return (
-            timezone.make_aware(datetime.strptime(end_date, "%Y-%m-%d"))
-            if end_date
-            else self.get_default_current_date()
-        )
-
     def state_display(self):
         """Return the display status of the domain."""
         if flag_is_active(self, "domain_renewal"):

--- a/src/registrar/models/domain.py
+++ b/src/registrar/models/domain.py
@@ -1117,7 +1117,6 @@ class Domain(TimeStampedModel, DomainHelper):
 
     def state_display(self, request=None):
         """Return the display status of the domain."""
-        print(flag_is_active(request, "domain_renewal"))
         if self.is_expired() and (self.state != self.State.UNKNOWN):
             return "Expired"
         elif flag_is_active(request, "domain_renewal") and self.is_expiring():

--- a/src/registrar/models/domain.py
+++ b/src/registrar/models/domain.py
@@ -1106,7 +1106,7 @@ class Domain(TimeStampedModel, DomainHelper):
         """
         Check if the domain's expiration date is within 60 days.
         Return False bc there's no expiration date meaning so not expiring
-        Return True if the expiration date is within 60 days
+        Return True if domain expiration exists and within 60 days
         """
         if self.expiration_date is None:
             return False

--- a/src/registrar/models/domain.py
+++ b/src/registrar/models/domain.py
@@ -1106,7 +1106,7 @@ class Domain(TimeStampedModel, DomainHelper):
         """
         Check if the domain's expiration date is within 60 days.
         Return False bc there's no expiration date meaning so not expiring
-        Return True if domain expiration exists and within 60 days
+        Return True if domain expiration date exists and within 60 days
         """
         if self.expiration_date is None:
             return False

--- a/src/registrar/models/domain.py
+++ b/src/registrar/models/domain.py
@@ -2,7 +2,7 @@ from itertools import zip_longest
 import logging
 import ipaddress
 import re
-from datetime import date, datetime, timedelta
+from datetime import date, timedelta
 from typing import Optional
 from django_fsm import FSMField, transition, TransitionNotAllowed  # type: ignore
 

--- a/src/registrar/models/domain.py
+++ b/src/registrar/models/domain.py
@@ -1117,13 +1117,10 @@ class Domain(TimeStampedModel, DomainHelper):
 
     def state_display(self):
         """Return the display status of the domain."""
-        if flag_is_active(self, "domain_renewal"):
-            if self.is_expiring() and (self.state == self.State.UNKNOWN):
-                return "Expiring soon"
-            if self.is_expired() and (self.state == self.State.UNKNOWN):
-                return "Expired"
         if self.is_expired() and (self.state != self.State.UNKNOWN):
             return "Expired"
+        elif flag_is_active(self, "domain_renewal") and self.is_expiring():
+            return "Expiring soon"
         elif self.state == self.State.UNKNOWN or self.state == self.State.DNS_NEEDED:
             return "DNS needed"
         return self.state.capitalize()

--- a/src/registrar/models/domain.py
+++ b/src/registrar/models/domain.py
@@ -1115,11 +1115,12 @@ class Domain(TimeStampedModel, DomainHelper):
         threshold_date = now + timedelta(days=60)
         return now <= self.expiration_date <= threshold_date
 
-    def state_display(self):
+    def state_display(self, request=None):
         """Return the display status of the domain."""
+        print(flag_is_active(request, "domain_renewal"))
         if self.is_expired() and (self.state != self.State.UNKNOWN):
             return "Expired"
-        elif flag_is_active(self, "domain_renewal") and self.is_expiring():
+        elif flag_is_active(request, "domain_renewal") and self.is_expiring():
             return "Expiring soon"
         elif self.state == self.State.UNKNOWN or self.state == self.State.DNS_NEEDED:
             return "DNS needed"

--- a/src/registrar/models/domain.py
+++ b/src/registrar/models/domain.py
@@ -1105,14 +1105,15 @@ class Domain(TimeStampedModel, DomainHelper):
     def is_expiring(self):
         """
         Check if the domain's expiration date is within 60 days.
-        Return False bc there's no expiration date meaning so not expiring
         Return True if domain expiration date exists and within 60 days
+        and otherwise False bc there's no expiration date meaning so not expiring
         """
         if self.expiration_date is None:
             return False
 
         now = timezone.now().date()
-        threshold_date = now + timedelta(days=60)
+        expiration_window=60
+        threshold_date = now + timedelta(days=expiration_window)
         return now <= self.expiration_date <= threshold_date
 
     def state_display(self, request=None):

--- a/src/registrar/models/user.py
+++ b/src/registrar/models/user.py
@@ -163,13 +163,13 @@ class User(AbstractUser):
         active_requests_count = self.domain_requests_created.filter(status__in=allowed_states).count()
         return active_requests_count
 
-    def get_expiring_domains(self, request):
-        """Return boolean if expiring/expired domains exists"""
+    def get_num_expiring_domains(self, request):
+        """Return number of expiring domains"""
         domain_ids = self.get_user_domain_ids(request)
         domains = Domain.objects.filter(id__in=domain_ids)
         how_many_expired_domains = 0
         for domain in domains:
-            if flag_is_active(request, "domain_renewal") and domain.is_expiring():
+            if domain.is_expiring():
                 how_many_expired_domains += 1
         return how_many_expired_domains
 

--- a/src/registrar/models/user.py
+++ b/src/registrar/models/user.py
@@ -165,8 +165,6 @@ class User(AbstractUser):
         active_requests_count = self.domain_requests_created.filter(status__in=allowed_states).count()
         return active_requests_count
 
-    # If this is causing performance problems,
-    # convert the is expiring check to sum or count filter condition
     def get_num_expiring_domains(self, request):
         """Return number of expiring domains"""
         domain_ids = self.get_user_domain_ids(request)
@@ -179,7 +177,6 @@ class User(AbstractUser):
             expiration_date__lte=threshold_date,
             expiration_date__gt=now
             ).count()
-        print(num_of_expiring_domains)
         return num_of_expiring_domains
 
 

--- a/src/registrar/models/user.py
+++ b/src/registrar/models/user.py
@@ -169,16 +169,15 @@ class User(AbstractUser):
         """Return number of expiring domains"""
         domain_ids = self.get_user_domain_ids(request)
         now = timezone.now().date()
-        expiration_window=60
+        expiration_window = 60
         threshold_date = now + timedelta(days=expiration_window)
-        num_of_expiring_domains= Domain.objects.filter(
+        num_of_expiring_domains = Domain.objects.filter(
             id__in=domain_ids,
             expiration_date__isnull=False,
             expiration_date__lte=threshold_date,
-            expiration_date__gt=now
-            ).count()
+            expiration_date__gt=now,
+        ).count()
         return num_of_expiring_domains
-
 
     def get_rejected_requests_count(self):
         """Return count of rejected requests"""

--- a/src/registrar/models/user.py
+++ b/src/registrar/models/user.py
@@ -270,7 +270,7 @@ class User(AbstractUser):
         return "Admin" in self.portfolio_role_summary(portfolio)
 
     def has_domain_renewal_flag(self):
-        return flag_is_active(self, "domain_renewal")
+        return flag_is_active_for_user(self, "domain_renewal")
 
     def get_first_portfolio(self):
         permission = self.portfolio_permissions.first()

--- a/src/registrar/models/user.py
+++ b/src/registrar/models/user.py
@@ -167,11 +167,11 @@ class User(AbstractUser):
         """Return number of expiring domains"""
         domain_ids = self.get_user_domain_ids(request)
         domains = Domain.objects.filter(id__in=domain_ids)
-        how_many_expired_domains = 0
+        how_many_expiring_domains = 0
         for domain in domains:
             if domain.is_expiring():
-                how_many_expired_domains += 1
-        return how_many_expired_domains
+                how_many_expiring_domains += 1
+        return how_many_expiring_domains
 
     def get_rejected_requests_count(self):
         """Return count of rejected requests"""

--- a/src/registrar/templates/django/forms/label.html
+++ b/src/registrar/templates/django/forms/label.html
@@ -1,4 +1,3 @@
-<!-- Exclude extraneous legend from radio elements -->
 <{{ label_tag }}
   class="{% if label_classes %} {{ label_classes }}{% endif %}{% if label_tag == 'legend' %} {{ legend_classes }}{% endif %}"
   {% if not field.use_fieldset %}for="{{ widget.attrs.id }}"{% endif %}

--- a/src/registrar/templates/django/forms/label.html
+++ b/src/registrar/templates/django/forms/label.html
@@ -2,8 +2,8 @@
   class="{% if label_classes %} {{ label_classes }}{% endif %}{% if label_tag == 'legend' %} {{ legend_classes }}{% endif %}"
   {% if not field.use_fieldset %}for="{{ widget.attrs.id }}"{% endif %}
 >
-  {% if legend_label %}
-    <h2 class="{{ legend_classes }}">{{ legend_label }} </h2>
+  {% if legend_heading %}
+    <h2 class="{{ legend_classes }}">{{ legend_heading }} </h2>
     {% if widget.attrs.id == 'id_additional_details-has_cisa_representative' %}
       <p>.gov is managed by the Cybersecurity and Infrastructure Security Agency. CISA has <a href="https://www.cisa.gov/about/regions" target="_blank">10 regions</a> that some organizations choose to work with. Regional representatives use titles like protective security advisors, cyber security advisors, or election security advisors.</p>
     {% endif %}

--- a/src/registrar/templates/django/forms/label.html
+++ b/src/registrar/templates/django/forms/label.html
@@ -4,6 +4,9 @@
 >
   {% if legend_label %}
     <h2>{{ legend_label }} </h2>
+    {% if widget.attrs.id == 'id_additional_details-has_cisa_representative' %}
+      <p>.gov is managed by the Cybersecurity and Infrastructure Security Agency. CISA has <a href="https://www.cisa.gov/about/regions" target="_blank">10 regions</a> that some organizations choose to work with. Regional representatives use titles like protective security advisors, cyber security advisors, or election security advisors.</p>
+    {% endif %}
   {% else %}
     {% if span_for_text %}
       <span>{{ field.label }}</span>

--- a/src/registrar/templates/django/forms/label.html
+++ b/src/registrar/templates/django/forms/label.html
@@ -3,7 +3,7 @@
   {% if not field.use_fieldset %}for="{{ widget.attrs.id }}"{% endif %}
 >
   {% if legend_label %}
-    <h2>{{ legend_label }} </h2>
+    <h2 class="{{ legend_classes }}">{{ legend_label }} </h2>
     {% if widget.attrs.id == 'id_additional_details-has_cisa_representative' %}
       <p>.gov is managed by the Cybersecurity and Infrastructure Security Agency. CISA has <a href="https://www.cisa.gov/about/regions" target="_blank">10 regions</a> that some organizations choose to work with. Regional representatives use titles like protective security advisors, cyber security advisors, or election security advisors.</p>
     {% endif %}

--- a/src/registrar/templates/django/forms/label.html
+++ b/src/registrar/templates/django/forms/label.html
@@ -1,19 +1,25 @@
-<{{ label_tag }}
-  class="{% if label_classes %} {{ label_classes }}{% endif %}{% if label_tag == 'legend' %} {{ legend_classes }}{% endif %}"
-  {% if not field.use_fieldset %}for="{{ widget.attrs.id }}"{% endif %}
->
-  {% if span_for_text %}
-    <span>{{ field.label }}</span>
-  {% else %}
-    {{ field.label }}
-  {% endif %}
+<!-- Exclude extraneous legend from radio elements -->
+{% if not type == "radio" and not label_tag == "legend" %}
+  <{{ label_tag }}
+    class="{% if label_classes %} {{ label_classes }}{% endif %}{% if label_tag == 'legend' %} {{ legend_classes }}{% endif %}"
+    {% if not field.use_fieldset %}for="{{ widget.attrs.id }}"{% endif %}
+  >
+{% endif %}
 
-  {% if widget.attrs.required %}
-  <!--Don't add asterisk to one-field forms -->
-    {% if field.label == "Is your organization an election office?" or field.label == "What .gov domain do you want?" or field.label == "I read and agree to the requirements for operating a .gov domain." or field.label == "Please explain why there are no other employees from your organization we can contact to help us assess your eligibility for a .gov domain." %}
+    {% if span_for_text %}
+      <span>{{ field.label }}</span>
     {% else %}
-      <abbr class="usa-hint usa-hint--required" title="required">*</abbr>
+      {{ field.label }}
     {% endif %}
-  {% endif %}
 
-</{{ label_tag }}>
+    {% if widget.attrs.required %}
+    <!--Don't add asterisk to one-field forms -->
+      {% if field.label == "Is your organization an election office?" or field.label == "What .gov domain do you want?" or field.label == "I read and agree to the requirements for operating a .gov domain." or field.label == "Please explain why there are no other employees from your organization we can contact to help us assess your eligibility for a .gov domain." %}
+      {% else %}
+        <abbr class="usa-hint usa-hint--required" title="required">*</abbr>
+      {% endif %}
+    {% endif %}
+
+{% if not type == "radio" and not label_tag == "legend" %}
+  </{{ label_tag }}>
+{% endif %}

--- a/src/registrar/templates/django/forms/label.html
+++ b/src/registrar/templates/django/forms/label.html
@@ -1,25 +1,24 @@
 <!-- Exclude extraneous legend from radio elements -->
-{% if not type == "radio" and not label_tag == "legend" %}
-  <{{ label_tag }}
-    class="{% if label_classes %} {{ label_classes }}{% endif %}{% if label_tag == 'legend' %} {{ legend_classes }}{% endif %}"
-    {% if not field.use_fieldset %}for="{{ widget.attrs.id }}"{% endif %}
-  >
-{% endif %}
-
+<{{ label_tag }}
+  class="{% if label_classes %} {{ label_classes }}{% endif %}{% if label_tag == 'legend' %} {{ legend_classes }}{% endif %}"
+  {% if not field.use_fieldset %}for="{{ widget.attrs.id }}"{% endif %}
+>
+  {% if legend_label %}
+    <h2>{{ legend_label }} </h2>
+  {% else %}
     {% if span_for_text %}
       <span>{{ field.label }}</span>
     {% else %}
       {{ field.label }}
     {% endif %}
+  {% endif %}
 
     {% if widget.attrs.required %}
     <!--Don't add asterisk to one-field forms -->
-      {% if field.label == "Is your organization an election office?" or field.label == "What .gov domain do you want?" or field.label == "I read and agree to the requirements for operating a .gov domain." or field.label == "Please explain why there are no other employees from your organization we can contact to help us assess your eligibility for a .gov domain." %}
+      {% if field.label == "Is your organization an election office?" or field.label == "What .gov domain do you want?" or field.label == "I read and agree to the requirements for operating a .gov domain." or field.label == "Please explain why there are no other employees from your organization we can contact to help us assess your eligibility for a .gov domain." or field.label == "Has other contacts" %}
       {% else %}
         <abbr class="usa-hint usa-hint--required" title="required">*</abbr>
       {% endif %}
     {% endif %}
 
-{% if not type == "radio" and not label_tag == "legend" %}
-  </{{ label_tag }}>
-{% endif %}
+</{{ label_tag }}>

--- a/src/registrar/templates/django/forms/label.html
+++ b/src/registrar/templates/django/forms/label.html
@@ -15,12 +15,15 @@
     {% endif %}
   {% endif %}
 
-    {% if widget.attrs.required %}
+  {% if widget.attrs.required %}
+
+    {% if field.widget_type == 'radioselect' %}
+      <em>Select one. <abbr class="usa-hint usa-hint--required" title="required">*</abbr></em>
     <!--Don't add asterisk to one-field forms -->
-      {% if field.label == "Is your organization an election office?" or field.label == "What .gov domain do you want?" or field.label == "I read and agree to the requirements for operating a .gov domain." or field.label == "Please explain why there are no other employees from your organization we can contact to help us assess your eligibility for a .gov domain." or field.label == "Has other contacts" %}
-      {% else %}
-        <abbr class="usa-hint usa-hint--required" title="required">*</abbr>
-      {% endif %}
+    {% elif field.label == "Is your organization an election office?" or field.label == "What .gov domain do you want?" or field.label == "I read and agree to the requirements for operating a .gov domain." or field.label == "Please explain why there are no other employees from your organization we can contact to help us assess your eligibility for a .gov domain." or field.label == "Has other contacts" %}
+    {% else %}
+      <abbr class="usa-hint usa-hint--required" title="required">*</abbr>
     {% endif %}
+  {% endif %}
 
 </{{ label_tag }}>

--- a/src/registrar/templates/domain_detail.html
+++ b/src/registrar/templates/domain_detail.html
@@ -36,9 +36,9 @@
           </span>
           <span class="text-primary-darker">
             {# UNKNOWN domains would not have an expiration date and thus would show 'Expired' #}
-            {% if domain.is_expired and domain.state != domain.State.UNKNOWN %}
+            {% if domain.is_expired and domain.state == domain.State.UNKNOWN %}
               Expired
-            {% elif domain.is_expiring and domain.state != domain.State.UNKNOWN %}
+            {% elif domain.is_expiring and domain.state == domain.State.UNKNOWN %}
               Expiring soon
             {% elif domain.state == domain.State.UNKNOWN or domain.state == domain.State.DNS_NEEDED %}
               DNS needed

--- a/src/registrar/templates/domain_detail.html
+++ b/src/registrar/templates/domain_detail.html
@@ -35,10 +35,11 @@
             Status:
           </span>
           <span class="text-primary-darker">
+
             {# UNKNOWN domains would not have an expiration date and thus would show 'Expired' #}
-            {% if domain.is_expired and domain.state == domain.State.UNKNOWN %}
+            {% if domain.is_expired and domain.state != domain.State.UNKNOWN %}
               Expired
-            {% elif has_domain_renewal_flag and domain.is_expiring and domain.state == domain.State.UNKNOWN %}
+            {% elif has_domain_renewal_flag and domain.is_expiring %}
               Expiring soon
             {% elif domain.state == domain.State.UNKNOWN or domain.state == domain.State.DNS_NEEDED %}
               DNS needed

--- a/src/registrar/templates/domain_detail.html
+++ b/src/registrar/templates/domain_detail.html
@@ -38,7 +38,7 @@
             {# UNKNOWN domains would not have an expiration date and thus would show 'Expired' #}
             {% if domain.is_expired and domain.state == domain.State.UNKNOWN %}
               Expired
-            {% elif domain.is_expiring and domain.state == domain.State.UNKNOWN %}
+            {% elif has_domain_renewal_flag and domain.is_expiring and domain.state == domain.State.UNKNOWN %}
               Expiring soon
             {% elif domain.state == domain.State.UNKNOWN or domain.state == domain.State.DNS_NEEDED %}
               DNS needed
@@ -48,9 +48,9 @@
           </span>
           {% if domain.get_state_help_text %}
             <div class="padding-top-1 text-primary-darker">
-              {% if domain.is_expiring and is_domain_manager %}
+              {% if has_domain_renewal_flag and domain.is_expiring and is_domain_manager %}
                 This domain will expire soon. <a href="/not-available-yet">Renew to maintain access.</a>
-              {% elif domain.is_expiring and is_portfolio_user %}
+              {% elif has_domain_renewal_flag and domain.is_expiring and is_portfolio_user %}
                 This domain will expire soon. Contact one of the listed domain managers to renew the domain.
               {% else %}
                 {{ domain.get_state_help_text }}

--- a/src/registrar/templates/domain_request_additional_details.html
+++ b/src/registrar/templates/domain_request_additional_details.html
@@ -15,9 +15,6 @@
         <p>.gov is managed by the Cybersecurity and Infrastructure Security Agency. CISA has <a href="https://www.cisa.gov/about/regions" target="_blank">10 regions</a> that some organizations choose to work with. Regional representatives use titles like protective security advisors, cyber security advisors, or election security advisors.</p>
       </legend> -->
 
-      <p id="testtest">.gov is managed by the Cybersecurity and Infrastructure Security Agency. CISA has <a href="https://www.cisa.gov/about/regions" target="_blank">10 regions</a> that some organizations choose to work with. Regional representatives use titles like protective security advisors, cyber security advisors, or election security advisors.</p>
-      <input aria-labelledby="testtest"></input>
-
       <!-- Toggle -->
       <em>Select one. <abbr class="usa-hint usa-hint--required" title="required">*</abbr></em>
       {% with add_class="usa-radio__input--tile" add_legend_label="Are you working with a CISA regional representative on your domain request?" %}

--- a/src/registrar/templates/domain_request_additional_details.html
+++ b/src/registrar/templates/domain_request_additional_details.html
@@ -10,14 +10,17 @@
 {% block form_fields %}
 
     <fieldset class="usa-fieldset margin-top-2">
-      <legend>
+      <!-- <legend>
         <h2>Are you working with a CISA regional representative on your domain request?</h2>
         <p>.gov is managed by the Cybersecurity and Infrastructure Security Agency. CISA has <a href="https://www.cisa.gov/about/regions" target="_blank">10 regions</a> that some organizations choose to work with. Regional representatives use titles like protective security advisors, cyber security advisors, or election security advisors.</p>
-      </legend>
+      </legend> -->
+
+      <p id="testtest">.gov is managed by the Cybersecurity and Infrastructure Security Agency. CISA has <a href="https://www.cisa.gov/about/regions" target="_blank">10 regions</a> that some organizations choose to work with. Regional representatives use titles like protective security advisors, cyber security advisors, or election security advisors.</p>
+      <input aria-labelledby="testtest"></input>
 
       <!-- Toggle -->
       <em>Select one. <abbr class="usa-hint usa-hint--required" title="required">*</abbr></em>
-      {% with add_class="usa-radio__input--tile" add_legend_class="usa-sr-only" %}
+      {% with add_class="usa-radio__input--tile" add_legend_label="Are you working with a CISA regional representative on your domain request?" %}
         {% input_with_errors forms.0.has_cisa_representative %}
       {% endwith %}
       {# forms.0 is a small yes/no form that toggles the visibility of "cisa representative" formset #} 

--- a/src/registrar/templates/domain_request_additional_details.html
+++ b/src/registrar/templates/domain_request_additional_details.html
@@ -10,11 +10,6 @@
 {% block form_fields %}
 
     <fieldset class="usa-fieldset margin-top-2">
-      <!-- <legend>
-        <h2>Are you working with a CISA regional representative on your domain request?</h2>
-        <p>.gov is managed by the Cybersecurity and Infrastructure Security Agency. CISA has <a href="https://www.cisa.gov/about/regions" target="_blank">10 regions</a> that some organizations choose to work with. Regional representatives use titles like protective security advisors, cyber security advisors, or election security advisors.</p>
-      </legend> -->
-
       <!-- Toggle -->
       {% with add_class="usa-radio__input--tile" add_legend_label="Are you working with a CISA regional representative on your domain request?" %}
         {% input_with_errors forms.0.has_cisa_representative %}
@@ -30,13 +25,8 @@
     </div>
 
     <fieldset class="usa-fieldset margin-top-2">
-        <legend>
-            <h2>Is there anything else you’d like us to know about your domain request?</h2> 
-        </legend>
-  
         <!-- Toggle -->
-        <em>Select one. <abbr class="usa-hint usa-hint--required" title="required">*</abbr></em>
-        {% with add_class="usa-radio__input--tile" add_legend_class="usa-sr-only" %}
+        {% with add_class="usa-radio__input--tile" add_legend_label="Is there anything else you’d like us to know about your domain request?" %}
           {% input_with_errors forms.2.has_anything_else_text %}
         {% endwith %}
         {# forms.2 is a small yes/no form that toggles the visibility of "cisa representative" formset #} 

--- a/src/registrar/templates/domain_request_additional_details.html
+++ b/src/registrar/templates/domain_request_additional_details.html
@@ -16,7 +16,6 @@
       </legend> -->
 
       <!-- Toggle -->
-      <em>Select one. <abbr class="usa-hint usa-hint--required" title="required">*</abbr></em>
       {% with add_class="usa-radio__input--tile" add_legend_label="Are you working with a CISA regional representative on your domain request?" %}
         {% input_with_errors forms.0.has_cisa_representative %}
       {% endwith %}

--- a/src/registrar/templates/domain_request_additional_details.html
+++ b/src/registrar/templates/domain_request_additional_details.html
@@ -34,7 +34,7 @@
   
     <div class="margin-top-3" id="anything-else">
         <p>Provide details below. <abbr class="usa-hint usa-hint--required" title="required">*</abbr></p>
-        {% with attr_maxlength=2000 add_label_class="usa-sr-only" %}
+        {% with attr_maxlength=2000 add_label_class="usa-sr-only" add_legend_class="usa-sr-only" add_legend_label="Is there anything else you’d like us to know about your domain request?" add_aria_label="Provide details below. You can enter up to 2000 characters" %}
             {% input_with_errors forms.3.anything_else %}
         {% endwith %}
         {# forms.3 is a form for inputting the e-mail of a cisa representative #}

--- a/src/registrar/templates/domain_request_additional_details.html
+++ b/src/registrar/templates/domain_request_additional_details.html
@@ -9,9 +9,9 @@
 
 {% block form_fields %}
 
-    <fieldset class="usa-fieldset margin-top-2">
+    <fieldset class="usa-fieldset">
       <!-- Toggle -->
-      {% with add_class="usa-radio__input--tile" add_legend_label="Are you working with a CISA regional representative on your domain request?" %}
+      {% with add_class="usa-radio__input--tile" add_legend_heading="Are you working with a CISA regional representative on your domain request?" %}
         {% input_with_errors forms.0.has_cisa_representative %}
       {% endwith %}
       {# forms.0 is a small yes/no form that toggles the visibility of "cisa representative" formset #} 
@@ -26,7 +26,7 @@
 
     <fieldset class="usa-fieldset margin-top-2">
         <!-- Toggle -->
-        {% with add_class="usa-radio__input--tile" add_legend_label="Is there anything else you’d like us to know about your domain request?" %}
+        {% with add_class="usa-radio__input--tile" add_legend_heading="Is there anything else you’d like us to know about your domain request?" %}
           {% input_with_errors forms.2.has_anything_else_text %}
         {% endwith %}
         {# forms.2 is a small yes/no form that toggles the visibility of "cisa representative" formset #} 
@@ -34,7 +34,7 @@
   
     <div class="margin-top-3" id="anything-else">
         <p>Provide details below. <abbr class="usa-hint usa-hint--required" title="required">*</abbr></p>
-        {% with attr_maxlength=2000 add_label_class="usa-sr-only" add_legend_class="usa-sr-only" add_legend_label="Is there anything else you’d like us to know about your domain request?" add_aria_label="Provide details below. You can enter up to 2000 characters" %}
+        {% with attr_maxlength=2000 add_label_class="usa-sr-only" add_legend_class="usa-sr-only" add_legend_heading="Is there anything else you’d like us to know about your domain request?" add_aria_label="Provide details below. You can enter up to 2000 characters" %}
             {% input_with_errors forms.3.anything_else %}
         {% endwith %}
         {# forms.3 is a form for inputting the e-mail of a cisa representative #}

--- a/src/registrar/templates/domain_request_additional_details.html
+++ b/src/registrar/templates/domain_request_additional_details.html
@@ -11,7 +11,7 @@
 
     <fieldset class="usa-fieldset">
       <!-- Toggle -->
-      {% with add_class="usa-radio__input--tile" add_legend_heading="Are you working with a CISA regional representative on your domain request?" %}
+      {% with add_class="usa-radio__input--tile" add_legend_class="margin-top-0" add_legend_heading="Are you working with a CISA regional representative on your domain request?" %}
         {% input_with_errors forms.0.has_cisa_representative %}
       {% endwith %}
       {# forms.0 is a small yes/no form that toggles the visibility of "cisa representative" formset #} 

--- a/src/registrar/templates/domain_request_other_contacts.html
+++ b/src/registrar/templates/domain_request_other_contacts.html
@@ -18,7 +18,7 @@
 
 {% block form_fields %}
     <div class="margin-top-2">
-      {% with add_class="usa-radio__input--tile" add_legend_label="Are there other employees who can help verify your request?" %}
+      {% with add_class="usa-radio__input--tile" add_legend_heading="Are there other employees who can help verify your request?" %}
         {% input_with_errors forms.0.has_other_contacts %}
       {% endwith %}
       {# forms.0 is a small yes/no form that toggles the visibility of "other contact" formset #}

--- a/src/registrar/templates/domain_request_other_contacts.html
+++ b/src/registrar/templates/domain_request_other_contacts.html
@@ -9,7 +9,7 @@
       <li><strong>We typically don’t reach out to these employees</strong>, but if contact is necessary, our practice is to coordinate with you first.</li>
     </ul>
   </p>
-
+  {% include "includes/required_fields.html" %}
 {% endblock %}
 
 {% block form_required_fields_help_text %}
@@ -25,7 +25,6 @@
     </div>
 
     <div id="other-employees" class="other-contacts-form">
-        {% include "includes/required_fields.html" %}
         {{ forms.1.management_form }}
         {# forms.1 is a formset and this iterates over its forms #}
         {% for form in forms.1.forms %}

--- a/src/registrar/templates/domain_request_other_contacts.html
+++ b/src/registrar/templates/domain_request_other_contacts.html
@@ -17,17 +17,12 @@
 {% endblock %}
 
 {% block form_fields %}
-    <fieldset class="usa-fieldset margin-top-2">
-      <legend>
-        <h2>Are there other employees who can help verify your request?</h2>
-      </legend>
-
-      {% with add_class="usa-radio__input--tile" add_legend_class="usa-sr-only" %}
+    <div class="margin-top-2">
+      {% with add_class="usa-radio__input--tile" add_legend_label="Are there other employees who can help verify your request?" %}
         {% input_with_errors forms.0.has_other_contacts %}
       {% endwith %}
       {# forms.0 is a small yes/no form that toggles the visibility of "other contact" formset #}
-
-    </fieldset>
+    </div>
 
     <div id="other-employees" class="other-contacts-form">
         {% include "includes/required_fields.html" %}

--- a/src/registrar/templates/includes/domain_requests_table.html
+++ b/src/registrar/templates/includes/domain_requests_table.html
@@ -54,11 +54,14 @@
         {% if portfolio %}
         <div class="section-outlined__utility-button mobile-lg:padding-right-105 {% if portfolio %} mobile:grid-col-12 desktop:grid-col-6 desktop:padding-left-3{% endif %}" id="export-csv">
             <section aria-label="Domain Requests report component" class="margin-top-205">
-              <a href="{% url 'export_data_type_requests' %}" class="usa-button usa-button--unstyled usa-button--with-icon usa-button--justify-right" role="button">
+                <!----------------------------------------------------------------------
+                   This link is commented out because we intend to add it back in later.
+                ------------------------------------------------------------------------->
+              <!-- <a href="{% url 'export_data_type_requests' %}" class="usa-button usa-button--unstyled usa-button--with-icon usa-button--justify-right" role="button">
                   <svg class="usa-icon usa-icon--large" aria-hidden="true" focusable="false" role="img" width="24" height="24">
                       <use xlink:href="{% static 'img/sprite.svg' %}#file_download"></use>
                   </svg>Export as CSV
-              </a>
+              </a> -->
           </section>
         </div>
         {% endif %}

--- a/src/registrar/templates/includes/domains_table.html
+++ b/src/registrar/templates/includes/domains_table.html
@@ -8,7 +8,7 @@
 
 <span id="get_domains_json_url" class="display-none">{{url}}</span>
 
-<!-- Banner for when it's org model (org manager can view, domain manager can edit)  -->
+<!-- Org model banner (org manager can view, domain manager can edit)  -->
 {% if has_domain_renewal_flag and num_expiring_domains > 0 and has_any_domains_portfolio_permission %}
 <section class="usa-site-alert usa-site-alert--info margin-bottom-2 {% if add_class %}{{ add_class }}{% endif %}" aria-label="Site alert">
   <div class="usa-alert">
@@ -74,7 +74,7 @@
     {% endif %}
   </div>
 
-  <!-- Banner for when it's not org model bc placement in the table -->
+  <!-- Non org model banner -->
   {% if has_domain_renewal_flag and num_expiring_domains > 0 and not portfolio %}
   <section class="usa-site-alert usa-site-alert--info margin-bottom-2 {% if add_class %}{{ add_class }}{% endif %}" aria-label="Site alert">
     <div class="usa-alert">

--- a/src/registrar/templates/includes/domains_table.html
+++ b/src/registrar/templates/includes/domains_table.html
@@ -9,12 +9,12 @@
 <span id="get_domains_json_url" class="display-none">{{url}}</span>
 
 <!-- Banner for when it's org model (org manager can view, domain manager can edit)  -->
-{% if has_domain_renewal_flag and has_expiring_domains > 0 and has_any_domains_portfolio_permission %}
+{% if has_domain_renewal_flag and num_expiring_domains > 0 and has_any_domains_portfolio_permission %}
 <section class="usa-site-alert usa-site-alert--info margin-bottom-2 {% if add_class %}{{ add_class }}{% endif %}" aria-label="Site alert">
   <div class="usa-alert">
     <div class="usa-alert__body {% if is_widescreen_mode %}usa-alert__body--widescreen{% endif %}">
       <p class="usa-alert__text maxw-none">
-        {% if has_expiring_domains == 1%}  
+        {% if num_expiring_domains == 1%}  
         One domain will expire soon. Go to "Manage" to renew the domain. <a href="#" id="link-expiring-domains" class="usa-link">Show expiring domain.</a>
         {% else%}
         Multiple domains will expire soon. Go to "Manage" to renew the domains. <a href="#" id="link-expiring-domains" class="usa-link">Show expiring domains.</a>
@@ -75,12 +75,12 @@
   </div>
 
   <!-- Banner for when it's not org model bc placement in the table -->
-  {% if has_domain_renewal_flag and has_expiring_domains > 0 and not portfolio %}
+  {% if has_domain_renewal_flag and num_expiring_domains > 0 and not portfolio %}
   <section class="usa-site-alert usa-site-alert--info margin-bottom-2 {% if add_class %}{{ add_class }}{% endif %}" aria-label="Site alert">
     <div class="usa-alert">
       <div class="usa-alert__body {% if is_widescreen_mode %}usa-alert__body--widescreen{% endif %}">
         <p class="usa-alert__text maxw-none">
-          {% if has_expiring_domains == 1%}  
+          {% if num_expiring_domains == 1%}  
           One domain will expire soon. Go to "Manage" to renew the domain. <a href="#" id="link-expiring-domains" class="usa-link">Show expiring domain.</a>
           {% else%}
           Multiple domains will expire soon. Go to "Manage" to renew the domains. <a href="#" id="link-expiring-domains" class="usa-link">Show expiring domains.</a>
@@ -172,7 +172,7 @@
               >Deleted</label
             >
           </div>
-          {% if has_domain_renewal_flag and has_expiring_domains > 0 %}
+          {% if has_domain_renewal_flag and num_expiring_domains > 0 %}
           <div class="usa-checkbox">
             <input
               class="usa-checkbox__input"

--- a/src/registrar/templates/includes/header_basic.html
+++ b/src/registrar/templates/includes/header_basic.html
@@ -1,7 +1,7 @@
 {% load static %}
 
 <header class="usa-header usa-header--basic">
-  <div class="usa-nav-container {% if is_widescreen_mode %} usa-nav-container--widescreen {% endif %}">
+  <div class="usa-nav-container {% if is_widescreen_mode %} ugit sa-nav-container--widescreen {% endif %}">
     <div class="usa-navbar">
         {% include "includes/gov_extended_logo.html" with logo_clickable=logo_clickable %}
       <button type="button" class="usa-menu-btn">Menu</button>

--- a/src/registrar/templates/includes/header_basic.html
+++ b/src/registrar/templates/includes/header_basic.html
@@ -1,7 +1,7 @@
 {% load static %}
 
 <header class="usa-header usa-header--basic">
-  <div class="usa-nav-container {% if is_widescreen_mode %} ugit sa-nav-container--widescreen {% endif %}">
+  <div class="usa-nav-container {% if is_widescreen_mode %} usa-nav-container--widescreen {% endif %}">
     <div class="usa-navbar">
         {% include "includes/gov_extended_logo.html" with logo_clickable=logo_clickable %}
       <button type="button" class="usa-menu-btn">Menu</button>

--- a/src/registrar/templates/includes/input_with_errors.html
+++ b/src/registrar/templates/includes/input_with_errors.html
@@ -71,7 +71,11 @@ error messages, if necessary.
   {% endif %}
 
   {# this is the input field, itself #}
-  {% include widget.template_name %}
+  {% with aria_label=aria_label %}
+      {% include widget.template_name %}
+  {% endwith %}
+  
+  
 
   {% if append_gov %}
       <span class="padding-top-05 padding-left-2px">.gov </span>

--- a/src/registrar/templates/portfolio_domain_request_additional_details.html
+++ b/src/registrar/templates/portfolio_domain_request_additional_details.html
@@ -6,9 +6,15 @@
 {% endblock %}
 
 {% block form_fields %}
+
+    <fieldset class="usa-fieldset">          
+            <h2 class="margin-top-0 margin-bottom-0">Is there anything else you’d like us to know about your domain request?</h2> 
+        </legend>
+    </fieldset>
+
     <div id="anything-else">
         <p><em>This question is optional.</em></p>
-        {% with attr_maxlength=2000 add_legend_heading="Is there anything else you’d like us to know about your domain request?" add_aria_label="This question is optional." %}
+        {% with attr_maxlength=2000 add_label_class="usa-sr-only" %}
             {% input_with_errors forms.0.anything_else %}
         {% endwith %}
     </div>

--- a/src/registrar/templates/portfolio_domain_request_additional_details.html
+++ b/src/registrar/templates/portfolio_domain_request_additional_details.html
@@ -6,15 +6,9 @@
 {% endblock %}
 
 {% block form_fields %}
-
-    <fieldset class="usa-fieldset">          
-            <h2 class="margin-top-0 margin-bottom-0">Is there anything else you’d like us to know about your domain request?</h2> 
-        </legend>
-    </fieldset>
-
     <div id="anything-else">
         <p><em>This question is optional.</em></p>
-        {% with attr_maxlength=2000 add_label_class="usa-sr-only" %}
+        {% with attr_maxlength=2000 add_legend_heading="Is there anything else you’d like us to know about your domain request?" add_aria_label="This question is optional." %}
             {% input_with_errors forms.0.anything_else %}
         {% endwith %}
     </div>

--- a/src/registrar/templates/portfolio_domains.html
+++ b/src/registrar/templates/portfolio_domains.html
@@ -15,6 +15,6 @@
 
 <div id="main-content">
     <h1 id="domains-header">Domains</h1>
-    {% include "includes/domains_table.html" with portfolio=portfolio user_domain_count=user_domain_count has_expiring_domains=has_expiring_domains%}
+    {% include "includes/domains_table.html" with portfolio=portfolio user_domain_count=user_domain_count num_expiring_domains=num_expiring_domains%}
 </div>
 {% endblock %}

--- a/src/registrar/templatetags/field_helpers.py
+++ b/src/registrar/templatetags/field_helpers.py
@@ -123,9 +123,6 @@ def input_with_errors(context, field=None):  # noqa: C901
     else:
         context["label_tag"] = "label"
 
-    if field.use_fieldset:
-        label_classes.append("usa-legend")
-
     if field.widget_type == "checkbox":
         label_classes.append("usa-checkbox__label")
     elif not field.use_fieldset:

--- a/src/registrar/templatetags/field_helpers.py
+++ b/src/registrar/templatetags/field_helpers.py
@@ -184,6 +184,5 @@ def input_with_errors(context, field=None):  # noqa: C901
     )  # -> {"widget": {"name": ...}}
 
     context["widget"] = widget["widget"]
-    print("context: ", context)
 
     return context

--- a/src/registrar/templatetags/field_helpers.py
+++ b/src/registrar/templatetags/field_helpers.py
@@ -57,6 +57,7 @@ def input_with_errors(context, field=None):  # noqa: C901
     legend_classes = []
     group_classes = []
     aria_labels = []
+    legend_headings = []
     sublabel_text = []
 
     # this will be converted to an attribute string
@@ -91,6 +92,8 @@ def input_with_errors(context, field=None):  # noqa: C901
             label_classes.append(value)
         elif key == "add_legend_class":
             legend_classes.append(value)
+        elif key == "add_legend_heading":
+            legend_headings.append(value)
 
         elif key == "add_group_class":
             group_classes.append(value)
@@ -152,6 +155,9 @@ def input_with_errors(context, field=None):  # noqa: C901
 
     if legend_classes:
         context["legend_classes"] = " ".join(legend_classes)
+
+    if legend_headings:
+        context["legend_heading"] = " ".join(legend_headings)
 
     if group_classes:
         context["group_classes"] = " ".join(group_classes)

--- a/src/registrar/templatetags/field_helpers.py
+++ b/src/registrar/templatetags/field_helpers.py
@@ -178,5 +178,6 @@ def input_with_errors(context, field=None):  # noqa: C901
     )  # -> {"widget": {"name": ...}}
 
     context["widget"] = widget["widget"]
+    print("context: ", context)
 
     return context

--- a/src/registrar/tests/test_admin_request.py
+++ b/src/registrar/tests/test_admin_request.py
@@ -1731,9 +1731,6 @@ class TestDomainRequestAdmin(MockEppLib):
                 "cisa_representative_first_name",
                 "cisa_representative_last_name",
                 "cisa_representative_email",
-                "requested_suborganization",
-                "suborganization_city",
-                "suborganization_state_territory",
             ]
             self.assertEqual(readonly_fields, expected_fields)
 
@@ -1967,6 +1964,7 @@ class TestDomainRequestAdmin(MockEppLib):
             # Grab the current list of table filters
             readonly_fields = self.admin.get_list_filter(request)
             expected_fields = (
+                DomainRequestAdmin.PortfolioFilter,
                 DomainRequestAdmin.StatusListFilter,
                 DomainRequestAdmin.GenericOrgFilter,
                 DomainRequestAdmin.FederalTypeFilter,

--- a/src/registrar/tests/test_views_domain.py
+++ b/src/registrar/tests/test_views_domain.py
@@ -2494,7 +2494,7 @@ class TestDomainRenewal(TestWithUser):
         except ValueError:
             pass
         super().tearDown()
-    
+
     # Remove test_without_domain_renewal_flag when domain renewal is released as a feature
     @less_console_noise_decorator
     @override_flag("domain_renewal", active=False)

--- a/src/registrar/tests/test_views_domain.py
+++ b/src/registrar/tests/test_views_domain.py
@@ -2494,7 +2494,8 @@ class TestDomainRenewal(TestWithUser):
         except ValueError:
             pass
         super().tearDown()
-
+    
+    # Remove test_without_domain_renewal_flag when domain renewal is released as a feature
     @less_console_noise_decorator
     @override_flag("domain_renewal", active=False)
     def test_without_domain_renewal_flag(self):
@@ -2505,7 +2506,7 @@ class TestDomainRenewal(TestWithUser):
 
     @less_console_noise_decorator
     @override_flag("domain_renewal", active=True)
-    def test_with_domain_renewal_flag_single_domain(self):
+    def test_domain_renewal_flag_single_domain(self):
         self.client.force_login(self.user)
         domains_page = self.client.get("/")
         self.assertContains(domains_page, "One domain will expire soon")
@@ -2541,7 +2542,7 @@ class TestDomainRenewal(TestWithUser):
     @less_console_noise_decorator
     @override_flag("domain_renewal", active=True)
     @override_flag("organization_feature", active=True)
-    def test_with_domain_renewal_flag_single_domain_w_org_feature_flag(self):
+    def test_domain_renewal_flag_single_domain_w_org_feature_flag(self):
         self.client.force_login(self.user)
         domains_page = self.client.get("/")
         self.assertContains(domains_page, "One domain will expire soon")

--- a/src/registrar/tests/test_views_domain.py
+++ b/src/registrar/tests/test_views_domain.py
@@ -239,6 +239,10 @@ class TestDomainDetail(TestDomainOverview):
         self.assertContains(detail_page, "igorville.gov")
         self.assertContains(detail_page, "Status")
 
+    # Uncomment skip for ticket #3211
+    @skip(
+        "Currently the logic ind domain_detail.html is incorrect for IRL state, but is set for local/sandbox testing purposes"
+    )
     def test_unknown_domain_does_not_show_as_expired_on_detail_page(self):
         """An UNKNOWN domain should not exist on the detail_page anymore.
         It shows as 'DNS needed'"""
@@ -457,6 +461,10 @@ class TestDomainDetailDomainRenewal(TestDomainOverview):
     def custom_is_expiring(self):
         return True
 
+    # Uncomment skip for ticket #3211
+    @skip(
+        "Currently the logic ind domain_detail.html is incorrect for IRL state, but is set for local/sandbox testing purposes"
+    )
     @override_flag("domain_renewal", active=True)
     def test_expiring_domain_on_detail_page_as_domain_manager(self):
         self.client.force_login(self.user)

--- a/src/registrar/tests/test_views_domain.py
+++ b/src/registrar/tests/test_views_domain.py
@@ -423,27 +423,28 @@ class TestDomainDetail(TestDomainOverview):
         self.assertContains(detail_page, "Invited domain managers")
         self.assertContains(detail_page, "invited@example.com")
 
+
 class TestDomainDetailDomainRenewal(TestDomainOverview):
     def setUp(self):
         super().setUp()
 
         self.user = get_user_model().objects.create(
-                first_name="User",
-                last_name="Test",
-                email="bogus@example.gov",
-                phone="8003111234",
-                title="test title",
-                username="usertest"
-            )
-        
+            first_name="User",
+            last_name="Test",
+            email="bogus@example.gov",
+            phone="8003111234",
+            title="test title",
+            username="usertest",
+        )
+
         self.expiringdomain, _ = Domain.objects.get_or_create(
-                name="expiringdomain.gov",
-            )
-        
+            name="expiringdomain.gov",
+        )
+
         UserDomainRole.objects.get_or_create(
-                user=self.user, domain=self.expiringdomain, role=UserDomainRole.Roles.MANAGER
-            )
-        
+            user=self.user, domain=self.expiringdomain, role=UserDomainRole.Roles.MANAGER
+        )
+
         DomainInformation.objects.get_or_create(creator=self.user, domain=self.expiringdomain)
 
         self.portfolio, _ = Portfolio.objects.get_or_create(organization_name="Test org", creator=self.user)
@@ -452,17 +453,19 @@ class TestDomainDetailDomainRenewal(TestDomainOverview):
 
     def custom_is_expired(self):
         return False
-    
+
     def custom_is_expiring(self):
         return True
 
     @override_flag("domain_renewal", active=True)
     def test_expiring_domain_on_detail_page_as_domain_manager(self):
         self.client.force_login(self.user)
-        with patch.object(Domain, "is_expiring", self.custom_is_expiring), patch.object(Domain, "is_expired", self.custom_is_expired):
+        with patch.object(Domain, "is_expiring", self.custom_is_expiring), patch.object(
+            Domain, "is_expired", self.custom_is_expired
+        ):
             self.assertEquals(self.expiringdomain.state, Domain.State.UNKNOWN)
             detail_page = self.client.get(
-                    reverse("domain", kwargs={"pk": self.expiringdomain.id}),
+                reverse("domain", kwargs={"pk": self.expiringdomain.id}),
             )
             self.assertContains(detail_page, "Expiring soon")
 
@@ -470,44 +473,62 @@ class TestDomainDetailDomainRenewal(TestDomainOverview):
 
             self.assertNotContains(detail_page, "DNS needed")
             self.assertNotContains(detail_page, "Expired")
-    
+
     @override_flag("domain_renewal", active=True)
     @override_flag("organization_feature", active=True)
     def test_expiring_domain_on_detail_page_in_org_model_as_a_non_domain_manager(self):
         portfolio, _ = Portfolio.objects.get_or_create(organization_name="Test org", creator=self.user)
         non_dom_manage_user = get_user_model().objects.create(
-                first_name="Non Domain",
-                last_name="Manager",
-                email="verybogus@example.gov",
-                phone="8003111234",
-                title="test title again",
-                username="nondomain"
-            )
-        
+            first_name="Non Domain",
+            last_name="Manager",
+            email="verybogus@example.gov",
+            phone="8003111234",
+            title="test title again",
+            username="nondomain",
+        )
+
         non_dom_manage_user.save()
         UserPortfolioPermission.objects.get_or_create(
-            user=non_dom_manage_user, portfolio=portfolio, roles=[UserPortfolioRoleChoices.ORGANIZATION_MEMBER]
+            user=non_dom_manage_user,
+            portfolio=portfolio,
+            roles=[UserPortfolioRoleChoices.ORGANIZATION_MEMBER],
+            additional_permissions=[
+                UserPortfolioPermissionChoices.VIEW_ALL_DOMAINS,
+            ],
         )
-        expiringdomain2,_= Domain.objects.get_or_create(name="bogusdomain2.gov")
-        DomainInformation.objects.get_or_create(creator=non_dom_manage_user, domain=expiringdomain2, portfolio=self.portfolio)
+        expiringdomain2, _ = Domain.objects.get_or_create(name="bogusdomain2.gov")
+        DomainInformation.objects.get_or_create(
+            creator=non_dom_manage_user, domain=expiringdomain2, portfolio=self.portfolio
+        )
+        non_dom_manage_user.refresh_from_db()
         self.client.force_login(non_dom_manage_user)
-        with patch.object(Domain, "is_expiring", self.custom_is_expiring), patch.object(Domain, "is_expired", self.custom_is_expired):
+        with patch.object(Domain, "is_expiring", self.custom_is_expiring), patch.object(
+            Domain, "is_expired", self.custom_is_expired
+        ):
             detail_page = self.client.get(
-                        reverse("domain", kwargs={"pk": expiringdomain2.id}),
+                reverse("domain", kwargs={"pk": expiringdomain2.id}),
             )
-            self.assertContains(detail_page,"Contact one of the listed domain managers to renew the domain.")
-    
+            self.assertContains(detail_page, "Contact one of the listed domain managers to renew the domain.")
+
     @override_flag("domain_renewal", active=True)
     @override_flag("organization_feature", active=True)
     def test_expiring_domain_on_detail_page_in_org_model_as_a_domain_manager(self):
-        expiringdomain3,_ = Domain.objects.get_or_create(name="bogusdomain2.gov")
-        DomainInformation.objects.get_or_create(creator=self.user, domain=expiringdomain3, portfolio=self.portfolio)
+        portfolio, _ = Portfolio.objects.get_or_create(organization_name="Test org2", creator=self.user)
+
+        expiringdomain3, _ = Domain.objects.get_or_create(name="bogusdomain3.gov")
+
+        UserDomainRole.objects.get_or_create(user=self.user, domain=expiringdomain3, role=UserDomainRole.Roles.MANAGER)
+        DomainInformation.objects.get_or_create(creator=self.user, domain=expiringdomain3, portfolio=portfolio)
+        self.user.refresh_from_db()
         self.client.force_login(self.user)
-        with patch.object(Domain, "is_expiring", self.custom_is_expiring), patch.object(Domain, "is_expired", self.custom_is_expired):
+        with patch.object(Domain, "is_expiring", self.custom_is_expiring), patch.object(
+            Domain, "is_expired", self.custom_is_expired
+        ):
             detail_page = self.client.get(
-                        reverse("domain", kwargs={"pk": expiringdomain3.id}),
+                reverse("domain", kwargs={"pk": expiringdomain3.id}),
             )
-            self.assertContains(detail_page,"Renew to maintain access")
+            self.assertContains(detail_page, "Renew to maintain access")
+
 
 class TestDomainManagers(TestDomainOverview):
     @classmethod
@@ -2523,7 +2544,6 @@ class TestDomainRenewal(TestWithUser):
     def test_with_domain_renewal_flag_single_domain_w_org_feature_flag(self):
         self.client.force_login(self.user)
         domains_page = self.client.get("/")
-        print("domains_page is", domains_page)
         self.assertContains(domains_page, "One domain will expire soon")
         self.assertContains(domains_page, "Expiring soon")
 
@@ -2555,43 +2575,3 @@ class TestDomainRenewal(TestWithUser):
         domains_page = self.client.get("/")
         self.assertNotContains(domains_page, "Expiring soon")
         self.assertNotContains(domains_page, "will expire soon")
-
-
-# class TestDomainDetailExpiring(WebTest):
-#     @override_flag("domain_renewal", active=True)
-#     def test_expiring_domain_on_detail_page_as_domain_manager(self):
-#         with less_console_noise():
-#             PublicContact.objects.all().delete()
-#             Domain.objects.all().delete()
-#             UserDomainRole.objects.all().delete()
-
-#             self.expiringdomain, _ = Domain.objects.get_or_create(name="expiringdomain.gov")
-#             self.expiringdomain.expiration_date = timezone.make_aware(
-#                 datetime.combine(datetime.today() + timedelta(days=30), datetime.min.time())
-#             )
-#             self.domain_information, _ = DomainInformation.objects.get_or_create(
-#                 creator=self.user, domain=self.expiringdomain
-#             )
-#             self.role, _ = UserDomainRole.objects.get_or_create(
-#                 user=self.user, domain=self.expiringdomain, role=UserDomainRole.Roles.MANAGER
-#             )
-#             self.expiringdomain.save()
-#             self.domain_information.save()
-#             self.role.save()
-
-#             # Where is May 25, 2023 coming from?
-#             print("self.expiringdomain.expiration_date is #1 ", Domain.objects.get(id=self.expiringdomain.id).expiration_date)
-
-#             expiringdomain = Domain.objects.get(name="expiringdomain.gov")
-#             print("self.expiringdomain.expiration_date is #2 ", Domain.objects.get(id=expiringdomain.id).expiration_date)
-#             self.assertEquals(expiringdomain.state, Domain.State.UNKNOWN)
-#             print("self.expiringdomain.expiration_date is #3 ", Domain.objects.get(id=expiringdomain.id).expiration_date)
-#             detail_page = self.app.get(f"/domain/{expiringdomain.id}")
-#             print("self.expiringdomain.expiration_date is #4 ", Domain.objects.get(id=expiringdomain.id).expiration_date)
-
-#             self.assertContains(detail_page, "Expiring soon")
-
-#             self.assertContains(detail_page, "Renew to maintain access")
-
-#             self.assertNotContains(detail_page, "DNS needed")
-#             self.assertNotContains(detail_page, "Expired")

--- a/src/registrar/tests/test_views_domain.py
+++ b/src/registrar/tests/test_views_domain.py
@@ -241,7 +241,8 @@ class TestDomainDetail(TestDomainOverview):
 
     # Uncomment skip for ticket #3211
     @skip(
-        "Currently the logic ind domain_detail.html is incorrect for IRL state, but is set for local/sandbox testing purposes"
+        "Currently the logic ind domain_detail.html is incorrect for IRL state"
+        "but is set for local/sandbox testing purposes"
     )
     def test_unknown_domain_does_not_show_as_expired_on_detail_page(self):
         """An UNKNOWN domain should not exist on the detail_page anymore.
@@ -463,7 +464,8 @@ class TestDomainDetailDomainRenewal(TestDomainOverview):
 
     # Uncomment skip for ticket #3211
     @skip(
-        "Currently the logic ind domain_detail.html is incorrect for IRL state, but is set for local/sandbox testing purposes"
+        "Currently the logic ind domain_detail.html is incorrect for IRL state,"
+        "but is set for local/sandbox testing purposes"
     )
     @override_flag("domain_renewal", active=True)
     def test_expiring_domain_on_detail_page_as_domain_manager(self):

--- a/src/registrar/views/index.py
+++ b/src/registrar/views/index.py
@@ -8,6 +8,6 @@ def index(request):
     if request and request.user and request.user.is_authenticated:
         # This controls the creation of a new domain request in the wizard
         context["user_domain_count"] = request.user.get_user_domain_ids(request).count()
-        context["has_expiring_domains"] = request.user.get_expiring_domains(request)
+        context["has_expiring_domains"] = request.user.get_num_expiring_domains(request)
 
     return render(request, "home.html", context)

--- a/src/registrar/views/index.py
+++ b/src/registrar/views/index.py
@@ -8,6 +8,6 @@ def index(request):
     if request and request.user and request.user.is_authenticated:
         # This controls the creation of a new domain request in the wizard
         context["user_domain_count"] = request.user.get_user_domain_ids(request).count()
-        context["has_expiring_domains"] = request.user.get_num_expiring_domains(request)
+        context["num_expiring_domains"] = request.user.get_num_expiring_domains(request)
 
     return render(request, "home.html", context)

--- a/src/registrar/views/portfolios.py
+++ b/src/registrar/views/portfolios.py
@@ -39,7 +39,7 @@ class PortfolioDomainsView(PortfolioDomainsPermissionView, View):
         context = {}
         if self.request and self.request.user and self.request.user.is_authenticated:
             context["user_domain_count"] = self.request.user.get_user_domain_ids(request).count()
-            context["has_expiring_domains"] = request.user.get_num_expiring_domains(request)
+            context["num_expiring_domains"] = request.user.get_num_expiring_domains(request)
         return render(request, "portfolio_domains.html", context)
 
 

--- a/src/registrar/views/portfolios.py
+++ b/src/registrar/views/portfolios.py
@@ -39,7 +39,7 @@ class PortfolioDomainsView(PortfolioDomainsPermissionView, View):
         context = {}
         if self.request and self.request.user and self.request.user.is_authenticated:
             context["user_domain_count"] = self.request.user.get_user_domain_ids(request).count()
-            context["has_expiring_domains"] = request.user.get_expiring_domains(request)
+            context["has_expiring_domains"] = request.user.get_num_expiring_domains(request)
         return render(request, "portfolio_domains.html", context)
 
 

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -13,7 +13,7 @@ defusedxml==0.7.1; python_version >= '2.7' and python_version not in '3.0, 3.1, 
 diff-match-patch==20230430; python_version >= '3.7'
 dj-database-url==2.2.0
 dj-email-url==1.0.6
-django==4.2.10; python_version >= '3.8'
+django==4.2.17; python_version >= '3.8'
 django-admin-multiple-choice-list-filter==0.1.1
 django-allow-cidr==0.7.1
 django-auditlog==3.0.0; python_version >= '3.8'


### PR DESCRIPTION
## Ticket

Resolves #3142

## Changes

- [ ] Domain renewal feature flag (see /admin)

**For domain_renewal flag off:**
- [ ] Should see no banner 
- [ ] Should see no "Expiring soon" status in the Status column

**If domain_renewal flag on:**
- [ ] New filter by addition in the table (only for non org model)
- [ ] Call to action banner if the user has 1 domain
* [Non org model Figma](https://www.figma.com/design/xFtGLHVrhp0lvwh0gYWnbx/.gov-registar?node-id=13711-6974&t=o0MwvRJxfvNC39cs-4) - the text is correct even though this is on org model
* [Org model Figma](https://www.figma.com/design/xFtGLHVrhp0lvwh0gYWnbx/.gov-registar?node-id=13711-6974&t=o0MwvRJxfvNC39cs-4)

- [ ] Call to action banner if user has multiple domains 
* [Non org model Figma](https://www.figma.com/design/xFtGLHVrhp0lvwh0gYWnbx/.gov-registar?node-id=13847-10354&t=o0MwvRJxfvNC39cs-4)
* [Org model Figma](https://www.figma.com/design/xFtGLHVrhp0lvwh0gYWnbx/.gov-registar?node-id=13847-10354&t=o0MwvRJxfvNC39cs-4) -  the text is correct even though this is on non org model

- [ ] Call to action banner's link is clickable and click to update the status to "Expiring soon" 
* [Non org model Figma](https://www.figma.com/design/xFtGLHVrhp0lvwh0gYWnbx/.gov-registar?node-id=13847-10354&t=o0MwvRJxfvNC39cs-4)
* [Org model Figma](https://www.figma.com/design/xFtGLHVrhp0lvwh0gYWnbx/.gov-registar?node-id=13798-8959&t=o0MwvRJxfvNC39cs-4)

- [ ] Domain Overview 
- [Non org model Figma](https://www.figma.com/design/xFtGLHVrhp0lvwh0gYWnbx/.gov-registar?node-id=13644-21561&t=cDHdNNQgVOHLqyHQ-4)
- [Org model Figma for if domain manager](https://www.figma.com/design/xFtGLHVrhp0lvwh0gYWnbx/.gov-registar?node-id=13697-3506&t=cDHdNNQgVOHLqyHQ-4)
- [Org model Figma if not domain manager](https://www.figma.com/design/xFtGLHVrhp0lvwh0gYWnbx/.gov-registar?node-id=13711-7954&t=cDHdNNQgVOHLqyHQ-4)

- [ ] In the Status column, if a domain is in "Expiring soon" state, make sure there is a red "!" by it
- [ ] If user does not have expiring domains, make sure call to action banner does not exist


## Context for reviewers

For domains pending expiration (≤60 days from its expiration date), highlight the need to take action in the Domains dashboard.

## Setup

1. Test without the `domain_renewal` flag on first
2. Test with only the `domain_renewal` flag on
3. Test with the `domain_renewal` flag on + now `organization_feature` flag on 


#### Note: If you don't have domains that are expiring within 60 days
1. Go to the `sr/registrar/fixtures/fixtures/fixtures_domains.py`, and then to `_generate_fake_expiration_date`
2. Update the expiration date to a number between 1 and 60.
3. Run the following to load the fixtures:
`docker-compose exec app bash`
`./manage.py load`
*must have domains in review for this to work* 


## Code Review Verification Steps

### As the original developer, I have

#### Satisfied acceptance criteria and met development standards

- [ ] Met the acceptance criteria, or will meet them in a subsequent PR
- [ ] Created/modified automated tests
- [ ] Update documentation in READMEs and/or onboarding guide

#### Ensured code standards are met (Original Developer)
<!-- Mark "- N/A" and check at the end of each check that is not applicable to your PR -->
- [ ] If any updated dependencies on Pipfile, also update dependencies in requirements.txt.
- [ ] Interactions with external systems are wrapped in try/except
- [ ] Error handling exists for unusual or missing values

#### Validated user-facing changes (if applicable)

- [ ] Tag @dotgov-designers in this PR's Reviewers for design review. If code is not user-facing, delete design reviewer checklist
- [ ] Verify new pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Checked keyboard navigability
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)

### As a code reviewer, I have

#### Reviewed, tested, and left feedback about the changes

- [ ] Pulled this branch locally and tested it
- [ ] Verified code meets all checks above. Address any checks that are not satisfied
- [ ] Reviewed this code and left comments. Indicate if comments must be addressed before code is merged
- [ ] Checked that all code is adequately covered by tests
- [ ] Verify migrations are valid and do not conflict with existing migrations

#### Validated user-facing changes as a developer
**Note:** Multiple code reviewers can share the checklists above, a second reviewer should not make a duplicate checklist. All checks should be checked before approving, even those labeled N/A. 

- [ ] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Checked keyboard navigability
- [ ] Meets all designs and user flows provided by design/product
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)
- [ ] (Rarely needed) Tested as both an analyst and applicant user

### As a designer reviewer, I have

#### Verified that the changes match the design intention

- [ ] Checked that the design translated visually
- [ ] Checked behavior. Comment any found issues or broken flows.
- [ ] Checked different states (empty, one, some, error)
- [ ] Checked for landmarks, page heading structure, and links

#### Validated user-facing changes as a designer

- [ ] Checked keyboard navigability
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)
- [ ] Tested with multiple browsers (check off which ones were used)
  - [ ] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari
- [ ] (Rarely needed) Tested as both an analyst and applicant user

### References
- [Code review best practices](../docs/dev-practices/code_review.md)

## Screenshots

<!-- If this PR makes visible interface changes, an image of the finished interface can help reviewers
and casual observers understand the context of the changes.
A before image is optional and can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow.
You may want to use [GIPHY Capture](https://giphy.com/apps/giphycapture) for this! 📸

_Please frame images to show useful context but also highlight the affected regions._
--->
