### PR TITLE
#3228: DJA - new domain invitations are auto retrieved when user exists [MEOWARD]

### DIFF
--- a/src/registrar/admin.py
+++ b/src/registrar/admin.py
@@ -1439,18 +1439,12 @@ class DomainInvitationAdmin(ListHeaderAdmin):
         Override the save_model method.
 
         On creation of a new domain invitation, attempt to retrieve the invitation,
-        which will be successful if a user exists for that email; otherwise, will
-        raise a RuntimeError, and in this case can continue to create the invitation.
+        which will be successful if a single User exists for that email; otherwise, will
+        just continue to create the invitation.
         """
-        # NOTE: is a future ticket accounting for a 'not member of this org' scenario
-        # to mirror the logic in DomainAddUser view?
-        if not change:  # Domain Invitation creation
-            try:
-                User.objects.get(email=obj.email)
-                obj.retrieve()
-            except User.DoesNotExist:
-                # Proceed with invitation as new as exception indicates user does not exist
-                pass
+        if not change and User.objects.filter(email=obj.email).count() == 1:
+            # Domain Invitation creation for an existing User
+            obj.retrieve()
         # Call the parent save method to save the object
         super().save_model(request, obj, form, change)
 

--- a/src/registrar/tests/test_admin.py
+++ b/src/registrar/tests/test_admin.py
@@ -131,13 +131,11 @@ class TestDomainInvitationAdmin(TestCase):
       tests have available superuser, client, and admin
     """
 
-    @classmethod
-    def setUpClass(cls):
-        cls.factory = RequestFactory()
-        cls.admin = ListHeaderAdmin(model=DomainInvitationAdmin, admin_site=AdminSite())
-        cls.superuser = create_superuser()
-
     def setUp(self):
+        self.factory = RequestFactory()
+        self.admin = ListHeaderAdmin(model=DomainInvitationAdmin, admin_site=AdminSite())
+        self.superuser = create_superuser()
+        self.domain = Domain.objects.create(name="example.com")
         """Create a client object"""
         self.client = Client(HTTP_HOST="localhost:8080")
 
@@ -145,9 +143,6 @@ class TestDomainInvitationAdmin(TestCase):
         """Delete all DomainInvitation objects"""
         DomainInvitation.objects.all().delete()
         Contact.objects.all().delete()
-
-    @classmethod
-    def tearDownClass(self):
         User.objects.all().delete()
 
     @less_console_noise_decorator
@@ -168,6 +163,7 @@ class TestDomainInvitationAdmin(TestCase):
         )
         self.assertContains(response, "Show more")
 
+    @less_console_noise_decorator
     def test_get_filters(self):
         """Ensures that our filters are displaying correctly"""
         with less_console_noise():
@@ -191,6 +187,59 @@ class TestDomainInvitationAdmin(TestCase):
 
             self.assertContains(response, invited_html, count=1)
             self.assertContains(response, retrieved_html, count=1)
+
+    @less_console_noise_decorator
+    def test_save_model_user_exists(self):
+        """Test saving a domain invitation when the user exists.
+        
+        Should attempt to retrieve the domain invitation."""
+        # Create a user with the same email
+        User.objects.create_user(email="test@example.com", password="password", username="username")
+
+        # Create a domain invitation instance
+        invitation = DomainInvitation(email="test@example.com", domain=self.domain)
+
+        admin_instance = DomainInvitationAdmin(DomainInvitation, admin_site=None)
+
+        # Create a request object
+        request = self.factory.post("/admin/registrar/DomainInvitation/add/")
+        request.user = self.superuser
+
+        # Patch the retrieve method
+        with patch.object(DomainInvitation, "retrieve") as mock_retrieve:
+            admin_instance.save_model(request, invitation, form=None, change=False)
+
+        # Assert retrieve was called
+        mock_retrieve.assert_called_once()
+
+        # Assert the invitation was saved
+        self.assertEqual(DomainInvitation.objects.count(), 1)
+        self.assertEqual(DomainInvitation.objects.first().email, "test@example.com")
+
+    @less_console_noise_decorator
+    def test_save_model_user_does_not_exist(self):
+        """Test saving a domain invitation when the user does not exist.
+        
+        Should not attempt to retrieve the domain invitation."""
+        # Create a domain invitation instance
+        invitation = DomainInvitation(email="nonexistent@example.com", domain=self.domain)
+
+        admin_instance = DomainInvitationAdmin(DomainInvitation, admin_site=None)
+
+        # Create a request object
+        request = self.factory.post("/admin/registrar/DomainInvitation/add/")
+        request.user = self.superuser
+
+        # Patch the retrieve method to ensure it is not called
+        with patch.object(DomainInvitation, "retrieve") as mock_retrieve:
+            admin_instance.save_model(request, invitation, form=None, change=False)
+
+        # Assert retrieve was not called
+        mock_retrieve.assert_not_called()
+
+        # Assert the invitation was saved
+        self.assertEqual(DomainInvitation.objects.count(), 1)
+        self.assertEqual(DomainInvitation.objects.first().email, "nonexistent@example.com")
 
 
 class TestUserPortfolioPermissionAdmin(TestCase):

--- a/src/registrar/tests/test_admin.py
+++ b/src/registrar/tests/test_admin.py
@@ -191,10 +191,10 @@ class TestDomainInvitationAdmin(TestCase):
     @less_console_noise_decorator
     def test_save_model_user_exists(self):
         """Test saving a domain invitation when the user exists.
-        
+
         Should attempt to retrieve the domain invitation."""
         # Create a user with the same email
-        User.objects.create_user(email="test@example.com", password="password", username="username")
+        User.objects.create_user(email="test@example.com", username="username")
 
         # Create a domain invitation instance
         invitation = DomainInvitation(email="test@example.com", domain=self.domain)
@@ -219,7 +219,7 @@ class TestDomainInvitationAdmin(TestCase):
     @less_console_noise_decorator
     def test_save_model_user_does_not_exist(self):
         """Test saving a domain invitation when the user does not exist.
-        
+
         Should not attempt to retrieve the domain invitation."""
         # Create a domain invitation instance
         invitation = DomainInvitation(email="nonexistent@example.com", domain=self.domain)


### PR DESCRIPTION

## Ticket

<!-- PR title format: `#issue_number: Descriptive name ideally matching ticket name - [sandbox]`-->
Resolves #3228 

## Changes

<!-- What was added, updated, or removed in this PR. -->
- Modified django admin, DomainInvitation save so that new DomainInvitations created through DJA are auto-retrieved if a user already exists
- This solution "solves" the problem in ticket #3228 in that all of the views for existing portfolio users will not need to look at both UserDomainRoles and DomainInvitations when displaying information about domains a portfolio user has access to. Instead, the views will only need to look at UserDomainRoles 

<!--
    Please add/remove/edit any of the template below to fit the needs
    of this specific PR.
--->

## Context for reviewers

<!--Background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers.  -->

## Setup

<!--  Add any steps or code to run in this section to help others run your code.
    
    Example 1:
    ```sh
    echo "Code goes here"
    ``` 
    
    Example 2: If the PR was to add a new link with a redirect, this section could simply be:
    -go to /path/to/start/page
    -click the blue link in the <insert location>
    -notice user is redirected to <proper end location>
-->

## Code Review Verification Steps

### As the original developer, I have

#### Satisfied acceptance criteria and met development standards

- [x] Met the acceptance criteria, or will meet them in a subsequent PR
- [x] Created/modified automated tests
- [x] Update documentation in READMEs and/or onboarding guide

#### Ensured code standards are met (Original Developer)
<!-- Mark "- N/A" and check at the end of each check that is not applicable to your PR -->
- [x] If any updated dependencies on Pipfile, also update dependencies in requirements.txt.
- [x] Interactions with external systems are wrapped in try/except
- [x] Error handling exists for unusual or missing values

#### Validated user-facing changes (if applicable)

- [x] Tag @dotgov-designers in this PR's Reviewers for design review. If code is not user-facing, delete design reviewer checklist
- [x] Verify new pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [x] Checked keyboard navigability
- [x] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)

### As a code reviewer, I have

#### Reviewed, tested, and left feedback about the changes

- [x] Pulled this branch locally and tested it
- [x] Verified code meets all checks above. Address any checks that are not satisfied
- [x] Reviewed this code and left comments. Indicate if comments must be addressed before code is merged
- [x] Checked that all code is adequately covered by tests
- [x] Verify migrations are valid and do not conflict with existing migrations

#### Validated user-facing changes as a developer
**Note:** Multiple code reviewers can share the checklists above, a second reviewer should not make a duplicate checklist. All checks should be checked before approving, even those labeled N/A. 

- [x] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [x] Checked keyboard navigability
- [x] Meets all designs and user flows provided by design/product
- [x] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)
- [x] (Rarely needed) Tested as both an analyst and applicant user

### As a designer reviewer, I have

#### Verified that the changes match the design intention

- [ ] Checked that the design translated visually
- [ ] Checked behavior. Comment any found issues or broken flows.
- [ ] Checked different states (empty, one, some, error)
- [ ] Checked for landmarks, page heading structure, and links

#### Validated user-facing changes as a designer

- [ ] Checked keyboard navigability
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)
- [ ] Tested with multiple browsers (check off which ones were used)
  - [ ] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari
- [ ] (Rarely needed) Tested as both an analyst and applicant user

### References
- [Code review best practices](../docs/dev-practices/code_review.md)

## Screenshots

<!-- If this PR makes visible interface changes, an image of the finished interface can help reviewers
and casual observers understand the context of the changes.
A before image is optional and can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow.
You may want to use [GIPHY Capture](https://giphy.com/apps/giphycapture) for this! 📸

_Please frame images to show useful context but also highlight the affected regions._
--->
