### PR TITLE
#2853: Member domains submit - [RJM]

### DIFF
--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -6921,16 +6921,6 @@
         "validate-npm-package-license": "^3.0.1"
       }
     },
-    "node_modules/normalize-package-data/node_modules/semver": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
     "node_modules/normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -7306,39 +7296,6 @@
       "engines": {
         "node": ">= 12"
       }
-    },
-    "node_modules/pa11y/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/pa11y/node_modules/semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-      "license": "ISC",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/pa11y/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "license": "ISC"
     },
     "node_modules/parse-filepath": {
       "version": "1.0.2",
@@ -8888,13 +8845,15 @@
       }
     },
     "node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/semver-greatest-satisfied-range": {

--- a/src/registrar/assets/src/js/getgov/helpers.js
+++ b/src/registrar/assets/src/js/getgov/helpers.js
@@ -1,9 +1,17 @@
 export function hideElement(element) {
-    element.classList.add('display-none');
+    if (element) {
+        element.classList.add('display-none');
+    } else {
+        throw new Error('hideElement expected a passed DOM element as an argument, but none was provided.');
+    }
 };
   
 export function showElement(element) {
-    element.classList.remove('display-none');
+    if (element) {
+        element.classList.remove('display-none');
+    } else {
+        throw new Error('showElement expected a passed DOM element as an argument, but none was provided.');
+    }
 };
 
 /**

--- a/src/registrar/assets/src/js/getgov/table-base.js
+++ b/src/registrar/assets/src/js/getgov/table-base.js
@@ -143,7 +143,7 @@ export class BaseTable {
     this.statusCheckboxes = document.querySelectorAll(`.${this.sectionSelector} input[name="filter-status"]`);
     this.statusIndicator = document.getElementById(`${this.sectionSelector}__filter-indicator`);
     this.statusToggle = document.getElementById(`${this.sectionSelector}__usa-button--filter`);
-    this.noTableWrapper = document.getElementById(`${this.sectionSelector}__no-data`);
+    this.noDataTableWrapper = document.getElementById(`${this.sectionSelector}__no-data`);
     this.noSearchResultsWrapper = document.getElementById(`${this.sectionSelector}__no-search-results`);
     this.portfolioElement = document.getElementById('portfolio-js-value');
     this.portfolioValue = this.portfolioElement ? this.portfolioElement.getAttribute('data-portfolio') : null;
@@ -451,7 +451,7 @@ export class BaseTable {
         }
 
         // handle the display of proper messaging in the event that no members exist in the list or search returns no results
-        this.updateDisplay(data, this.tableWrapper, this.noTableWrapper, this.noSearchResultsWrapper, this.currentSearchTerm);
+        this.updateDisplay(data, this.tableWrapper, this.noDataTableWrapper, this.noSearchResultsWrapper, this.currentSearchTerm);
         // identify the DOM element where the list of results will be inserted into the DOM
         const tbody = this.tableWrapper.querySelector('tbody');
         tbody.innerHTML = '';

--- a/src/registrar/assets/src/js/getgov/table-edit-member-domains.js
+++ b/src/registrar/assets/src/js/getgov/table-edit-member-domains.js
@@ -22,7 +22,7 @@ export class EditMemberDomainsTable extends BaseTable {
     this.editModeContainer =  document.getElementById('domain-assignments-edit-view');
     this.readonlyModeContainer = document.getElementById('domain-assignments-readonly-view');
     this.reviewButton = document.getElementById('review-domain-assignments');
-    this.backButton = document.querySelectorAll('.back-to-edit-domain-assignments');
+    this.backButton = document.getElementById('back-to-edit-domain-assignments');
     this.saveButton = document.getElementById('save-domain-assignments');
     this.initializeDomainAssignments();
     this.initCancelEditDomainAssignmentButton();
@@ -326,17 +326,15 @@ export class EditMemberDomainsTable extends BaseTable {
         this.showReadonlyMode();
       });
     } else {
-      console.warn('Missing DOM element. Expected element with id review-domain-assignments')
+      console.warn('Missing DOM element. Expected element with id review-domain-assignments');
     }
 
-    if (this.backButton.length == 2) {
-      this.backButton.forEach(backbutton => {
-        backbutton.addEventListener('click', () => {
-          this.showEditMode();
-        });
+    if (this.backButton) {
+      this.backButton.addEventListener('click', () => {
+        this.showEditMode();
       });
     } else {
-      console.warn('Missing one or more DOM element. Expected 2 elements with class back-to-edit-domain-assignments')
+      console.warn('Missing DOM element. Expected element with id back-to-edit-domain-assignments');
     }
 
     if (this.saveButton) {
@@ -344,7 +342,7 @@ export class EditMemberDomainsTable extends BaseTable {
         this.submitChanges();
       });
     } else {
-      console.warn('Missing DOM element. Expected element with id save-domain-assignments')
+      console.warn('Missing DOM element. Expected element with id save-domain-assignments');
     }
   }
 }

--- a/src/registrar/assets/src/js/getgov/table-edit-member-domains.js
+++ b/src/registrar/assets/src/js/getgov/table-edit-member-domains.js
@@ -1,5 +1,6 @@
 
 import { BaseTable } from './table-base.js';
+import { hideElement, showElement } from './helpers.js';
 
 /**
  * EditMemberDomainsTable is used for PortfolioMember and PortfolioInvitedMember
@@ -18,8 +19,14 @@ export class EditMemberDomainsTable extends BaseTable {
     this.initialDomainAssignmentsOnlyMember = []; // list of initially assigned domains which are readonly
     this.addedDomains = []; // list of domains added to member
     this.removedDomains = []; // list of domains removed from member
+    this.editModeContainer =  document.getElementById('domain-assignments-edit-view');
+    this.readonlyModeContainer = document.getElementById('domain-assignments-readonly-view');
+    this.reviewButton = document.getElementById('review-domain-assignments');
+    this.backButton = document.querySelectorAll('.back-to-edit-domain-assignments');
+    this.saveButton = document.getElementById('save-domain-assignments');
     this.initializeDomainAssignments();
     this.initCancelEditDomainAssignmentButton();
+    this.initEventListeners();
   }
   getBaseUrl() {
     return document.getElementById("get_member_domains_json_url");
@@ -55,6 +62,14 @@ export class EditMemberDomainsTable extends BaseTable {
   getSearchParams(page, sortBy, order, searchTerm, status, portfolio) {
     let searchParams = super.getSearchParams(page, sortBy, order, searchTerm, status, portfolio);
     // Add checkedDomains to searchParams
+    let checkedDomains = this.getCheckedDomains();
+    // Append updated checkedDomain IDs to searchParams
+    if (checkedDomains.length > 0) {
+        searchParams.append("checkedDomainIds", checkedDomains.join(","));
+    }
+    return searchParams;
+  }
+  getCheckedDomains() {
     // Clone the initial domains to avoid mutating them
     let checkedDomains = [...this.initialDomainAssignments];
     // Add IDs from addedDomains that are not already in checkedDomains
@@ -70,11 +85,7 @@ export class EditMemberDomainsTable extends BaseTable {
             checkedDomains.splice(index, 1);
         }
     });
-    // Append updated checkedDomain IDs to searchParams
-    if (checkedDomains.length > 0) {
-        searchParams.append("checkedDomainIds", checkedDomains.join(","));
-    }
-    return searchParams;
+    return checkedDomains
   }
   addRow(dataObject, tbody, customTableOptions) {
     const domain = dataObject;
@@ -217,7 +228,125 @@ export class EditMemberDomainsTable extends BaseTable {
       }
     });
   }
+
+  updateReadonlyDisplay() {
+    let totalAssignedDomains = this.getCheckedDomains().length;
+
+    // Create unassigned domains list
+    const unassignedDomainsList = document.createElement('ul');
+    unassignedDomainsList.classList.add('usa-list', 'usa-list--unstyled');
+    this.removedDomains.forEach(removedDomain => {
+        const removedDomainListItem = document.createElement('li');
+        removedDomainListItem.textContent = removedDomain.name; // Use textContent for security
+        unassignedDomainsList.appendChild(removedDomainListItem);
+    });
+
+    // Create assigned domains list
+    const assignedDomainsList = document.createElement('ul');
+    assignedDomainsList.classList.add('usa-list', 'usa-list--unstyled');
+    this.addedDomains.forEach(addedDomain => {
+        const addedDomainListItem = document.createElement('li');
+        addedDomainListItem.textContent = addedDomain.name; // Use textContent for security
+        assignedDomainsList.appendChild(addedDomainListItem);
+    });
+
+    // Get the summary container
+    const domainAssignmentSummary = document.getElementById('domain-assignments-summary');
     
+    // Clear existing content
+    domainAssignmentSummary.innerHTML = '';
+
+    // Append unassigned domains section
+    if (this.removedDomains.length) {
+      const unassignedHeader = document.createElement('h3');
+      unassignedHeader.classList.add('header--body', 'text-primary', 'margin-bottom-1');
+      unassignedHeader.textContent = 'Unassigned domains';
+      domainAssignmentSummary.appendChild(unassignedHeader);
+      domainAssignmentSummary.appendChild(unassignedDomainsList);
+    }
+
+    // Append assigned domains section
+    if (this.addedDomains.length) {
+      const assignedHeader = document.createElement('h3');
+      assignedHeader.classList.add('header--body', 'text-primary', 'margin-bottom-1');
+      assignedHeader.textContent = 'Assigned domains';
+      domainAssignmentSummary.appendChild(assignedHeader);
+      domainAssignmentSummary.appendChild(assignedDomainsList);
+    }
+
+    // Append total assigned domains section
+    const totalHeader = document.createElement('h3');
+    totalHeader.classList.add('header--body', 'text-primary', 'margin-bottom-1');
+    totalHeader.textContent = 'Total assigned domains';
+    domainAssignmentSummary.appendChild(totalHeader);
+    const totalCount = document.createElement('p');
+    totalCount.classList.add('margin-y-0');
+    totalCount.textContent = totalAssignedDomains;
+    domainAssignmentSummary.appendChild(totalCount);
+  }
+
+  showReadonlyMode() {
+    this.updateReadonlyDisplay();
+    hideElement(this.editModeContainer);
+    showElement(this.readonlyModeContainer);
+  }
+
+  showEditMode() {
+    hideElement(this.readonlyModeContainer);
+    showElement(this.editModeContainer);
+  }
+
+  submitChanges() {
+    let memberDomainsEditForm = document.getElementById("member-domains-edit-form");
+    if (memberDomainsEditForm) {
+      // Serialize data to send
+      const addedDomainIds = this.addedDomains.map(domain => domain.id);
+      const addedDomainsInput = document.createElement('input');
+      addedDomainsInput.type = 'hidden';
+      addedDomainsInput.name = 'added_domains'; // Backend will use this key to retrieve data
+      addedDomainsInput.value = JSON.stringify(addedDomainIds); // Stringify the array
+      
+      const removedDomainsIds = this.removedDomains.map(domain => domain.id);
+      const removedDomainsInput = document.createElement('input');
+      removedDomainsInput.type = 'hidden';
+      removedDomainsInput.name = 'removed_domains'; // Backend will use this key to retrieve data
+      removedDomainsInput.value = JSON.stringify(removedDomainsIds); // Stringify the array
+
+      // Append input to the form
+      memberDomainsEditForm.appendChild(addedDomainsInput);
+      memberDomainsEditForm.appendChild(removedDomainsInput);
+
+      memberDomainsEditForm.submit();
+    }
+  }
+
+  initEventListeners() {
+    if (this.reviewButton) {
+      this.reviewButton.addEventListener('click', () => {
+        this.showReadonlyMode();
+      });
+    } else {
+      console.warn('Missing DOM element. Expected element with id review-domain-assignments')
+    }
+
+    if (this.backButton.length == 2) {
+      this.backButton.forEach(backbutton => {
+        backbutton.addEventListener('click', () => {
+          this.showEditMode();
+        });
+      });
+    } else {
+      console.warn('Missing one or more DOM element. Expected 2 elements with class back-to-edit-domain-assignments')
+    }
+
+    if (this.saveButton) {
+      this.saveButton.addEventListener('click', () => {
+        this.submitChanges();
+      });
+    } else {
+      console.warn('Missing DOM element. Expected element with id save-domain-assignments')
+    }
+  }
 }
 
 export function initEditMemberDomainsTable() {

--- a/src/registrar/assets/src/js/getgov/table-member-domains.js
+++ b/src/registrar/assets/src/js/getgov/table-member-domains.js
@@ -1,4 +1,5 @@
 
+import { showElement, hideElement } from './helpers.js';
 import { BaseTable } from './table-base.js';
 
 export class MemberDomainsTable extends BaseTable {
@@ -24,7 +25,28 @@ export class MemberDomainsTable extends BaseTable {
     `;
     tbody.appendChild(row);
   }
-
+  updateDisplay = (data, dataWrapper, noDataWrapper, noSearchResultsWrapper) => {
+    const { unfiltered_total, total } = data;
+    const searchSection = document.getElementById('edit-member-domains__search');
+    if (!searchSection) console.warn('MemberDomainsTable updateDisplay expected an element with id edit-member-domains__search but none was found');
+    if (unfiltered_total) {
+      showElement(searchSection);
+      if (total) {
+        showElement(dataWrapper);
+        hideElement(noSearchResultsWrapper);
+        hideElement(noDataWrapper);
+      } else {
+        hideElement(dataWrapper);
+        showElement(noSearchResultsWrapper);
+        hideElement(noDataWrapper);
+      }
+    } else {
+      hideElement(searchSection);
+      hideElement(dataWrapper);
+      hideElement(noSearchResultsWrapper);
+      showElement(noDataWrapper);
+    }
+  };
 }
   
 export function initMemberDomainsTable() {

--- a/src/registrar/assets/src/sass/_theme/_register-form.scss
+++ b/src/registrar/assets/src/sass/_theme/_register-form.scss
@@ -12,7 +12,7 @@
   margin-top: units(1);
 }
 
-// register-form-review-header is used on the summary page and
+// header--body is used on the summary page and
 // should not be styled like the register form headers
 .register-form-step h3 {
   color: color('primary-dark');
@@ -25,15 +25,6 @@
   }
 }
 
-.register-form-review-header {
-  color: color('primary-dark');
-  margin-top: units(2);
-  margin-bottom: 0;
-  font-weight: font-weight('semibold');
-  // The units mixin can only get us close, so it's between 
-  // hardcoding the value and using  in markup
-  font-size: 16.96px;
-}
 
 .register-form-step h4 {
   margin-bottom: 0;

--- a/src/registrar/assets/src/sass/_theme/_typography.scss
+++ b/src/registrar/assets/src/sass/_theme/_typography.scss
@@ -23,6 +23,14 @@ h2 {
   color: color('primary-darker');
 }
 
+.header--body {
+  margin-top: units(2);
+  font-weight: font-weight('semibold');
+  // The units mixin can only get us close, so it's between 
+  // hardcoding the value and using  in markup
+  font-size: 16.96px;
+}
+
 .h4--sm-05 {
   font-size: size('body', 'sm');
   font-weight: normal;

--- a/src/registrar/fixtures/fixtures_user_portfolio_permissions.py
+++ b/src/registrar/fixtures/fixtures_user_portfolio_permissions.py
@@ -60,7 +60,10 @@ class UserPortfolioPermissionFixture:
                             user=user,
                             portfolio=portfolio,
                             roles=[UserPortfolioRoleChoices.ORGANIZATION_ADMIN],
-                            additional_permissions=[UserPortfolioPermissionChoices.EDIT_MEMBERS],
+                            additional_permissions=[
+                                UserPortfolioPermissionChoices.EDIT_MEMBERS,
+                                UserPortfolioPermissionChoices.EDIT_REQUESTS,
+                            ],
                         )
                         user_portfolio_permissions_to_create.append(user_portfolio_permission)
                     else:

--- a/src/registrar/templates/includes/domain_request_status_manage.html
+++ b/src/registrar/templates/includes/domain_request_status_manage.html
@@ -213,7 +213,7 @@
 
         {# We always show this field even if None #}
         {% if DomainRequest %}
-            <h3 class="register-form-review-header">CISA Regional Representative</h3>
+            <h3 class="header--body text-primary-dark margin-bottom-0">CISA Regional Representative</h3>
             <ul class="usa-list usa-list--unstyled margin-top-0">
                 {% if DomainRequest.cisa_representative_first_name %}
                 {{ DomainRequest.get_formatted_cisa_rep_name }}
@@ -221,7 +221,7 @@
                 No
                 {% endif %}
             </ul>
-            <h3 class="register-form-review-header">Anything else</h3>
+            <h3 class="header--body text-primary-dark margin-bottom-0">Anything else</h3>
             <ul class="usa-list usa-list--unstyled margin-top-0">
                 {% if DomainRequest.anything_else %}
                 {{DomainRequest.anything_else}}

--- a/src/registrar/templates/includes/member_domains_table.html
+++ b/src/registrar/templates/includes/member_domains_table.html
@@ -34,7 +34,7 @@
       {% endif %}
     </h2>
 
-  <div class="section-outlined__header margin-bottom-3 grid-row">
+  <div class="section-outlined__header margin-bottom-3 grid-row" id="edit-member-domains__search">
       <!-- ---------- SEARCH ---------- -->
       <div class="section-outlined__search mobile:grid-col-12 desktop:grid-col-9">
         <section aria-label="Member domains search component" class="margin-top-2">

--- a/src/registrar/templates/includes/portfolio_request_review_steps.html
+++ b/src/registrar/templates/includes/portfolio_request_review_steps.html
@@ -46,7 +46,7 @@
         {% endwith %}
 
         {% if domain_request.alternative_domains.all %}
-            <h3 class="register-form-review-header">Alternative domains</h3>
+            <h3 class="header--body text-primary-dark margin-bottom-0">Alternative domains</h3>
             <ul class="usa-list usa-list--unstyled margin-top-0">
             {% for site in domain_request.alternative_domains.all %}
                 <li>{{ site.website }}</li>

--- a/src/registrar/templates/includes/request_review_steps.html
+++ b/src/registrar/templates/includes/request_review_steps.html
@@ -88,7 +88,7 @@
         {% endwith %}
 
         {% if domain_request.alternative_domains.all %}
-            <h3 class="register-form-review-header">Alternative domains</h3>
+            <h3 class="header--body text-primary-dark margin-bottom-0">Alternative domains</h3>
             <ul class="usa-list usa-list--unstyled margin-top-0">
             {% for site in domain_request.alternative_domains.all %}
                 <li>{{ site.website }}</li>
@@ -132,7 +132,7 @@
         {% with title=form_titles|get_item:step %}
             {% if domain_request.has_additional_details %}
                 {% include "includes/summary_item.html" with title="Additional Details" value=" " heading_level=heading_level editable=is_editable edit_link=domain_request_url %}
-                <h3 class="register-form-review-header">CISA Regional Representative</h3>
+                <h3 class="header--body text-primary-dark margin-bottom-0">CISA Regional Representative</h3>
                 <ul class="usa-list usa-list--unstyled margin-top-0">
                     {% if domain_request.cisa_representative_first_name %}
                         <li>{{domain_request.cisa_representative_first_name}} {{domain_request.cisa_representative_last_name}}</li>
@@ -144,7 +144,7 @@
                     {% endif %}
                 </ul>
 
-            <h3 class="register-form-review-header">Anything else</h3>
+            <h3 class="header--body text-primary-dark margin-bottom-0">Anything else</h3>
             <ul class="usa-list usa-list--unstyled margin-top-0">
                 {% if domain_request.anything_else %}
                     {{domain_request.anything_else}}

--- a/src/registrar/templates/includes/request_status_manage.html
+++ b/src/registrar/templates/includes/request_status_manage.html
@@ -216,7 +216,7 @@
 
             {# We always show this field even if None #}
             {% if DomainRequest %}
-                <h3 class="register-form-review-header">CISA Regional Representative</h3>
+                <h3 class="header--body text-primary-dark margin-bottom-0">CISA Regional Representative</h3>
                 <ul class="usa-list usa-list--unstyled margin-top-0">
                     {% if DomainRequest.cisa_representative_first_name %}
                     {{ DomainRequest.get_formatted_cisa_rep_name }}
@@ -224,7 +224,7 @@
                     No
                     {% endif %}
                 </ul>
-                <h3 class="register-form-review-header">Anything else</h3>
+                <h3 class="header--body text-primary-dark margin-bottom-0">Anything else</h3>
                 <ul class="usa-list usa-list--unstyled margin-top-0">
                     {% if DomainRequest.anything_else %}
                     {{DomainRequest.anything_else}}

--- a/src/registrar/templates/includes/summary_item.html
+++ b/src/registrar/templates/includes/summary_item.html
@@ -22,7 +22,7 @@
       </h3>
     {% endif %}
       {% if sub_header_text %}
-        <h4 class="register-form-review-header">{{ sub_header_text }}</h4>
+        <h4 class="header--body text-primary-dark margin-bottom-0">{{ sub_header_text }}</h4>
       {% endif %}
       {% if permissions %}
         {% include "includes/member_permissions.html" with permissions=value %}

--- a/src/registrar/templates/portfolio_member_domains_edit.html
+++ b/src/registrar/templates/portfolio_member_domains_edit.html
@@ -17,53 +17,108 @@
         {% url 'invitedmember-domains' pk=portfolio_invitation.id as url3 %}
     {% endif %}
     <nav class="usa-breadcrumb padding-top-0 margin-bottom-3" aria-label="Portfolio member breadcrumb">
-    <ol class="usa-breadcrumb__list">
-        <li class="usa-breadcrumb__list-item">
-        <a href="{{ url }}" class="usa-breadcrumb__link"><span>Members</span></a>
-        </li>
-        <li class="usa-breadcrumb__list-item">
-            <a href="{{ url2 }}" class="usa-breadcrumb__link"><span>Manage member</span></a>
-        </li>
-        <li class="usa-breadcrumb__list-item">
-            <a href="{{ url3 }}" class="usa-breadcrumb__link"><span>Domain assignments</span></a>
-        </li>
-        <li class="usa-breadcrumb__list-item usa-current edit-domain-assignments-breadcrumb" aria-current="page">
-            <span>Edit domain assignments</span>
-        </li>
-    </ol>
+        <ol class="usa-breadcrumb__list">
+            <li class="usa-breadcrumb__list-item">
+            <a href="{{ url }}" class="usa-breadcrumb__link"><span>Members</span></a>
+            </li>
+            <li class="usa-breadcrumb__list-item">
+                <a href="{{ url2 }}" class="usa-breadcrumb__link"><span>Manage member</span></a>
+            </li>
+            <li class="usa-breadcrumb__list-item">
+                <a href="{{ url3 }}" class="usa-breadcrumb__link"><span>Domain assignments</span></a>
+            </li>
+            <li class="usa-breadcrumb__list-item usa-current domain-assignments-edit-breadcrumb" aria-current="page">
+                <span>Edit domain assignments</span>
+            </li>
+        </ol>
     </nav>
 
-    <h1 class="margin-bottom-3">Edit domain assignments</h1>
+    <section id="domain-assignments-edit-view">
+        <h1 class="margin-bottom-3">Edit domain assignments</h1>
 
-    <p class="margin-bottom-0">
-        A domain manager can be assigned to any domain across the organization. Domain managers can change domain information, adjust DNS settings, and invite or assign other domain managers to their assigned domains.
-    </p>
-    <p>
-        When you save this form the member will get an email to notify them of any changes.
-    </p>
+        <p class="margin-bottom-0">
+            A domain manager can be assigned to any domain across the organization. Domain managers can change domain information, adjust DNS settings, and invite or assign other domain managers to their assigned domains.
+        </p>
+        <p>
+            When you save this form the member will get an email to notify them of any changes.
+        </p>
 
-    {% include "includes/member_domains_edit_table.html" %}
+        {% include "includes/member_domains_edit_table.html" %}
 
-    <ul class="usa-button-group">
-        <li class="usa-button-group__item">
-            <button
-                id="cancel-edit-domain-assignments"
-                type="button"
-                class="usa-button usa-button--outline"
-            >
-                Cancel
-            </button>
+        <ul class="usa-button-group">
+            <li class="usa-button-group__item">
+                <button
+                    id="cancel-edit-domain-assignments"
+                    type="button"
+                    class="usa-button usa-button--outline"
+                >
+                    Cancel
+                </button>
 
-        </li>      
-        <li class="usa-button-group__item">
-            <button
-                type="button"
-                class="usa-button"
-            >
-                Review
-            </button>
-        </li>
-    </ul>
+            </li>      
+            <li class="usa-button-group__item">
+                <button
+                    id="review-domain-assignments"
+                    type="button"
+                    class="usa-button"
+                >
+                    Review
+                </button>
+            </li>
+        </ul>
+    </section>
+
+    <section id="domain-assignments-readonly-view" class="display-none">
+        <h1 class="margin-bottom-3">Review domain assignments</h1>
+
+        <h2 class="text-primary-dark">Would you like to continue with the following domain assignment changes for 
+            {% if member %}
+                {{ member.email }}
+            {% else %}
+                {{ portfolio_invitation.email }}
+            {% endif %}
+        </h2>
+
+        <p>When you save this form the member will get an email to notify them of any changes.</p>
+
+        <div id="domain-assignments-summary" class="margin-bottom-2">
+             <!-- AJAX will populate this summary -->
+              <h3 class="header--body text-primary margin-bottom-1">Unassigned domains</h3>
+              <ul class="usa-list usa-list--unstyled">
+                <li>item1</li>
+                <li>item2</li>
+              </ul>
+
+              <h3 class="header--body text-primary-dark margin-bottom-0">Assigned domains</h3>
+              <ul class="usa-list usa-list--unstyled">
+                <li>item1</li>
+                <li>item2</li>
+              </ul>
+        </div>
+
+        <ul class="usa-button-group">
+            <li class="usa-button-group__item">
+                <button
+                    type="button"
+                    class="usa-button usa-button--outline back-to-edit-domain-assignments"
+                >
+                    Back
+                </button>
+
+            </li>      
+            <li class="usa-button-group__item">
+                <button
+                    id="save-domain-assignments"
+                    type="button"
+                    class="usa-button"
+                >
+                    Save
+                </button>
+            </li>
+        </ul>
+    </section>
+
+    <form method="post" id="member-domains-edit-form" action="{{ request.path }}"> {% csrf_token %} </form>
 
 </div>
 {% endblock %}

--- a/src/registrar/templates/portfolio_member_domains_edit.html
+++ b/src/registrar/templates/portfolio_member_domains_edit.html
@@ -100,7 +100,8 @@
             <li class="usa-button-group__item">
                 <button
                     type="button"
-                    class="usa-button usa-button--outline back-to-edit-domain-assignments"
+                    class="usa-button usa-button--outline"
+                    id="back-to-edit-domain-assignments"
                 >
                     Back
                 </button>

--- a/src/registrar/templates/portfolio_members_add_new.html
+++ b/src/registrar/templates/portfolio_members_add_new.html
@@ -134,7 +134,6 @@
     id="invite-member-modal"
     aria-labelledby="invite-member-heading"
     aria-describedby="confirm-invite-description"
-    style="display: none;"
 >
     <div class="usa-modal__content">
         <div class="usa-modal__main">

--- a/src/registrar/tests/test_views_member_domains_json.py
+++ b/src/registrar/tests/test_views_member_domains_json.py
@@ -94,6 +94,12 @@ class GetPortfolioMemberDomainsJsonTest(TestWithUser, WebTest):
         DomainInvitation.objects.create(
             email=cls.invited_member_email, domain=cls.domain2, status=DomainInvitation.DomainInvitationStatus.INVITED
         )
+        DomainInvitation.objects.create(
+            email=cls.invited_member_email, domain=cls.domain3, status=DomainInvitation.DomainInvitationStatus.CANCELED
+        )
+        DomainInvitation.objects.create(
+            email=cls.invited_member_email, domain=cls.domain4, status=DomainInvitation.DomainInvitationStatus.RETRIEVED
+        )
 
     @classmethod
     def tearDownClass(cls):

--- a/src/registrar/tests/test_views_member_domains_json.py
+++ b/src/registrar/tests/test_views_member_domains_json.py
@@ -144,7 +144,8 @@ class GetPortfolioMemberDomainsJsonTest(TestWithUser, WebTest):
     @override_flag("organization_feature", active=True)
     @override_flag("organization_members", active=True)
     def test_get_portfolio_invitedmember_domains_json_authenticated(self):
-        """Test that portfolio invitedmember's domains are returned properly for an authenticated user."""
+        """Test that portfolio invitedmember's domains are returned properly for an authenticated user.
+        CANCELED and RETRIEVED invites should be ignored."""
         response = self.app.get(
             reverse("get_member_domains_json"),
             params={"portfolio": self.portfolio.id, "email": self.invited_member_email, "member_only": "true"},

--- a/src/registrar/tests/test_views_members_json.py
+++ b/src/registrar/tests/test_views_members_json.py
@@ -157,7 +157,7 @@ class GetPortfolioMembersJsonTest(MockEppLib, WebTest):
     @override_flag("organization_members", active=True)
     def test_get_portfolio_invited_json_authenticated(self):
         """Test that portfolio invitees are returned properly for an authenticated user."""
-        """Also tests that reposnse is 200 when no domains"""
+        """Also tests that response is 200 when no domains"""
         UserPortfolioPermission.objects.create(
             user=self.user,
             portfolio=self.portfolio,
@@ -318,17 +318,31 @@ class GetPortfolioMembersJsonTest(MockEppLib, WebTest):
             domain=domain,
         )
 
-        # create a domain not in the portfolio
+        # create another domain in the portfolio
         domain2 = Domain.objects.create(
-            name="somedomain2.com",
+            name="thissecondinvitetestsasubqueryinjson@lets.notbreak",
         )
         DomainInformation.objects.create(
             creator=self.user,
             domain=domain2,
+            portfolio=self.portfolio,
         )
         DomainInvitation.objects.create(
             email=self.email6,
             domain=domain2,
+        )
+
+        # create a domain not in the portfolio
+        domain3 = Domain.objects.create(
+            name="somedomain2.com",
+        )
+        DomainInformation.objects.create(
+            creator=self.user,
+            domain=domain3,
+        )
+        DomainInvitation.objects.create(
+            email=self.email6,
+            domain=domain3,
         )
 
         response = self.app.get(reverse("get_portfolio_members_json"), params={"portfolio": self.portfolio.id})
@@ -338,6 +352,7 @@ class GetPortfolioMembersJsonTest(MockEppLib, WebTest):
         # Check if the domain appears in the response JSON and domain2 does not
         domain_names = [domain_name for member in data["members"] for domain_name in member.get("domain_names", [])]
         self.assertIn("somedomain1.com", domain_names)
+        self.assertIn("thissecondinvitetestsasubqueryinjson@lets.notbreak", domain_names)
         self.assertNotIn("somedomain2.com", domain_names)
 
     @less_console_noise_decorator

--- a/src/registrar/tests/test_views_members_json.py
+++ b/src/registrar/tests/test_views_members_json.py
@@ -258,17 +258,32 @@ class GetPortfolioMembersJsonTest(MockEppLib, WebTest):
             role=UserDomainRole.Roles.MANAGER,
         )
 
-        # create domain for which user is manager and domain not in portfolio
+        # create another domain in the portfolio
         domain2 = Domain.objects.create(
-            name="somedomain2.com",
+            name="thissecondpermtestsmultipleperms@lets.notbreak",
         )
         DomainInformation.objects.create(
             creator=self.user,
             domain=domain2,
+            portfolio=self.portfolio,
         )
         UserDomainRole.objects.create(
             user=self.user,
             domain=domain2,
+            role=UserDomainRole.Roles.MANAGER,
+        )
+
+        # create domain for which user is manager and domain not in portfolio
+        domain3 = Domain.objects.create(
+            name="somedomain3.com",
+        )
+        DomainInformation.objects.create(
+            creator=self.user,
+            domain=domain3,
+        )
+        UserDomainRole.objects.create(
+            user=self.user,
+            domain=domain3,
             role=UserDomainRole.Roles.MANAGER,
         )
 
@@ -279,7 +294,8 @@ class GetPortfolioMembersJsonTest(MockEppLib, WebTest):
         # Check if the domain appears in the response JSON and that domain2 does not
         domain_names = [domain_name for member in data["members"] for domain_name in member.get("domain_names", [])]
         self.assertIn("somedomain1.com", domain_names)
-        self.assertNotIn("somedomain2.com", domain_names)
+        self.assertIn("thissecondpermtestsmultipleperms@lets.notbreak", domain_names)
+        self.assertNotIn("somedomain3.com", domain_names)
 
     @less_console_noise_decorator
     @override_flag("organization_feature", active=True)
@@ -334,7 +350,7 @@ class GetPortfolioMembersJsonTest(MockEppLib, WebTest):
 
         # create a domain not in the portfolio
         domain3 = Domain.objects.create(
-            name="somedomain2.com",
+            name="somedomain3.com",
         )
         DomainInformation.objects.create(
             creator=self.user,
@@ -353,7 +369,7 @@ class GetPortfolioMembersJsonTest(MockEppLib, WebTest):
         domain_names = [domain_name for member in data["members"] for domain_name in member.get("domain_names", [])]
         self.assertIn("somedomain1.com", domain_names)
         self.assertIn("thissecondinvitetestsasubqueryinjson@lets.notbreak", domain_names)
-        self.assertNotIn("somedomain2.com", domain_names)
+        self.assertNotIn("somedomain3.com", domain_names)
 
     @less_console_noise_decorator
     @override_flag("organization_feature", active=True)

--- a/src/registrar/tests/test_views_portfolio.py
+++ b/src/registrar/tests/test_views_portfolio.py
@@ -2294,12 +2294,12 @@ class TestPortfolioInvitedMemberEditDomainsView(TestPortfolioInvitedMemberDomain
     @classmethod
     def tearDownClass(cls):
         super().tearDownClass()
-        
+
     def setUp(self):
         super().setUp()
         names = ["1.gov", "2.gov", "3.gov"]
         Domain.objects.bulk_create([Domain(name=name) for name in names])
-    
+
     def tearDown(self):
         super().tearDown()
         Domain.objects.all().delete()

--- a/src/registrar/tests/test_views_portfolio.py
+++ b/src/registrar/tests/test_views_portfolio.py
@@ -2303,6 +2303,7 @@ class TestPortfolioInvitedMemberEditDomainsView(TestPortfolioInvitedMemberDomain
     def tearDown(self):
         super().tearDown()
         Domain.objects.all().delete()
+        DomainInvitation.objects.all().delete()
 
     @less_console_noise_decorator
     @override_flag("organization_feature", active=True)

--- a/src/registrar/tests/test_views_portfolio.py
+++ b/src/registrar/tests/test_views_portfolio.py
@@ -2243,7 +2243,9 @@ class TestPortfolioMemberDomainsEditView(TestPortfolioMemberDomainsView):
         self.assertRedirects(response, reverse("member-domains", kwargs={"pk": self.portfolio_permission.pk}))
         messages = list(response.wsgi_request._messages)
         self.assertEqual(len(messages), 1)
-        self.assertEqual(str(messages[0]), "Invalid data for added domains.")
+        self.assertEqual(
+            str(messages[0]), "Invalid data for added domains. If the issue persists, please contact help@get.gov."
+        )
 
     @less_console_noise_decorator
     @override_flag("organization_feature", active=True)
@@ -2264,7 +2266,9 @@ class TestPortfolioMemberDomainsEditView(TestPortfolioMemberDomainsView):
         self.assertRedirects(response, reverse("member-domains", kwargs={"pk": self.portfolio_permission.pk}))
         messages = list(response.wsgi_request._messages)
         self.assertEqual(len(messages), 1)
-        self.assertEqual(str(messages[0]), "Invalid data for removed domains.")
+        self.assertEqual(
+            str(messages[0]), "Invalid data for removed domains. If the issue persists, please contact help@get.gov."
+        )
 
     @less_console_noise_decorator
     @override_flag("organization_feature", active=True)
@@ -2479,7 +2483,9 @@ class TestPortfolioInvitedMemberEditDomainsView(TestPortfolioInvitedMemberDomain
         self.assertRedirects(response, reverse("invitedmember-domains", kwargs={"pk": self.invitation.pk}))
         messages = list(response.wsgi_request._messages)
         self.assertEqual(len(messages), 1)
-        self.assertEqual(str(messages[0]), "Invalid data for added domains.")
+        self.assertEqual(
+            str(messages[0]), "Invalid data for added domains. If the issue persists, please contact help@get.gov."
+        )
 
     @less_console_noise_decorator
     @override_flag("organization_feature", active=True)
@@ -2500,7 +2506,9 @@ class TestPortfolioInvitedMemberEditDomainsView(TestPortfolioInvitedMemberDomain
         self.assertRedirects(response, reverse("invitedmember-domains", kwargs={"pk": self.invitation.pk}))
         messages = list(response.wsgi_request._messages)
         self.assertEqual(len(messages), 1)
-        self.assertEqual(str(messages[0]), "Invalid data for removed domains.")
+        self.assertEqual(
+            str(messages[0]), "Invalid data for removed domains. If the issue persists, please contact help@get.gov."
+        )
 
     @less_console_noise_decorator
     @override_flag("organization_feature", active=True)

--- a/src/registrar/tests/test_views_portfolio.py
+++ b/src/registrar/tests/test_views_portfolio.py
@@ -2188,7 +2188,7 @@ class TestPortfolioMemberDomainsEditView(TestPortfolioMemberDomainsView):
         response = self.client.post(self.url, data)
 
         # Check that the UserDomainRole objects were created
-        self.assertEqual(UserDomainRole.objects.filter(user=self.user).count(), 3)
+        self.assertEqual(UserDomainRole.objects.filter(user=self.user, role=UserDomainRole.Roles.MANAGER).count(), 3)
 
         # Check for a success message and a redirect
         self.assertRedirects(response, reverse("member-domains", kwargs={"pk": self.portfolio_permission.pk}))

--- a/src/registrar/tests/test_views_portfolio.py
+++ b/src/registrar/tests/test_views_portfolio.py
@@ -2109,12 +2109,18 @@ class TestPortfolioMemberDomainsEditView(TestPortfolioMemberDomainsView):
     def setUpClass(cls):
         super().setUpClass()
         cls.url = reverse("member-domains-edit", kwargs={"pk": cls.portfolio_permission.pk})
-        names = ["1.gov", "2.gov", "3.gov"]
-        Domain.objects.bulk_create([Domain(name=name) for name in names])
 
     @classmethod
     def tearDownClass(cls):
         super().tearDownClass()
+
+    def setUp(self):
+        super().setUp()
+        names = ["1.gov", "2.gov", "3.gov"]
+        Domain.objects.bulk_create([Domain(name=name) for name in names])
+
+    def tearDown(self):
+        super().tearDown()
         UserDomainRole.objects.all().delete()
         Domain.objects.all().delete()
 
@@ -2284,17 +2290,19 @@ class TestPortfolioInvitedMemberEditDomainsView(TestPortfolioInvitedMemberDomain
     def setUpClass(cls):
         super().setUpClass()
         cls.url = reverse("invitedmember-domains-edit", kwargs={"pk": cls.invitation.pk})
-        names = ["1.gov", "2.gov", "3.gov"]
-        Domain.objects.bulk_create([Domain(name=name) for name in names])
 
     @classmethod
     def tearDownClass(cls):
         super().tearDownClass()
-        Domain.objects.all().delete()
-
+        
+    def setUp(self):
+        super().setUp()
+        names = ["1.gov", "2.gov", "3.gov"]
+        Domain.objects.bulk_create([Domain(name=name) for name in names])
+    
     def tearDown(self):
-        return super().tearDown()
-        DomainInvitation.objects.all().delete()
+        super().tearDown()
+        Domain.objects.all().delete()
 
     @less_console_noise_decorator
     @override_flag("organization_feature", active=True)

--- a/src/registrar/tests/test_views_portfolio.py
+++ b/src/registrar/tests/test_views_portfolio.py
@@ -14,6 +14,7 @@ from registrar.models import (
     Suborganization,
     AllowedEmail,
 )
+from registrar.models.domain_invitation import DomainInvitation
 from registrar.models.portfolio_invitation import PortfolioInvitation
 from registrar.models.user_group import UserGroup
 from registrar.models.user_portfolio_permission import UserPortfolioPermission
@@ -25,6 +26,7 @@ from django.contrib.sessions.middleware import SessionMiddleware
 import boto3_mocking  # type: ignore
 from django.test import Client
 import logging
+import json
 
 logger = logging.getLogger(__name__)
 
@@ -1927,7 +1929,7 @@ class TestPortfolioMemberDomainsView(TestWithUser, WebTest):
         cls.portfolio = Portfolio.objects.create(creator=cls.user, organization_name="Test Portfolio")
 
         # Assign permissions to the user making requests
-        UserPortfolioPermission.objects.create(
+        cls.portfolio_permission = UserPortfolioPermission.objects.create(
             user=cls.user,
             portfolio=cls.portfolio,
             roles=[UserPortfolioRoleChoices.ORGANIZATION_ADMIN],
@@ -2106,10 +2108,15 @@ class TestPortfolioMemberDomainsEditView(TestPortfolioMemberDomainsView):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+        cls.url = reverse("member-domains-edit", kwargs={"pk": cls.portfolio_permission.pk})
+        names = ["1.gov", "2.gov", "3.gov"]
+        Domain.objects.bulk_create([Domain(name=name) for name in names])
 
     @classmethod
     def tearDownClass(cls):
         super().tearDownClass()
+        UserDomainRole.objects.all().delete()
+        Domain.objects.all().delete()
 
     @less_console_noise_decorator
     @override_flag("organization_feature", active=True)
@@ -2162,15 +2169,132 @@ class TestPortfolioMemberDomainsEditView(TestPortfolioMemberDomainsView):
         # Make sure the response is not found
         self.assertEqual(response.status_code, 404)
 
+    @less_console_noise_decorator
+    @override_flag("organization_feature", active=True)
+    @override_flag("organization_members", active=True)
+    def test_post_with_valid_added_domains(self):
+        """Test that domains can be successfully added."""
+        self.client.force_login(self.user)
+
+        data = {
+            "added_domains": json.dumps([1, 2, 3]),  # Mock domain IDs
+        }
+        response = self.client.post(self.url, data)
+
+        # Check that the UserDomainRole objects were created
+        self.assertEqual(UserDomainRole.objects.filter(user=self.user).count(), 3)
+
+        # Check for a success message and a redirect
+        self.assertRedirects(response, reverse("member-domains", kwargs={"pk": self.portfolio_permission.pk}))
+        messages = list(response.wsgi_request._messages)
+        self.assertEqual(len(messages), 1)
+        self.assertEqual(str(messages[0]), "The domain assignment changes have been saved.")
+
+    @less_console_noise_decorator
+    @override_flag("organization_feature", active=True)
+    @override_flag("organization_members", active=True)
+    def test_post_with_valid_removed_domains(self):
+        """Test that domains can be successfully removed."""
+        self.client.force_login(self.user)
+
+        # Create some UserDomainRole objects
+        domains = [1, 2, 3]
+        UserDomainRole.objects.bulk_create([UserDomainRole(domain_id=domain, user=self.user) for domain in domains])
+
+        data = {
+            "removed_domains": json.dumps([1, 2]),
+        }
+        response = self.client.post(self.url, data)
+
+        # Check that the UserDomainRole objects were deleted
+        self.assertEqual(UserDomainRole.objects.filter(user=self.user).count(), 1)
+        self.assertEqual(UserDomainRole.objects.filter(domain_id=3, user=self.user).count(), 1)
+
+        # Check for a success message and a redirect
+        self.assertRedirects(response, reverse("member-domains", kwargs={"pk": self.portfolio_permission.pk}))
+        messages = list(response.wsgi_request._messages)
+        self.assertEqual(len(messages), 1)
+        self.assertEqual(str(messages[0]), "The domain assignment changes have been saved.")
+
+        UserDomainRole.objects.all().delete()
+
+    @less_console_noise_decorator
+    @override_flag("organization_feature", active=True)
+    @override_flag("organization_members", active=True)
+    def test_post_with_invalid_added_domains_data(self):
+        """Test that an error is returned for invalid added domains data."""
+        self.client.force_login(self.user)
+
+        data = {
+            "added_domains": "json-statham",
+        }
+        response = self.client.post(self.url, data)
+
+        # Check that no UserDomainRole objects were created
+        self.assertEqual(UserDomainRole.objects.filter(user=self.user).count(), 0)
+
+        # Check for an error message and a redirect
+        self.assertRedirects(response, reverse("member-domains", kwargs={"pk": self.portfolio_permission.pk}))
+        messages = list(response.wsgi_request._messages)
+        self.assertEqual(len(messages), 1)
+        self.assertEqual(str(messages[0]), "Invalid data for added domains.")
+
+    @less_console_noise_decorator
+    @override_flag("organization_feature", active=True)
+    @override_flag("organization_members", active=True)
+    def test_post_with_invalid_removed_domains_data(self):
+        """Test that an error is returned for invalid removed domains data."""
+        self.client.force_login(self.user)
+
+        data = {
+            "removed_domains": "not-a-json",
+        }
+        response = self.client.post(self.url, data)
+
+        # Check that no UserDomainRole objects were deleted
+        self.assertEqual(UserDomainRole.objects.filter(user=self.user).count(), 0)
+
+        # Check for an error message and a redirect
+        self.assertRedirects(response, reverse("member-domains", kwargs={"pk": self.portfolio_permission.pk}))
+        messages = list(response.wsgi_request._messages)
+        self.assertEqual(len(messages), 1)
+        self.assertEqual(str(messages[0]), "Invalid data for removed domains.")
+
+    @less_console_noise_decorator
+    @override_flag("organization_feature", active=True)
+    @override_flag("organization_members", active=True)
+    def test_post_with_no_changes(self):
+        """Test that no changes message is displayed when no changes are made."""
+        self.client.force_login(self.user)
+
+        response = self.client.post(self.url, {})
+
+        # Check that no UserDomainRole objects were created or deleted
+        self.assertEqual(UserDomainRole.objects.filter(user=self.user).count(), 0)
+
+        # Check for an info message and a redirect
+        self.assertRedirects(response, reverse("member-domains", kwargs={"pk": self.portfolio_permission.pk}))
+        messages = list(response.wsgi_request._messages)
+        self.assertEqual(len(messages), 1)
+        self.assertEqual(str(messages[0]), "No changes detected.")
+
 
 class TestPortfolioInvitedMemberEditDomainsView(TestPortfolioInvitedMemberDomainsView):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+        cls.url = reverse("invitedmember-domains-edit", kwargs={"pk": cls.invitation.pk})
+        names = ["1.gov", "2.gov", "3.gov"]
+        Domain.objects.bulk_create([Domain(name=name) for name in names])
 
     @classmethod
     def tearDownClass(cls):
         super().tearDownClass()
+        Domain.objects.all().delete()
+
+    def tearDown(self):
+        return super().tearDown()
+        DomainInvitation.objects.all().delete()
 
     @less_console_noise_decorator
     @override_flag("organization_feature", active=True)
@@ -2221,6 +2345,171 @@ class TestPortfolioInvitedMemberEditDomainsView(TestPortfolioInvitedMemberDomain
 
         # Make sure the response is not found
         self.assertEqual(response.status_code, 404)
+
+    @less_console_noise_decorator
+    @override_flag("organization_feature", active=True)
+    @override_flag("organization_members", active=True)
+    def test_post_with_valid_added_domains(self):
+        """Test adding new domains successfully."""
+        self.client.force_login(self.user)
+
+        data = {
+            "added_domains": json.dumps([1, 2, 3]),  # Mock domain IDs
+        }
+        response = self.client.post(self.url, data)
+
+        # Check that the DomainInvitation objects were created
+        self.assertEqual(
+            DomainInvitation.objects.filter(
+                email="invited@example.com", status=DomainInvitation.DomainInvitationStatus.INVITED
+            ).count(),
+            3,
+        )
+
+        # Check for a success message and a redirect
+        self.assertRedirects(response, reverse("invitedmember-domains", kwargs={"pk": self.invitation.pk}))
+        messages = list(response.wsgi_request._messages)
+        self.assertEqual(len(messages), 1)
+        self.assertEqual(str(messages[0]), "The domain assignment changes have been saved.")
+
+    @less_console_noise_decorator
+    @override_flag("organization_feature", active=True)
+    @override_flag("organization_members", active=True)
+    def test_post_with_existing_and_new_added_domains(self):
+        """Test updating existing and adding new invitations."""
+        self.client.force_login(self.user)
+
+        # Create existing invitations
+        DomainInvitation.objects.bulk_create(
+            [
+                DomainInvitation(
+                    domain_id=1, email="invited@example.com", status=DomainInvitation.DomainInvitationStatus.CANCELED
+                ),
+                DomainInvitation(
+                    domain_id=2, email="invited@example.com", status=DomainInvitation.DomainInvitationStatus.INVITED
+                ),
+            ]
+        )
+
+        data = {
+            "added_domains": json.dumps([1, 2, 3]),
+        }
+        response = self.client.post(self.url, data)
+
+        # Check that status for domain_id=1 was updated to INVITED
+        self.assertEqual(
+            DomainInvitation.objects.get(domain_id=1, email="invited@example.com").status,
+            DomainInvitation.DomainInvitationStatus.INVITED,
+        )
+
+        # Check that domain_id=3 was created as INVITED
+        self.assertTrue(
+            DomainInvitation.objects.filter(
+                domain_id=3, email="invited@example.com", status=DomainInvitation.DomainInvitationStatus.INVITED
+            ).exists()
+        )
+
+        # Check for a success message and a redirect
+        self.assertRedirects(response, reverse("invitedmember-domains", kwargs={"pk": self.invitation.pk}))
+
+    @less_console_noise_decorator
+    @override_flag("organization_feature", active=True)
+    @override_flag("organization_members", active=True)
+    def test_post_with_valid_removed_domains(self):
+        """Test removing domains successfully."""
+        self.client.force_login(self.user)
+
+        # Create existing invitations
+        DomainInvitation.objects.bulk_create(
+            [
+                DomainInvitation(
+                    domain_id=1, email="invited@example.com", status=DomainInvitation.DomainInvitationStatus.INVITED
+                ),
+                DomainInvitation(
+                    domain_id=2, email="invited@example.com", status=DomainInvitation.DomainInvitationStatus.INVITED
+                ),
+            ]
+        )
+
+        data = {
+            "removed_domains": json.dumps([1]),
+        }
+        response = self.client.post(self.url, data)
+
+        # Check that the status for domain_id=1 was updated to CANCELED
+        self.assertEqual(
+            DomainInvitation.objects.get(domain_id=1, email="invited@example.com").status,
+            DomainInvitation.DomainInvitationStatus.CANCELED,
+        )
+
+        # Check that domain_id=2 remains INVITED
+        self.assertEqual(
+            DomainInvitation.objects.get(domain_id=2, email="invited@example.com").status,
+            DomainInvitation.DomainInvitationStatus.INVITED,
+        )
+
+        # Check for a success message and a redirect
+        self.assertRedirects(response, reverse("invitedmember-domains", kwargs={"pk": self.invitation.pk}))
+
+    @less_console_noise_decorator
+    @override_flag("organization_feature", active=True)
+    @override_flag("organization_members", active=True)
+    def test_post_with_invalid_added_domains_data(self):
+        """Test handling of invalid JSON for added domains."""
+        self.client.force_login(self.user)
+
+        data = {
+            "added_domains": "not-a-json",
+        }
+        response = self.client.post(self.url, data)
+
+        # Check that no DomainInvitation objects were created
+        self.assertEqual(DomainInvitation.objects.count(), 0)
+
+        # Check for an error message and a redirect
+        self.assertRedirects(response, reverse("invitedmember-domains", kwargs={"pk": self.invitation.pk}))
+        messages = list(response.wsgi_request._messages)
+        self.assertEqual(len(messages), 1)
+        self.assertEqual(str(messages[0]), "Invalid data for added domains.")
+
+    @less_console_noise_decorator
+    @override_flag("organization_feature", active=True)
+    @override_flag("organization_members", active=True)
+    def test_post_with_invalid_removed_domains_data(self):
+        """Test handling of invalid JSON for removed domains."""
+        self.client.force_login(self.user)
+
+        data = {
+            "removed_domains": "json-sudeikis",
+        }
+        response = self.client.post(self.url, data)
+
+        # Check that no DomainInvitation objects were updated
+        self.assertEqual(DomainInvitation.objects.count(), 0)
+
+        # Check for an error message and a redirect
+        self.assertRedirects(response, reverse("invitedmember-domains", kwargs={"pk": self.invitation.pk}))
+        messages = list(response.wsgi_request._messages)
+        self.assertEqual(len(messages), 1)
+        self.assertEqual(str(messages[0]), "Invalid data for removed domains.")
+
+    @less_console_noise_decorator
+    @override_flag("organization_feature", active=True)
+    @override_flag("organization_members", active=True)
+    def test_post_with_no_changes(self):
+        """Test the case where no changes are made."""
+        self.client.force_login(self.user)
+
+        response = self.client.post(self.url, {})
+
+        # Check that no DomainInvitation objects were created or updated
+        self.assertEqual(DomainInvitation.objects.count(), 0)
+
+        # Check for an info message and a redirect
+        self.assertRedirects(response, reverse("invitedmember-domains", kwargs={"pk": self.invitation.pk}))
+        messages = list(response.wsgi_request._messages)
+        self.assertEqual(len(messages), 1)
+        self.assertEqual(str(messages[0]), "No changes detected.")
 
 
 class TestRequestingEntity(WebTest):

--- a/src/registrar/views/member_domains_json.py
+++ b/src/registrar/views/member_domains_json.py
@@ -90,7 +90,9 @@ class PortfolioMemberDomainsJson(PortfolioMemberDomainsPermission, View):
                 domain_info_ids = DomainInformation.objects.filter(portfolio=portfolio).values_list(
                     "domain_id", flat=True
                 )
-                domain_invitations = DomainInvitation.objects.filter(email=email, status=DomainInvitation.DomainInvitationStatus.INVITED).values_list("domain_id", flat=True)
+                domain_invitations = DomainInvitation.objects.filter(
+                    email=email, status=DomainInvitation.DomainInvitationStatus.INVITED
+                ).values_list("domain_id", flat=True)
                 return domain_info_ids.intersection(domain_invitations)
         else:
             domain_infos = DomainInformation.objects.filter(portfolio=portfolio)

--- a/src/registrar/views/member_domains_json.py
+++ b/src/registrar/views/member_domains_json.py
@@ -90,7 +90,7 @@ class PortfolioMemberDomainsJson(PortfolioMemberDomainsPermission, View):
                 domain_info_ids = DomainInformation.objects.filter(portfolio=portfolio).values_list(
                     "domain_id", flat=True
                 )
-                domain_invitations = DomainInvitation.objects.filter(email=email).values_list("domain_id", flat=True)
+                domain_invitations = DomainInvitation.objects.filter(email=email, status=DomainInvitation.DomainInvitationStatus.INVITED).values_list("domain_id", flat=True)
                 return domain_info_ids.intersection(domain_invitations)
         else:
             domain_infos = DomainInformation.objects.filter(portfolio=portfolio)

--- a/src/registrar/views/portfolio_members_json.py
+++ b/src/registrar/views/portfolio_members_json.py
@@ -1,7 +1,6 @@
 from django.http import JsonResponse
 from django.core.paginator import Paginator
 from django.db.models import Value, F, CharField, TextField, Q, Case, When, OuterRef, Subquery
-from django.contrib.postgres.fields import ArrayField
 from django.db.models.functions import Cast, Coalesce, Concat
 from django.contrib.postgres.aggregates import ArrayAgg
 from django.urls import reverse
@@ -152,7 +151,8 @@ class PortfolioMembersJson(PortfolioMembersPermission, View):
                     # We've pre-concatenated the domain infos to limit the subquery to return a single virtual 'row',
                     # otherwise we'll trigger a "more than one row returned by a subquery used as an expression"
                     # when an email matches multiple domain invitations.
-                    # We'll take care when processing the list of one single concatenated items item in serialize_members
+                    # We'll take care when processing the list of one single concatenated items item
+                    # in serialize_members.
                     Subquery(concatenated_domain_info),
                     distinct=True,
                 )

--- a/src/registrar/views/portfolio_members_json.py
+++ b/src/registrar/views/portfolio_members_json.py
@@ -136,7 +136,10 @@ class PortfolioMembersJson(PortfolioMembersPermission, View):
             # Use ArrayRemove to return an empty list when no domain invitations are found
             domain_info=ArrayRemoveNull(
                 ArrayAgg(
-                    Subquery(domain_invitations.values("domain_info")),
+                    # Use order_by("id")[:1] to limit the subquery to a single row,
+                    # otherwise we'll trigger a "more than one row returned by a subquery used as an expression"
+                    # when an email matches multiple domain invitations
+                    Subquery(domain_invitations.values("domain_info").order_by("id")[:1]),
                     distinct=True,
                 )
             ),

--- a/src/registrar/views/portfolio_members_json.py
+++ b/src/registrar/views/portfolio_members_json.py
@@ -208,16 +208,19 @@ class PortfolioMembersJson(PortfolioMembersPermission, View):
         is_admin = UserPortfolioRoleChoices.ORGANIZATION_ADMIN in (item.get("roles") or [])
         action_url = reverse(item["type"], kwargs={"pk": item["id"]})
 
-        # Ensure domain_info is properly processed
+        item_type = item.get("type", "")
+
+        # Ensure domain_info is properly processed for invites -
+        # we need to un-concatenate the subquery
         domain_info_list = item.get("domain_info", [])
-        if isinstance(domain_info_list, list) and domain_info_list:
+        if item_type == "invitedmember" and isinstance(domain_info_list, list) and domain_info_list:
             # Split the first item in the list if it exists
             domain_info_list = domain_info_list[0].split(", ")
 
         # Serialize member data
         member_json = {
             "id": item.get("id", ""),  # id is id of UserPortfolioPermission or PortfolioInvitation
-            "type": item.get("type", ""),  # source is member or invitedmember
+            "type": item_type,  # source is member or invitedmember
             "name": " ".join(filter(None, [item.get("first_name", ""), item.get("last_name", "")])),
             "email": item.get("email_display", ""),
             "member_display": item.get("member_display", ""),

--- a/src/registrar/views/portfolio_members_json.py
+++ b/src/registrar/views/portfolio_members_json.py
@@ -1,6 +1,7 @@
 from django.http import JsonResponse
 from django.core.paginator import Paginator
 from django.db.models import Value, F, CharField, TextField, Q, Case, When, OuterRef, Subquery
+from django.contrib.postgres.fields import ArrayField
 from django.db.models.functions import Cast, Coalesce, Concat
 from django.contrib.postgres.aggregates import ArrayAgg
 from django.urls import reverse
@@ -12,6 +13,7 @@ from registrar.models.user_portfolio_permission import UserPortfolioPermission
 from registrar.models.utility.portfolio_helper import UserPortfolioPermissionChoices, UserPortfolioRoleChoices
 from registrar.views.utility.mixins import PortfolioMembersPermission
 from registrar.models.utility.orm_helper import ArrayRemoveNull
+from django.contrib.postgres.aggregates import StringAgg
 
 
 class PortfolioMembersJson(PortfolioMembersPermission, View):
@@ -119,11 +121,21 @@ class PortfolioMembersJson(PortfolioMembersPermission, View):
 
     def initial_invitations_search(self, portfolio):
         """Perform initial invitations search and get related DomainInvitation data based on the email."""
-        # Get DomainInvitation query for matching email and for the portfolio
+        
+        # Subquery to get concatenated domain information for each email
         domain_invitations = DomainInvitation.objects.filter(
-            email=OuterRef("email"),  # Check if email matches the OuterRef("email")
-            domain__domain_info__portfolio=portfolio,  # Check if the domain's portfolio matches the given portfolio
-        ).annotate(domain_info=Concat(F("domain__id"), Value(":"), F("domain__name"), output_field=CharField()))
+            email=OuterRef("email"),
+            domain__domain_info__portfolio=portfolio
+        ).annotate(
+            concatenated_info=Concat(
+                F("domain__id"), Value(":"), F("domain__name"), output_field=CharField()
+            )
+        ).values("concatenated_info")
+
+        concatenated_domain_info = domain_invitations.values("email").annotate(
+            domain_info=StringAgg("concatenated_info", delimiter=", ")
+        ).values("domain_info")
+        
         # PortfolioInvitation query
         invitations = PortfolioInvitation.objects.filter(portfolio=portfolio)
         invitations = invitations.annotate(
@@ -136,10 +148,11 @@ class PortfolioMembersJson(PortfolioMembersPermission, View):
             # Use ArrayRemove to return an empty list when no domain invitations are found
             domain_info=ArrayRemoveNull(
                 ArrayAgg(
-                    # Use order_by("id")[:1] to limit the subquery to a single row,
+                    # We've pre-concatenated the domain infos to limit the subquery to return a single virtual 'row',
                     # otherwise we'll trigger a "more than one row returned by a subquery used as an expression"
-                    # when an email matches multiple domain invitations
-                    Subquery(domain_invitations.values("domain_info").order_by("id")[:1]),
+                    # when an email matches multiple domain invitations.
+                    # We'll take care when processing the list of one single concatenated items item in serialize_members
+                    Subquery(concatenated_domain_info),
                     distinct=True,
                 )
             ),
@@ -156,6 +169,7 @@ class PortfolioMembersJson(PortfolioMembersPermission, View):
             "domain_info",
             "type",
         )
+
         return invitations
 
     def apply_search_term(self, queryset, request):
@@ -193,6 +207,12 @@ class PortfolioMembersJson(PortfolioMembersPermission, View):
         is_admin = UserPortfolioRoleChoices.ORGANIZATION_ADMIN in (item.get("roles") or [])
         action_url = reverse(item["type"], kwargs={"pk": item["id"]})
 
+        # Ensure domain_info is properly processed
+        domain_info_list = item.get("domain_info", [])
+        if isinstance(domain_info_list, list) and domain_info_list:
+            # Split the first item in the list if it exists
+            domain_info_list = domain_info_list[0].split(", ")
+
         # Serialize member data
         member_json = {
             "id": item.get("id", ""),  # id is id of UserPortfolioPermission or PortfolioInvitation
@@ -206,9 +226,9 @@ class PortfolioMembersJson(PortfolioMembersPermission, View):
             ),
             # split domain_info array values into ids to form urls, and names
             "domain_urls": [
-                reverse("domain", kwargs={"pk": domain_info.split(":")[0]}) for domain_info in item.get("domain_info")
+                reverse("domain", kwargs={"pk": domain_info.split(":")[0]}) for domain_info in domain_info_list
             ],
-            "domain_names": [domain_info.split(":")[1] for domain_info in item.get("domain_info")],
+            "domain_names": [domain_info.split(":")[1] for domain_info in domain_info_list],
             "is_admin": is_admin,
             "last_active": item.get("last_active"),
             "action_url": action_url,

--- a/src/registrar/views/portfolios.py
+++ b/src/registrar/views/portfolios.py
@@ -292,7 +292,10 @@ class PortfolioMemberDomainsEditView(PortfolioMemberDomainsEditPermissionView, V
         if added_domain_ids:
             # Bulk create UserDomainRole instances for added domains
             UserDomainRole.objects.bulk_create(
-                [UserDomainRole(domain_id=domain_id, user=member) for domain_id in added_domain_ids],
+                [
+                    UserDomainRole(domain_id=domain_id, user=member, role=UserDomainRole.Roles.MANAGER)
+                    for domain_id in added_domain_ids
+                ],
                 ignore_conflicts=True,  # Avoid duplicate entries
             )
 

--- a/src/registrar/views/portfolios.py
+++ b/src/registrar/views/portfolios.py
@@ -219,7 +219,7 @@ class PortfolioMemberDomainsEditView(PortfolioMemberDomainsEditPermissionView, V
                 "member": member,
             },
         )
-    
+
     def post(self, request, pk):
         """
         Handles adding and removing domains for a portfolio member.
@@ -229,41 +229,23 @@ class PortfolioMemberDomainsEditView(PortfolioMemberDomainsEditPermissionView, V
         portfolio_permission = get_object_or_404(UserPortfolioPermission, pk=pk)
         member = portfolio_permission.user
 
-        try:
-            added_domain_ids = json.loads(added_domains) if added_domains else []
-        except json.JSONDecodeError:
-            messages.error(request, "Invalid data for added domains.")
+        added_domain_ids = self._parse_domain_ids(added_domains, "added domains")
+        if added_domain_ids is None:
             return redirect(reverse("member-domains", kwargs={"pk": pk}))
 
-        try:
-            removed_domain_ids = json.loads(removed_domains) if removed_domains else []
-        except json.JSONDecodeError:
-            messages.error(request, "Invalid data for removed domains.")
+        removed_domain_ids = self._parse_domain_ids(removed_domains, "removed domains")
+        if removed_domain_ids is None:
             return redirect(reverse("member-domains", kwargs={"pk": pk}))
 
         if added_domain_ids or removed_domain_ids:
             try:
-                if added_domain_ids:
-                    # Bulk create UserDomainRole instances for added domains
-                    UserDomainRole.objects.bulk_create(
-                        [
-                            UserDomainRole(domain_id=domain_id, user=member)
-                            for domain_id in added_domain_ids
-                        ],
-                        ignore_conflicts=True,  # Avoid duplicate entries
-                    )
-
-                if removed_domain_ids:
-                    # Delete UserDomainRole instances for removed domains
-                    UserDomainRole.objects.filter(domain_id__in=removed_domain_ids, user=member).delete()
-
+                self._process_added_domains(added_domain_ids, member)
+                self._process_removed_domains(removed_domain_ids, member)
                 messages.success(request, "The domain assignment changes have been saved.")
                 return redirect(reverse("member-domains", kwargs={"pk": pk}))
-
             except IntegrityError:
                 messages.error(request, "A database error occurred while saving changes.")
                 return redirect(reverse("member-domains-edit", kwargs={"pk": pk}))
-
             except Exception as e:
                 messages.error(request, f"An unexpected error occurred: {str(e)}")
                 return redirect(reverse("member-domains-edit", kwargs={"pk": pk}))
@@ -271,6 +253,34 @@ class PortfolioMemberDomainsEditView(PortfolioMemberDomainsEditPermissionView, V
             messages.info(request, "No changes detected.")
             return redirect(reverse("member-domains", kwargs={"pk": pk}))
 
+    def _parse_domain_ids(self, domain_data, domain_type):
+        """
+        Parses the domain IDs from the request and handles JSON errors.
+        """
+        try:
+            return json.loads(domain_data) if domain_data else []
+        except json.JSONDecodeError:
+            messages.error(self.request, f"Invalid data for {domain_type}.")
+            return None
+
+    def _process_added_domains(self, added_domain_ids, member):
+        """
+        Processes added domains by bulk creating UserDomainRole instances.
+        """
+        if added_domain_ids:
+            # Bulk create UserDomainRole instances for added domains
+            UserDomainRole.objects.bulk_create(
+                [UserDomainRole(domain_id=domain_id, user=member) for domain_id in added_domain_ids],
+                ignore_conflicts=True,  # Avoid duplicate entries
+            )
+
+    def _process_removed_domains(self, removed_domain_ids, member):
+        """
+        Processes removed domains by deleting corresponding UserDomainRole instances.
+        """
+        if removed_domain_ids:
+            # Delete UserDomainRole instances for removed domains
+            UserDomainRole.objects.filter(domain_id__in=removed_domain_ids, user=member).delete()
 
 
 class PortfolioInvitedMemberView(PortfolioMemberPermissionView, View):
@@ -396,78 +406,91 @@ class PortfolioInvitedMemberDomainsEditView(PortfolioMemberDomainsEditPermission
                 "portfolio_invitation": portfolio_invitation,
             },
         )
-    
+
     def post(self, request, pk):
         """
         Handles adding and removing domains for a portfolio invitee.
-
-        Instead of deleting DomainInvitations, we move their status to CANCELED.
-        Instead of adding DomainIncitations, we first do a lookup and if the invite exists
-        we change its status to INVITED, otherwise we do a create.
         """
         added_domains = request.POST.get("added_domains")
         removed_domains = request.POST.get("removed_domains")
         portfolio_invitation = get_object_or_404(PortfolioInvitation, pk=pk)
         email = portfolio_invitation.email
 
-        try:
-            added_domain_ids = json.loads(added_domains) if added_domains else []
-        except json.JSONDecodeError:
-            messages.error(request, "Invalid data for added domains.")
-            return redirect(reverse("member-domains", kwargs={"pk": pk}))
+        added_domain_ids = self._parse_domain_ids(added_domains, "added domains")
+        if added_domain_ids is None:
+            return redirect(reverse("invitedmember-domains", kwargs={"pk": pk}))
 
-        try:
-            removed_domain_ids = json.loads(removed_domains) if removed_domains else []
-        except json.JSONDecodeError:
-            messages.error(request, "Invalid data for removed domains.")
-            return redirect(reverse("member-domains", kwargs={"pk": pk}))
+        removed_domain_ids = self._parse_domain_ids(removed_domains, "removed domains")
+        if removed_domain_ids is None:
+            return redirect(reverse("invitedmember-domains", kwargs={"pk": pk}))
 
         if added_domain_ids or removed_domain_ids:
             try:
-                if added_domain_ids:
-                    # Get existing invitations for the added domains
-                    existing_invitations = DomainInvitation.objects.filter(
-                        domain_id__in=added_domain_ids, email=email
-                    )
-                    
-                    # Update existing invitations from CANCELED to INVITED
-                    existing_invitations.update(status=DomainInvitation.DomainInvitationStatus.INVITED)
-
-                    # Determine which domains need new invitations
-                    existing_domain_ids = existing_invitations.values_list("domain_id", flat=True)
-                    new_domain_ids = set(added_domain_ids) - set(existing_domain_ids)
-
-                    # Bulk create new invitations for domains without existing invitations
-                    DomainInvitation.objects.bulk_create(
-                        [
-                            DomainInvitation(
-                                domain_id=domain_id,
-                                email=email,
-                                status=DomainInvitation.DomainInvitationStatus.INVITED,
-                            )
-                            for domain_id in new_domain_ids
-                        ]
-                    )
-
-                if removed_domain_ids:
-                    # Bulk update invitations for removed domains from INVITED to CANCELED
-                    DomainInvitation.objects.filter(
-                        domain_id__in=removed_domain_ids, email=email, status=DomainInvitation.DomainInvitationStatus.INVITED
-                    ).update(status=DomainInvitation.DomainInvitationStatus.CANCELED)
-        
+                self._process_added_domains(added_domain_ids, email)
+                self._process_removed_domains(removed_domain_ids, email)
                 messages.success(request, "The domain assignment changes have been saved.")
                 return redirect(reverse("invitedmember-domains", kwargs={"pk": pk}))
-
             except IntegrityError:
                 messages.error(request, "A database error occurred while saving changes.")
                 return redirect(reverse("invitedmember-domains-edit", kwargs={"pk": pk}))
-
             except Exception as e:
                 messages.error(request, f"An unexpected error occurred: {str(e)}")
                 return redirect(reverse("invitedmember-domains-edit", kwargs={"pk": pk}))
         else:
             messages.info(request, "No changes detected.")
             return redirect(reverse("invitedmember-domains", kwargs={"pk": pk}))
+
+    def _parse_domain_ids(self, domain_data, domain_type):
+        """
+        Parses the domain IDs from the request and handles JSON errors.
+        """
+        try:
+            return json.loads(domain_data) if domain_data else []
+        except json.JSONDecodeError:
+            messages.error(self.request, f"Invalid data for {domain_type}.")
+            return None
+
+    def _process_added_domains(self, added_domain_ids, email):
+        """
+        Processes added domain invitations by updating existing invitations
+        or creating new ones.
+        """
+        if not added_domain_ids:
+            return
+
+        # Update existing invitations from CANCELED to INVITED
+        existing_invitations = DomainInvitation.objects.filter(domain_id__in=added_domain_ids, email=email)
+        existing_invitations.update(status=DomainInvitation.DomainInvitationStatus.INVITED)
+
+        # Determine which domains need new invitations
+        existing_domain_ids = existing_invitations.values_list("domain_id", flat=True)
+        new_domain_ids = set(added_domain_ids) - set(existing_domain_ids)
+
+        # Bulk create new invitations
+        DomainInvitation.objects.bulk_create(
+            [
+                DomainInvitation(
+                    domain_id=domain_id,
+                    email=email,
+                    status=DomainInvitation.DomainInvitationStatus.INVITED,
+                )
+                for domain_id in new_domain_ids
+            ]
+        )
+
+    def _process_removed_domains(self, removed_domain_ids, email):
+        """
+        Processes removed domain invitations by updating their status to CANCELED.
+        """
+        if not removed_domain_ids:
+            return
+
+        # Update invitations from INVITED to CANCELED
+        DomainInvitation.objects.filter(
+            domain_id__in=removed_domain_ids,
+            email=email,
+            status=DomainInvitation.DomainInvitationStatus.INVITED,
+        ).update(status=DomainInvitation.DomainInvitationStatus.CANCELED)
 
 
 class PortfolioNoDomainsView(NoPortfolioDomainsPermissionView, View):

--- a/src/registrar/views/portfolios.py
+++ b/src/registrar/views/portfolios.py
@@ -15,6 +15,7 @@ from registrar.models.user_domain_role import UserDomainRole
 from registrar.models.user_portfolio_permission import UserPortfolioPermission
 from registrar.models.utility.portfolio_helper import UserPortfolioPermissionChoices, UserPortfolioRoleChoices
 from registrar.utility.email import EmailSendingError
+from registrar.utility.enums import DefaultUserValues
 from registrar.views.utility.mixins import PortfolioMemberPermission
 from registrar.views.utility.permission_views import (
     PortfolioDomainRequestsPermissionView,
@@ -250,10 +251,18 @@ class PortfolioMemberDomainsEditView(PortfolioMemberDomainsEditPermissionView, V
                 messages.success(request, "The domain assignment changes have been saved.")
                 return redirect(reverse("member-domains", kwargs={"pk": pk}))
             except IntegrityError:
-                messages.error(request, "A database error occurred while saving changes.")
+                messages.error(
+                    request,
+                    f"A database error occurred while saving changes. If the issue persists, please contact {DefaultUserValues.HELP_EMAIL}",
+                )
+                logger.error("A database error occurred while saving changes.")
                 return redirect(reverse("member-domains-edit", kwargs={"pk": pk}))
             except Exception as e:
-                messages.error(request, f"An unexpected error occurred: {str(e)}")
+                messages.error(
+                    request,
+                    f"An unexpected error occurred: {str(e)}. If the issue persists, please contact {DefaultUserValues.HELP_EMAIL}",
+                )
+                logger.error(f"An unexpected error occurred: {str(e)}")
                 return redirect(reverse("member-domains-edit", kwargs={"pk": pk}))
         else:
             messages.info(request, "No changes detected.")
@@ -266,7 +275,11 @@ class PortfolioMemberDomainsEditView(PortfolioMemberDomainsEditPermissionView, V
         try:
             return json.loads(domain_data) if domain_data else []
         except json.JSONDecodeError:
-            messages.error(self.request, f"Invalid data for {domain_type}.")
+            messages.error(
+                self.request,
+                f"Invalid data for {domain_type}. If the issue persists, please contact {DefaultUserValues.HELP_EMAIL}",
+            )
+            logger.error(f"Invalid data for {domain_type}")
             return None
 
     def _process_added_domains(self, added_domain_ids, member):
@@ -438,10 +451,18 @@ class PortfolioInvitedMemberDomainsEditView(PortfolioMemberDomainsEditPermission
                 messages.success(request, "The domain assignment changes have been saved.")
                 return redirect(reverse("invitedmember-domains", kwargs={"pk": pk}))
             except IntegrityError:
-                messages.error(request, "A database error occurred while saving changes.")
+                messages.error(
+                    request,
+                    f"A database error occurred while saving changes. If the issue persists, please contact {DefaultUserValues.HELP_EMAIL}.",
+                )
+                logger.error(f"A database error occurred while saving changes.")
                 return redirect(reverse("invitedmember-domains-edit", kwargs={"pk": pk}))
             except Exception as e:
-                messages.error(request, f"An unexpected error occurred: {str(e)}")
+                messages.error(
+                    request,
+                    f"An unexpected error occurred: {str(e)}. If the issue persists, please contact {DefaultUserValues.HELP_EMAIL}",
+                )
+                logger.error(f"An unexpected error occurred: {str(e)}.")
                 return redirect(reverse("invitedmember-domains-edit", kwargs={"pk": pk}))
         else:
             messages.info(request, "No changes detected.")
@@ -454,7 +475,11 @@ class PortfolioInvitedMemberDomainsEditView(PortfolioMemberDomainsEditPermission
         try:
             return json.loads(domain_data) if domain_data else []
         except json.JSONDecodeError:
-            messages.error(self.request, f"Invalid data for {domain_type}.")
+            messages.error(
+                self.request,
+                f"Invalid data for {domain_type}. If the issue persists, please contact {DefaultUserValues.HELP_EMAIL}.",
+            )
+            logger.error(f"Invalid data for {domain_type}.")
             return None
 
     def _process_added_domains(self, added_domain_ids, email):

--- a/src/registrar/views/portfolios.py
+++ b/src/registrar/views/portfolios.py
@@ -279,7 +279,7 @@ class PortfolioMemberDomainsEditView(PortfolioMemberDomainsEditPermissionView, V
         except json.JSONDecodeError:
             messages.error(
                 self.request,
-                "Invalid data for {domain_type}. If the issue persists, "
+                f"Invalid data for {domain_type}. If the issue persists, "
                 f"please contact {DefaultUserValues.HELP_EMAIL}.",
             )
             logger.error(f"Invalid data for {domain_type}")
@@ -485,7 +485,7 @@ class PortfolioInvitedMemberDomainsEditView(PortfolioMemberDomainsEditPermission
         except json.JSONDecodeError:
             messages.error(
                 self.request,
-                "Invalid data for {domain_type}. If the issue persists, "
+                f"Invalid data for {domain_type}. If the issue persists, "
                 f"please contact {DefaultUserValues.HELP_EMAIL}.",
             )
             logger.error(f"Invalid data for {domain_type}.")

--- a/src/registrar/views/portfolios.py
+++ b/src/registrar/views/portfolios.py
@@ -253,14 +253,16 @@ class PortfolioMemberDomainsEditView(PortfolioMemberDomainsEditPermissionView, V
             except IntegrityError:
                 messages.error(
                     request,
-                    f"A database error occurred while saving changes. If the issue persists, please contact {DefaultUserValues.HELP_EMAIL}",
+                    "A database error occurred while saving changes. If the issue persists, "
+                    f"please contact {DefaultUserValues.HELP_EMAIL}.",
                 )
                 logger.error("A database error occurred while saving changes.")
                 return redirect(reverse("member-domains-edit", kwargs={"pk": pk}))
             except Exception as e:
                 messages.error(
                     request,
-                    f"An unexpected error occurred: {str(e)}. If the issue persists, please contact {DefaultUserValues.HELP_EMAIL}",
+                    "An unexpected error occurred: {str(e)}. If the issue persists, "
+                    f"please contact {DefaultUserValues.HELP_EMAIL}.",
                 )
                 logger.error(f"An unexpected error occurred: {str(e)}")
                 return redirect(reverse("member-domains-edit", kwargs={"pk": pk}))
@@ -277,7 +279,8 @@ class PortfolioMemberDomainsEditView(PortfolioMemberDomainsEditPermissionView, V
         except json.JSONDecodeError:
             messages.error(
                 self.request,
-                f"Invalid data for {domain_type}. If the issue persists, please contact {DefaultUserValues.HELP_EMAIL}",
+                "Invalid data for {domain_type}. If the issue persists, "
+                f"please contact {DefaultUserValues.HELP_EMAIL}.",
             )
             logger.error(f"Invalid data for {domain_type}")
             return None
@@ -453,14 +456,16 @@ class PortfolioInvitedMemberDomainsEditView(PortfolioMemberDomainsEditPermission
             except IntegrityError:
                 messages.error(
                     request,
-                    f"A database error occurred while saving changes. If the issue persists, please contact {DefaultUserValues.HELP_EMAIL}.",
+                    "A database error occurred while saving changes. If the issue persists, "
+                    f"please contact {DefaultUserValues.HELP_EMAIL}.",
                 )
-                logger.error(f"A database error occurred while saving changes.")
+                logger.error("A database error occurred while saving changes.")
                 return redirect(reverse("invitedmember-domains-edit", kwargs={"pk": pk}))
             except Exception as e:
                 messages.error(
                     request,
-                    f"An unexpected error occurred: {str(e)}. If the issue persists, please contact {DefaultUserValues.HELP_EMAIL}",
+                    "An unexpected error occurred: {str(e)}. If the issue persists, "
+                    f"please contact {DefaultUserValues.HELP_EMAIL}.",
                 )
                 logger.error(f"An unexpected error occurred: {str(e)}.")
                 return redirect(reverse("invitedmember-domains-edit", kwargs={"pk": pk}))
@@ -477,7 +482,8 @@ class PortfolioInvitedMemberDomainsEditView(PortfolioMemberDomainsEditPermission
         except json.JSONDecodeError:
             messages.error(
                 self.request,
-                f"Invalid data for {domain_type}. If the issue persists, please contact {DefaultUserValues.HELP_EMAIL}.",
+                "Invalid data for {domain_type}. If the issue persists, "
+                f"please contact {DefaultUserValues.HELP_EMAIL}.",
             )
             logger.error(f"Invalid data for {domain_type}.")
             return None


### PR DESCRIPTION
## Ticket

<!-- PR title format: `#issue_number: Descriptive name ideally matching ticket name - [sandbox]`-->
Resolves #2853 

## Changes

<!-- What was added, updated, or removed in this PR. -->
- The review button toggles between the ajax table and a rendered read only view with a save button
- The breadcrumbs reflect the router config
- Save triggers a form submit with the removed and added domains
- Backend ajax endpoint
- Instead of deleting DomainInvitations, we move their status to CANCELED (new AC)
- Instead of adding DomainIncitations, we first do a lookup and if the invite exists we change its status to INVITED, otherwise we do a create (new AC)
- On success response, trigger a render of the readonly domains list with a trigger that activates a generic success message: The domain assignment changes have been saved. (redirect in JS after we get the ajax response)
- On error response, trigger a render of the edit page with a generic error message
- Clicking "go back" takes you to the "Edit domain assignments page"
- Unit tests

<!--
    Please add/remove/edit any of the template below to fit the needs
    of this specific PR.
--->

## Context for reviewers

<!--Background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers.  -->

## Setup

<!--  Add any steps or code to run in this section to help others run your code.
    
    Example 1:
    ```sh
    echo "Code goes here"
    ``` 
    
    Example 2: If the PR was to add a new link with a redirect, this section could simply be:
    -go to /path/to/start/page
    -click the blue link in the <insert location>
    -notice user is redirected to <proper end location>
-->

Make sure you test on a portfolio member and on an invited 'user'.
For the invited user, test that an existing invite flips between CANCELED and INVITED (a non-existing will get created).

## Code Review Verification Steps

### As the original developer, I have

#### Satisfied acceptance criteria and met development standards

- [x] Met the acceptance criteria, or will meet them in a subsequent PR
- [x] Created/modified automated tests
- [x] Update documentation in READMEs and/or onboarding guide

#### Ensured code standards are met (Original Developer)
<!-- Mark "- N/A" and check at the end of each check that is not applicable to your PR -->
- [x] If any updated dependencies on Pipfile, also update dependencies in requirements.txt.
- [x] Interactions with external systems are wrapped in try/except
- [x] Error handling exists for unusual or missing values

#### Validated user-facing changes (if applicable)

- [x] Tag @dotgov-designers in this PR's Reviewers for design review. If code is not user-facing, delete design reviewer checklist
- [x] Verify new pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [x] Checked keyboard navigability
- [x] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)

### As a code reviewer, I have

#### Reviewed, tested, and left feedback about the changes

- [x] Pulled this branch locally and tested it
- [x] Verified code meets all checks above. Address any checks that are not satisfied
- [x] Reviewed this code and left comments. Indicate if comments must be addressed before code is merged
- [x] Checked that all code is adequately covered by tests
- [x] Verify migrations are valid and do not conflict with existing migrations

#### Validated user-facing changes as a developer
**Note:** Multiple code reviewers can share the checklists above, a second reviewer should not make a duplicate checklist. All checks should be checked before approving, even those labeled N/A. 

- [x] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [x] Checked keyboard navigability
- [x] Meets all designs and user flows provided by design/product
- [x] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)
- [x] (Rarely needed) Tested as both an analyst and applicant user

### As a designer reviewer, I have

#### Verified that the changes match the design intention

- [ ] Checked that the design translated visually
- [ ] Checked behavior. Comment any found issues or broken flows.
- [ ] Checked different states (empty, one, some, error)
- [ ] Checked for landmarks, page heading structure, and links

#### Validated user-facing changes as a designer

- [ ] Checked keyboard navigability
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)
- [ ] Tested with multiple browsers (check off which ones were used)
  - [ ] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari
- [ ] (Rarely needed) Tested as both an analyst and applicant user

### References
- [Code review best practices](../docs/dev-practices/code_review.md)

## Screenshots

<!-- If this PR makes visible interface changes, an image of the finished interface can help reviewers
and casual observers understand the context of the changes.
A before image is optional and can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow.
You may want to use [GIPHY Capture](https://giphy.com/apps/giphycapture) for this! 📸

_Please frame images to show useful context but also highlight the affected regions._
--->
