### PR TITLE
#3149: Bundle - 2 tickets related to request form compliance testing why tests failing in pipeline [NO SANDBOX]

### DIFF
--- a/src/registrar/assets/src/js/getgov/domain-dnssec.js
+++ b/src/registrar/assets/src/js/getgov/domain-dnssec.js
@@ -1,0 +1,15 @@
+import { submitForm } from './helpers.js';
+
+export function initDomainDNSSEC() {
+    document.addEventListener('DOMContentLoaded', function() {
+        let domain_dnssec_page = document.getElementById("domain-dnssec");
+        if (domain_dnssec_page) {
+            const button = document.getElementById("disable-dnssec-button");
+            if (button) {
+                button.addEventListener("click", function () {
+                    submitForm("disable-dnssec-form");
+                });
+            }
+        }
+    });
+}

--- a/src/registrar/assets/src/js/getgov/domain-dsdata.js
+++ b/src/registrar/assets/src/js/getgov/domain-dsdata.js
@@ -1,0 +1,27 @@
+import { submitForm } from './helpers.js';
+
+export function initDomainDSData() {
+    document.addEventListener('DOMContentLoaded', function() {
+        let domain_dsdata_page = document.getElementById("domain-dsdata");
+        if (domain_dsdata_page) {
+            const override_button = document.getElementById("disable-override-click-button");
+            const cancel_button = document.getElementById("btn-cancel-click-button");
+            const cancel_close_button = document.getElementById("btn-cancel-click-close-button");
+            if (override_button) {
+                override_button.addEventListener("click", function () {
+                    submitForm("disable-override-click-form");
+                });
+            }
+            if (cancel_button) {
+                cancel_button.addEventListener("click", function () {
+                    submitForm("btn-cancel-click-form");
+                });
+            } 
+            if (cancel_close_button) {
+                cancel_close_button.addEventListener("click", function () {
+                    submitForm("btn-cancel-click-form");
+                });
+            } 
+        }
+    });
+}

--- a/src/registrar/assets/src/js/getgov/domain-managers.js
+++ b/src/registrar/assets/src/js/getgov/domain-managers.js
@@ -1,0 +1,20 @@
+import { submitForm } from './helpers.js';
+
+export function initDomainManagersPage() {
+    document.addEventListener('DOMContentLoaded', function() {
+        let domain_managers_page = document.getElementById("domain-managers");
+        if (domain_managers_page) {
+            // Add event listeners for all buttons matching user-delete-button-{NUMBER}
+            const deleteButtons = document.querySelectorAll('[id^="user-delete-button-"]'); // Select buttons with ID starting with "user-delete-button-"
+            deleteButtons.forEach((button) => {
+                const buttonId = button.id; // e.g., "user-delete-button-1"
+                const number = buttonId.split('-').pop(); // Extract the NUMBER part
+                const formId = `user-delete-form-${number}`; // Generate the corresponding form ID
+                
+                button.addEventListener("click", function () {
+                    submitForm(formId); // Pass the form ID to submitForm
+                });
+            });
+        } 
+    });
+}

--- a/src/registrar/assets/src/js/getgov/domain-request-form.js
+++ b/src/registrar/assets/src/js/getgov/domain-request-form.js
@@ -1,0 +1,12 @@
+import { submitForm } from './helpers.js';
+
+export function initDomainRequestForm() {
+    document.addEventListener('DOMContentLoaded', function() {
+        const button = document.getElementById("domain-request-form-submit-button");
+        if (button) {
+            button.addEventListener("click", function () {
+                submitForm("submit-domain-request-form");
+            });
+        } 
+    });
+}

--- a/src/registrar/assets/src/js/getgov/form-errors.js
+++ b/src/registrar/assets/src/js/getgov/form-errors.js
@@ -1,0 +1,19 @@
+export function initFormErrorHandling() {
+  document.addEventListener('DOMContentLoaded', function() {
+    const errorSummary = document.getElementById('form-errors');
+    const firstErrorField = document.querySelector('.usa-input--error');
+    if (firstErrorField) {
+      // Scroll to the first field in error
+      firstErrorField.scrollIntoView({ behavior: 'smooth', block: 'center' });
+  
+      // Add focus to the first field in error
+      setTimeout(() => {
+        firstErrorField.focus();
+      }, 50);
+    } else if (errorSummary) {
+      // Focus on the error summary for screen reader users
+      errorSummary.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    }
+
+  });
+}

--- a/src/registrar/assets/src/js/getgov/helpers.js
+++ b/src/registrar/assets/src/js/getgov/helpers.js
@@ -75,3 +75,17 @@ export function debounce(handler, cooldown=600) {
 export function getCsrfToken() {
     return document.querySelector('input[name="csrfmiddlewaretoken"]').value;
 }
+
+/**
+ * Helper function to submit a form
+ * @param {} form_id - the id of the form to be submitted
+ */
+export function submitForm(form_id) {
+    let form = document.getElementById(form_id);
+    if (form) {
+        console.log("submitting form");
+        form.submit();
+    } else {
+        console.error("Form '" + form_id + "' not found.");
+    }
+}

--- a/src/registrar/assets/src/js/getgov/main.js
+++ b/src/registrar/assets/src/js/getgov/main.js
@@ -15,6 +15,7 @@ import { initDomainRequestForm } from './domain-request-form.js';
 import { initDomainManagersPage } from './domain-managers.js';
 import { initDomainDSData } from './domain-dsdata.js';
 import { initDomainDNSSEC } from './domain-dnssec.js';
+import { initFormErrorHandling } from './form-errors.js';
 
 initDomainValidators();
 
@@ -45,8 +46,9 @@ initDomainManagersPage();
 initDomainDSData();
 initDomainDNSSEC();
 
+initFormErrorHandling();
+
 // Init the portfolio new member page
 initPortfolioMemberPageRadio();
 initPortfolioNewMemberPageToggle();
 initAddNewMemberPageListeners();
-//ignore, testing why test fails in pipeline

--- a/src/registrar/assets/src/js/getgov/main.js
+++ b/src/registrar/assets/src/js/getgov/main.js
@@ -40,3 +40,4 @@ initEditMemberDomainsTable();
 initPortfolioMemberPageRadio();
 initPortfolioNewMemberPageToggle();
 initAddNewMemberPageListeners();
+//ignore, testing why test fails in pipeline

--- a/src/registrar/assets/src/js/getgov/main.js
+++ b/src/registrar/assets/src/js/getgov/main.js
@@ -11,6 +11,10 @@ import { initMembersTable } from './table-members.js';
 import { initMemberDomainsTable } from './table-member-domains.js';
 import { initEditMemberDomainsTable } from './table-edit-member-domains.js';
 import { initPortfolioNewMemberPageToggle, initAddNewMemberPageListeners, initPortfolioMemberPageRadio } from './portfolio-member-page.js';
+import { initDomainRequestForm } from './domain-request-form.js';
+import { initDomainManagersPage } from './domain-managers.js';
+import { initDomainDSData } from './domain-dsdata.js';
+import { initDomainDNSSEC } from './domain-dnssec.js';
 
 initDomainValidators();
 
@@ -35,6 +39,11 @@ initDomainRequestsTable();
 initMembersTable();
 initMemberDomainsTable();
 initEditMemberDomainsTable();
+
+initDomainRequestForm();
+initDomainManagersPage();
+initDomainDSData();
+initDomainDNSSEC();
 
 // Init the portfolio new member page
 initPortfolioMemberPageRadio();

--- a/src/registrar/templates/domain_dnssec.html
+++ b/src/registrar/templates/domain_dnssec.html
@@ -27,7 +27,7 @@
   {% endif %}
   {% endblock breadcrumb %}
 
-  <h1>DNSSEC</h1>
+  <h1 id="domain-dnssec">DNSSEC</h1>
 
   <p>DNSSEC, or DNS Security Extensions, is an additional security layer to protect your website. Enabling DNSSEC ensures that when someone visits your domain, they can be certain that it’s connecting to the correct server, preventing potential hijacking or tampering with your domain's records.</p>
 
@@ -78,7 +78,11 @@
     aria-labelledby="Are you sure you want to continue?"
     aria-describedby="Your DNSSEC records will be deleted from the registry."
   >
-      {% include 'includes/modal.html' with modal_heading="Are you sure you want to disable DNSSEC?" modal_button=modal_button|safe %}
+      {% include 'includes/modal.html' with modal_heading="Are you sure you want to disable DNSSEC?" modal_button_id="disable-dnssec-button" modal_button_text="Confirm" modal_button_class="usa-button--secondary" %}
   </div>
+  <form method="post" id="disable-dnssec-form">
+    {% csrf_token %}
+    <input type="hidden" name="disable_dnssec" value="1">
+  </form>
 
 {% endblock %}  {# domain_content #}

--- a/src/registrar/templates/domain_dsdata.html
+++ b/src/registrar/templates/domain_dsdata.html
@@ -42,7 +42,7 @@
     {% include "includes/form_errors.html" with form=form %}
   {% endfor %}
 
-  <h1>DS data</h1>
+  <h1 id="domain-dsdata">DS data</h1>
 
   <p>In order to enable DNSSEC, you must first configure it with your DNS hosting service.</p>
 
@@ -141,7 +141,15 @@
     aria-describedby="Your DNSSEC records will be deleted from the registry."
     data-force-action
   >
-      {% include 'includes/modal.html' with cancel_button_resets_ds_form=True modal_heading="Warning: You are about to remove all DS records on your domain." modal_description="To fully disable DNSSEC: In addition to removing your DS records here, you’ll need to delete the DS records at your DNS host. To avoid causing your domain to appear offline, you should wait to delete your DS records at your DNS host until the Time to Live (TTL) expires. This is often less than 24 hours, but confirm with your provider." modal_button=modal_button|safe %}
+      {% include 'includes/modal.html' with cancel_button_resets_ds_form=True modal_heading="Warning: You are about to remove all DS records on your domain." modal_description="To fully disable DNSSEC: In addition to removing your DS records here, you’ll need to delete the DS records at your DNS host. To avoid causing your domain to appear offline, you should wait to delete your DS records at your DNS host until the Time to Live (TTL) expires. This is often less than 24 hours, but confirm with your provider." modal_button_id="disable-override-click-button" modal_button_text="Remove all DS data" modal_button_class="usa-button--secondary" %}
   </div>
+  <form method="post" id="disable-override-click-form">
+    {% csrf_token %}
+    <input type="hidden" name="disable-override-click" value="1">
+  </form>
+  <form method="post" id="btn-cancel-click-form">
+    {% csrf_token %}
+    <input type="hidden" name="btn-cancel-click" value="1">
+  </form>
 
 {% endblock %}  {# domain_content #}

--- a/src/registrar/templates/domain_request_form.html
+++ b/src/registrar/templates/domain_request_form.html
@@ -130,8 +130,20 @@
           aria-describedby="Are you sure you want to submit a domain request?"
           data-force-action
         >
-            {% include 'includes/modal.html' with is_domain_request_form=True review_form_is_complete=review_form_is_complete modal_heading=modal_heading|safe modal_description=modal_description|safe modal_button=modal_button|safe %}
+          {% if review_form_is_complete %}
+            {% with modal_heading="You are about to submit a domain request for " domain_name_modal=requested_domain__name modal_description="Once you submit this request, you won’t be able to edit it until we review it. You’ll only be able to withdraw your request." modal_button_id="domain-request-form-submit-button" modal_button_text="Submit request" %}
+              {% include 'includes/modal.html' %}
+            {% endwith %}
+          {% else %}
+            {% with modal_heading="Your request form is incomplete" modal_description='This request cannot be submitted yet. Return to the request and visit the steps that are marked as "incomplete."' modal_button_text="Return to request" cancel_button_only=True %}
+              {% include 'includes/modal.html' %}
+            {% endwith %}
+          {% endif %}
         </div>
+
+        <form method="post" id="submit-domain-request-form">
+          {% csrf_token %}
+        </form>
 
 {% block after_form_content %}{% endblock %}
 

--- a/src/registrar/templates/domain_users.html
+++ b/src/registrar/templates/domain_users.html
@@ -49,7 +49,7 @@
   </ul>
 
   {% if domain_manager_roles %}
-  <section class="section-outlined">
+  <section class="section-outlined" id="domain-managers">
   <table class="usa-table usa-table--borderless usa-table--stacked dotgov-table--stacked dotgov-table">
     <h2 class> Domain managers </h2>
     <caption class="sr-only">Domain managers</caption>
@@ -89,12 +89,13 @@
             aria-describedby="You will be removed from this domain"
             data-force-action
             >
-              <form method="POST" action="{% url "domain-user-delete" pk=domain.id user_pk=item.permission.user.id %}">
-                {% with domain_name=domain.name|force_escape %}
-                  {% include 'includes/modal.html' with modal_heading="Are you sure you want to remove yourself as a domain manager?" modal_description="You will no longer be able to manage the domain <strong>"|add:domain_name|add:"</strong>."|safe modal_button=modal_button_self|safe %}
-                {% endwith %}
-              </form>
+              {% with domain_name=domain.name|force_escape counter_str=forloop.counter|stringformat:"s" %}
+                {% include 'includes/modal.html' with modal_heading="Are you sure you want to remove yourself as a domain manager?" modal_description="You will no longer be able to manage the domain <strong>"|add:domain_name|add:"</strong>."|safe modal_button_id="user-delete-button-"|add:counter_str|safe modal_button_text="Yes, remove myself" modal_button_class="usa-button--secondary" %}
+              {% endwith %}
             </div>
+            <form method="POST" id="user-delete-form-{{ forloop.counter }}" action="{% url "domain-user-delete" pk=domain.id user_pk=item.permission.user.id %}" >
+              {% csrf_token %}
+            </form>
           {% else %}
             <div
               class="usa-modal"
@@ -103,12 +104,13 @@
               aria-describedby="{{ item.permission.user.email }} will be removed"
               data-force-action
             >
-              <form method="POST" action="{% url "domain-user-delete" pk=domain.id user_pk=item.permission.user.id %}">
-                {% with email=item.permission.user.email|default:item.permission.user|force_escape domain_name=domain.name|force_escape %}
-                  {% include 'includes/modal.html' with modal_heading="Are you sure you want to remove " heading_value=email|add:"?" modal_description="<strong>"|add:email|add:"</strong> will no longer be able to manage the domain <strong>"|add:domain_name|add:"</strong>."|safe modal_button=modal_button|safe %}
-                {% endwith %}
-              </form>
+              {% with email=item.permission.user.email|default:item.permission.user|force_escape domain_name=domain.name|force_escape counter_str=forloop.counter|stringformat:"s" %}
+                {% include 'includes/modal.html' with modal_heading="Are you sure you want to remove " heading_value=email|add:"?" modal_description="<strong>"|add:email|add:"</strong> will no longer be able to manage the domain <strong>"|add:domain_name|add:"</strong>."|safe modal_button_id="user-delete-button-"|add:counter_str|safe modal_button_text="Yes, remove domain manager" modal_button_class="usa-button--secondary" %}
+              {% endwith %}
             </div>
+            <form method="POST" id="user-delete-form-{{ forloop.counter }}" action="{% url "domain-user-delete" pk=domain.id user_pk=item.permission.user.id %}">
+              {% csrf_token %}
+            </form>
           {% endif %}
         {% else %}
           <input 

--- a/src/registrar/templates/includes/form_errors.html
+++ b/src/registrar/templates/includes/form_errors.html
@@ -1,6 +1,7 @@
 {% if form.errors %}
+  <div id="form-errors">
   {% for error in form.non_field_errors %}
-    <div class="usa-alert usa-alert--error usa-alert--slim margin-bottom-2">
+    <div class="usa-alert usa-alert--error usa-alert--slim margin-bottom-2" role="alert">
     <div class="usa-alert__body">
     {{ error|escape }}
     </div>
@@ -14,5 +15,6 @@
       </div>
     </div>
   {% endfor %}
-{% endfor %}
+  {% endfor %}
+  </div>
 {% endif %}

--- a/src/registrar/templates/includes/modal.html
+++ b/src/registrar/templates/includes/modal.html
@@ -1,4 +1,5 @@
 {% load static form_helpers url_helpers %}
+{% load custom_filters %}
 
 <div class="usa-modal__content">
     <div class="usa-modal__main">
@@ -24,39 +25,49 @@
         <div class="usa-modal__footer">
             <ul class="usa-button-group">
                 <li class="usa-button-group__item">
-                    {% if not_form and modal_button %}
-                        {{ modal_button }}
+                    {% if cancel_button_only %}
+                        <button
+                            type="button"
+                            class="{{ modal_button_class|button_class }}"
+                            data-close-modal
+                        >
+                        {% if modal_button_text %}
+                            {{ modal_button_text }}
+                        {% else %}
+                            Cancel
+                        {% endif %}
+                    </button>
+                    {% elif modal_button_id and modal_button_text %}
+                        <button
+                            id="{{ modal_button_id }}"
+                            type="button"
+                            class="{{ modal_button_class|button_class }}"
+                        >
+                            {{ modal_button_text }}
+                        </button>
                     {% elif modal_button_url and modal_button_text %}
                         <a
                             href="{{ modal_button_url }}"
                             type="button"
-                            class="usa-button"
+                            class="{{ modal_button_class|button_class }}"
                         >
                             {{ modal_button_text }}
                         </a>
-                    {% else %}
-                        <form method="post">
-                            {% csrf_token %}
-                            {{ modal_button }}
-                        </form>
                     {% endif %}
                 </li>
                 <li class="usa-button-group__item">
                     {% comment %} The cancel button the DS form actually triggers a context change in the view,
                     in addition to being a close modal hook {% endcomment %}
                     {% if cancel_button_resets_ds_form %}
-                        <form method="post">
-                            {% csrf_token %}
-                            <button
-                                type="submit"
-                                class="usa-button usa-button--unstyled padding-105 text-center"
-                                name="btn-cancel-click"
-                                data-close-modal
-                            >
-                                Cancel
-                            </button>
-                        </form>
-                    {% elif not is_domain_request_form or review_form_is_complete %}
+                        <button
+                            type="submit"
+                            class="usa-button usa-button--unstyled padding-105 text-center"
+                            id="btn-cancel-click-button"
+                            data-close-modal
+                        >
+                            Cancel
+                        </button>
+                    {% elif not cancel_button_only %}
                         <button
                             type="button"
                             class="usa-button usa-button--unstyled padding-105 text-center"
@@ -72,20 +83,17 @@
     {% comment %} The cancel button the DS form actually triggers a context change in the view,
     in addition to being a close modal hook {% endcomment %}
     {% if cancel_button_resets_ds_form %}
-        <form method="post">
-            {% csrf_token %}
-            <button
-                type="submit"
-                class="usa-button usa-modal__close"
-                aria-label="Close this window"
-                name="btn-cancel-click"
-                data-close-modal
-            >
-                <svg class="usa-icon" aria-hidden="true" focusable="false" role="img">
-                    <use xlink:href="{%static 'img/sprite.svg'%}#close"></use>
-                </svg>
-            </button>
-        </form>
+        <button
+            type="submit"
+            class="usa-button usa-modal__close"
+            aria-label="Close this window"
+            id="btn-cancel-click-close-button"
+            data-close-modal
+        >
+            <svg class="usa-icon" aria-hidden="true" focusable="false" role="img">
+                <use xlink:href="{%static 'img/sprite.svg'%}#close"></use>
+            </svg>
+        </button>
     {% else %}
         <button
             type="button"

--- a/src/registrar/templatetags/custom_filters.py
+++ b/src/registrar/templatetags/custom_filters.py
@@ -290,3 +290,9 @@ def get_dict_value(dictionary, key):
     if isinstance(dictionary, dict):
         return dictionary.get(key, "")
     return ""
+
+
+@register.filter
+def button_class(custom_class):
+    default_class = "usa-button"
+    return f"{default_class} {custom_class}" if custom_class else default_class

--- a/src/registrar/views/domain.py
+++ b/src/registrar/views/domain.py
@@ -805,15 +805,6 @@ class DomainDNSSECView(DomainFormBaseView):
         context = super().get_context_data(**kwargs)
 
         has_dnssec_records = self.object.dnssecdata is not None
-
-        # Create HTML for the modal button
-        modal_button = (
-            '<button type="submit" '
-            'class="usa-button usa-button--secondary" '
-            'name="disable_dnssec">Confirm</button>'
-        )
-
-        context["modal_button"] = modal_button
         context["has_dnssec_records"] = has_dnssec_records
         context["dnssec_enabled"] = self.request.session.pop("dnssec_enabled", False)
 
@@ -906,15 +897,6 @@ class DomainDsDataView(DomainFormBaseView):
             # to preserve the context["form"]
             context = super().get_context_data(form=formset)
             context["trigger_modal"] = True
-            # Create HTML for the modal button
-            modal_button = (
-                '<button type="submit" '
-                'class="usa-button usa-button--secondary" '
-                'name="disable-override-click">Remove all DS data</button>'
-            )
-
-            # context to back out of a broken form on all fields delete
-            context["modal_button"] = modal_button
             return self.render_to_response(context)
 
         if formset.is_valid() or override:
@@ -1050,9 +1032,6 @@ class DomainUsersView(DomainBaseView):
         # Add conditionals to the context (such as "can_delete_users")
         context = self._add_booleans_to_context(context)
 
-        # Add modal buttons to the context (such as for delete)
-        context = self._add_modal_buttons_to_context(context)
-
         # Get portfolio from session (if set)
         portfolio = self.request.session.get("portfolio")
 
@@ -1147,26 +1126,6 @@ class DomainUsersView(DomainBaseView):
             can_delete_users = UserDomainRole.objects.filter(domain__id=domain_pk).count() > 1
 
         context["can_delete_users"] = can_delete_users
-        return context
-
-    def _add_modal_buttons_to_context(self, context):
-        """Adds modal buttons (and their HTML) to the context"""
-        # Create HTML for the modal button
-        modal_button = (
-            '<button type="submit" '
-            'class="usa-button usa-button--secondary" '
-            'name="delete_domain_manager">Yes, remove domain manager</button>'
-        )
-        context["modal_button"] = modal_button
-
-        # Create HTML for the modal button when deleting yourself
-        modal_button_self = (
-            '<button type="submit" '
-            'class="usa-button usa-button--secondary" '
-            'name="delete_domain_manager_self">Yes, remove myself</button>'
-        )
-        context["modal_button_self"] = modal_button_self
-
         return context
 
 

--- a/src/registrar/views/domain_request.py
+++ b/src/registrar/views/domain_request.py
@@ -448,34 +448,21 @@ class DomainRequestWizard(DomainRequestWizardPermissionView, TemplateView):
         non_org_steps_complete = DomainRequest._form_complete(self.domain_request, self.request)
         org_steps_complete = len(self.db_check_for_unlocking_steps()) == len(self.steps)
         if (not self.is_portfolio and non_org_steps_complete) or (self.is_portfolio and org_steps_complete):
-            modal_button = '<button type="submit" ' 'class="usa-button" ' ">Submit request</button>"
             context = {
-                "not_form": False,
                 "form_titles": self.titles,
                 "steps": self.steps,
                 "visited": self.storage.get("step_history", []),
                 "is_federal": self.domain_request.is_federal(),
-                "modal_button": modal_button,
-                "modal_heading": "You are about to submit a domain request for ",
-                "domain_name_modal": str(self.domain_request.requested_domain),
-                "modal_description": "Once you submit this request, you won’t be able to edit it until we review it.\
-                You’ll only be able to withdraw your request.",
                 "review_form_is_complete": True,
                 "user": self.request.user,
                 "requested_domain__name": requested_domain_name,
             }
         else:  # form is not complete
-            modal_button = '<button type="button" class="usa-button" data-close-modal>Return to request</button>'
             context = {
-                "not_form": True,
                 "form_titles": self.titles,
                 "steps": self.steps,
                 "visited": self.storage.get("step_history", []),
                 "is_federal": self.domain_request.is_federal(),
-                "modal_button": modal_button,
-                "modal_heading": "Your request form is incomplete",
-                "modal_description": 'This request cannot be submitted yet.\
-                Return to the request and visit the steps that are marked as "incomplete."',
                 "review_form_is_complete": False,
                 "user": self.request.user,
                 "requested_domain__name": requested_domain_name,


### PR DESCRIPTION
## Ticket

<!-- PR title format: `#issue_number: Descriptive name ideally matching ticket name - [sandbox]`-->
Resolves #3149 
Resolves #2908 
Resolves #2909 

## Changes

<!-- What was added, updated, or removed in this PR. -->
- Fixed modal focus trap in the following modals:
  - Domain request form
  - Domain Disable DNSSEC modal
  - Domain Delete DS Data modal
  - Remove domain manager modal
- Form error messages (both field-specific and general form errors) have role="alert" on their containing divs so that screen readers will read the error messages.
- When there are field specific error messages, focus is initially set to the first field with an error message, and that field is scrolled into view.
- When there are only general form error messages, the error message section is scrolled into view.
- These changes are app-wide, when dealing with forms. Tested on domain and domain-request forms.

<!--
    Please add/remove/edit any of the template below to fit the needs
    of this specific PR.
--->

## Context for reviewers

<!--Background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers.  -->
Focus trap context:
Focus trap is broken when there are inputs of type hidden within the modal. This is because the focusElements in uswds modal code does not exclude hidden inputs, causing the problem. An app pattern was to include forms within the modals, along with hidden csrf token. To fix the problem, instead, removing forms from the modals, and creating listeners for button clicks and submit forms through javascript.

To test, make sure each of these modals works as expected. And also if the focustrap works on each of these modals. DNSSEC and DS Data are the most involved ones to test as they require DS Data to be stored in the registry. These must be tested on a sandbox.

Error focus context:
When an element has the role="alert" attribute, the browser sends an accessible alert event to assistive technology products, such as screen readers. The screen reader then immediately announces the content of the updated element without moving the focus to the alert message.

Did not to make form level error messages focusable.


## Setup

<!--  Add any steps or code to run in this section to help others run your code.
    
    Example 1:
    ```sh
    echo "Code goes here"
    ``` 
    
    Example 2: If the PR was to add a new link with a redirect, this section could simply be:
    -go to /path/to/start/page
    -click the blue link in the <insert location>
    -notice user is redirected to <proper end location>
-->

## Code Review Verification Steps

### As the original developer, I have

#### Satisfied acceptance criteria and met development standards

- [x] Met the acceptance criteria, or will meet them in a subsequent PR
- [x] Created/modified automated tests
- [x] Update documentation in READMEs and/or onboarding guide

#### Ensured code standards are met (Original Developer)
<!-- Mark "- N/A" and check at the end of each check that is not applicable to your PR -->
- [x] If any updated dependencies on Pipfile, also update dependencies in requirements.txt.
- [x] Interactions with external systems are wrapped in try/except
- [x] Error handling exists for unusual or missing values

#### Validated user-facing changes (if applicable)

- [x] Tag @dotgov-designers in this PR's Reviewers for design review. If code is not user-facing, delete design reviewer checklist
- [x] Verify new pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [x] Checked keyboard navigability
- [x] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)

### As a code reviewer, I have

#### Reviewed, tested, and left feedback about the changes

- [ ] Pulled this branch locally and tested it
- [ ] Verified code meets all checks above. Address any checks that are not satisfied
- [ ] Reviewed this code and left comments. Indicate if comments must be addressed before code is merged
- [ ] Checked that all code is adequately covered by tests
- [ ] Verify migrations are valid and do not conflict with existing migrations

#### Validated user-facing changes as a developer
**Note:** Multiple code reviewers can share the checklists above, a second reviewer should not make a duplicate checklist. All checks should be checked before approving, even those labeled N/A. 

- [ ] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Checked keyboard navigability
- [ ] Meets all designs and user flows provided by design/product
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)
- [ ] (Rarely needed) Tested as both an analyst and applicant user

### As a designer reviewer, I have

#### Verified that the changes match the design intention

- [ ] Checked that the design translated visually
- [ ] Checked behavior. Comment any found issues or broken flows.
- [ ] Checked different states (empty, one, some, error)
- [ ] Checked for landmarks, page heading structure, and links

#### Validated user-facing changes as a designer

- [ ] Checked keyboard navigability
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)
- [ ] Tested with multiple browsers (check off which ones were used)
  - [ ] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari
- [ ] (Rarely needed) Tested as both an analyst and applicant user

### References
- [Code review best practices](../docs/dev-practices/code_review.md)

## Screenshots

<!-- If this PR makes visible interface changes, an image of the finished interface can help reviewers
and casual observers understand the context of the changes.
A before image is optional and can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow.
You may want to use [GIPHY Capture](https://giphy.com/apps/giphycapture) for this! 📸

_Please frame images to show useful context but also highlight the affected regions._
--->
