### PR TITLE
#2960: Domain invitation updates [DK]

### DIFF
--- a/src/registrar/admin.py
+++ b/src/registrar/admin.py
@@ -1520,7 +1520,7 @@ class DomainInvitationAdmin(BaseInvitationAdmin):
         """
         if not change:
             domain = obj.domain
-            domain_org = domain.domain_info.portfolio
+            domain_org = getattr(domain.domain_info, "portfolio", None)
             requested_email = obj.email
             # Look up a user with that email
             requested_user = get_requested_user(requested_email)
@@ -1536,6 +1536,7 @@ class DomainInvitationAdmin(BaseInvitationAdmin):
                     and not flag_is_active(request, "multiple_portfolios")
                     and domain_org is not None
                     and not member_of_this_org
+                    and not member_of_a_different_org
                 ):
                     send_portfolio_invitation_email(email=requested_email, requestor=requestor, portfolio=domain_org)
                     portfolio_invitation, _ = PortfolioInvitation.objects.get_or_create(

--- a/src/registrar/admin.py
+++ b/src/registrar/admin.py
@@ -1439,18 +1439,12 @@ class DomainInvitationAdmin(ListHeaderAdmin):
         Override the save_model method.
 
         On creation of a new domain invitation, attempt to retrieve the invitation,
-        which will be successful if a user exists for that email; otherwise, will
-        raise a RuntimeError, and in this case can continue to create the invitation.
+        which will be successful if a single User exists for that email; otherwise, will
+        just continue to create the invitation.
         """
-        # NOTE: is a future ticket accounting for a 'not member of this org' scenario
-        # to mirror the logic in DomainAddUser view?
-        if not change:  # Domain Invitation creation
-            try:
-                User.objects.get(email=obj.email)
-                obj.retrieve()
-            except User.DoesNotExist:
-                # Proceed with invitation as new as exception indicates user does not exist
-                pass
+        if not change and User.objects.filter(email=obj.email).count() == 1:
+            # Domain Invitation creation for an existing User
+            obj.retrieve()
         # Call the parent save method to save the object
         super().save_model(request, obj, form, change)
 

--- a/src/registrar/admin.py
+++ b/src/registrar/admin.py
@@ -1393,6 +1393,7 @@ class UserDomainRoleAdmin(ListHeaderAdmin, ImportExportModelAdmin):
 
         return super().changeform_view(request, object_id, form_url, extra_context=extra_context)
 
+
 class BaseInvitationAdmin(ListHeaderAdmin):
     """Base class for admin classes which will customize save_model and send email invitations
     on model adds, and require custom handling of forms and form errors."""
@@ -1542,6 +1543,7 @@ class DomainInvitationAdmin(BaseInvitationAdmin):
                         portfolio=domain_org,
                         roles=[UserPortfolioRoleChoices.ORGANIZATION_MEMBER],
                     )
+                    # if user exists for email, immediately retrieve portfolio invitation upon creation
                     if requested_user is not None:
                         portfolio_invitation.retrieve()
                         portfolio_invitation.save()
@@ -1552,7 +1554,7 @@ class DomainInvitationAdmin(BaseInvitationAdmin):
                     requestor=requestor,
                     domains=domain,
                     is_member_of_different_org=member_of_a_different_org,
-                    requested_user=requested_user
+                    requested_user=requested_user,
                 )
                 if requested_user is not None:
                     # Domain Invitation creation for an existing User
@@ -1639,6 +1641,7 @@ class PortfolioInvitationAdmin(BaseInvitationAdmin):
                 if not permission_exists:
                     # if permission does not exist for a user with requested_email, send email
                     send_portfolio_invitation_email(email=requested_email, requestor=requestor, portfolio=portfolio)
+                    # if user exists for email, immediately retrieve portfolio invitation upon creation
                     if requested_user is not None:
                         obj.retrieve()
                     messages.success(request, f"{requested_email} has been invited.")

--- a/src/registrar/admin.py
+++ b/src/registrar/admin.py
@@ -1480,8 +1480,9 @@ class DomainInvitationAdmin(ListHeaderAdmin):
                 send_domain_invitation_email(
                     email=requested_email,
                     requestor=requestor,
-                    domain=domain,
+                    domains=domain,
                     is_member_of_different_org=member_of_a_different_org,
+                    requested_user=requested_user
                 )
                 if requested_user is not None:
                     # Domain Invitation creation for an existing User

--- a/src/registrar/admin.py
+++ b/src/registrar/admin.py
@@ -14,6 +14,7 @@ from django.db.models import (
 from django.db.models.functions import Concat, Coalesce
 from django.http import HttpResponseRedirect
 from registrar.models.federal_agency import FederalAgency
+from registrar.models.portfolio_invitation import PortfolioInvitation
 from registrar.utility.admin_helpers import (
     AutocompleteSelectWithPlaceholder,
     get_action_needed_reason_default_email,
@@ -27,8 +28,12 @@ from django.shortcuts import redirect
 from django_fsm import get_available_FIELD_transitions, FSMField
 from registrar.models import DomainInformation, Portfolio, UserPortfolioPermission, DomainInvitation
 from registrar.models.utility.portfolio_helper import UserPortfolioPermissionChoices, UserPortfolioRoleChoices
-from registrar.utility.email import EmailSendingError
-from registrar.utility.email_invitations import send_portfolio_invitation_email
+from registrar.utility.email_invitations import send_domain_invitation_email, send_portfolio_invitation_email
+from registrar.views.utility.portfolio_helper import (
+    get_org_membership,
+    get_requested_user,
+    handle_invitation_exceptions,
+)
 from waffle.decorators import flag_is_active
 from django.contrib import admin, messages
 from django.contrib.auth.admin import UserAdmin as BaseUserAdmin
@@ -41,7 +46,7 @@ from waffle.admin import FlagAdmin
 from waffle.models import Sample, Switch
 from registrar.models import Contact, Domain, DomainRequest, DraftDomain, User, Website, SeniorOfficial
 from registrar.utility.constants import BranchChoices
-from registrar.utility.errors import FSMDomainRequestError, FSMErrorCodes, MissingEmailError
+from registrar.utility.errors import FSMDomainRequestError, FSMErrorCodes
 from registrar.utility.waffle import flag_is_active_for_user
 from registrar.views.utility.mixins import OrderableFieldsMixin
 from django.contrib.admin.views.main import ORDER_VAR
@@ -1442,11 +1447,108 @@ class DomainInvitationAdmin(ListHeaderAdmin):
         which will be successful if a single User exists for that email; otherwise, will
         just continue to create the invitation.
         """
-        if not change and User.objects.filter(email=obj.email).count() == 1:
-            # Domain Invitation creation for an existing User
-            obj.retrieve()
-        # Call the parent save method to save the object
-        super().save_model(request, obj, form, change)
+        if not change:
+            domain = obj.domain
+            domain_org = domain.domain_info.portfolio
+            requested_email = obj.email
+            # Look up a user with that email
+            requested_user = get_requested_user(requested_email)
+            requestor = request.user
+
+            member_of_a_different_org, member_of_this_org = get_org_membership(
+                domain_org, requested_email, requested_user
+            )
+
+            try:
+                if (
+                    flag_is_active(request, "organization_feature")
+                    and not flag_is_active(request, "multiple_portfolios")
+                    and domain_org is not None
+                    and not member_of_this_org
+                ):
+                    send_portfolio_invitation_email(email=requested_email, requestor=requestor, portfolio=domain_org)
+                    PortfolioInvitation.objects.get_or_create(
+                        email=requested_email,
+                        portfolio=domain_org,
+                        roles=[UserPortfolioRoleChoices.ORGANIZATION_MEMBER],
+                    )
+                    messages.success(request, f"{requested_email} has been invited to the organization: {domain_org}")
+
+                send_domain_invitation_email(
+                    email=requested_email,
+                    requestor=requestor,
+                    domain=domain,
+                    is_member_of_different_org=member_of_a_different_org,
+                )
+                if requested_user is not None:
+                    # Domain Invitation creation for an existing User
+                    obj.retrieve()
+                # Call the parent save method to save the object
+                super().save_model(request, obj, form, change)
+                messages.success(request, f"{requested_email} has been invited to the domain: {domain}")
+            except Exception as e:
+                handle_invitation_exceptions(request, e, requested_email)
+                return
+        else:
+            # Call the parent save method to save the object
+            super().save_model(request, obj, form, change)
+
+    def response_add(self, request, obj, post_url_continue=None):
+        """
+        Override response_add to handle rendering when exceptions are raised during add model.
+
+        Normal flow on successful save_model on add is to redirect to changelist_view.
+        If there are errors, flow is modified to instead render change form.
+        """
+        # Check if there are any error or warning messages in the `messages` framework
+        storage = get_messages(request)
+        has_errors = any(message.level_tag in ["error", "warning"] for message in storage)
+
+        if has_errors:
+            # Re-render the change form if there are errors or warnings
+            # Prepare context for rendering the change form
+
+            # Get the model form
+            ModelForm = self.get_form(request, obj=obj)
+            form = ModelForm(instance=obj)
+
+            # Create an AdminForm instance
+            admin_form = AdminForm(
+                form,
+                list(self.get_fieldsets(request, obj)),
+                self.get_prepopulated_fields(request, obj),
+                self.get_readonly_fields(request, obj),
+                model_admin=self,
+            )
+            media = self.media + form.media
+
+            opts = obj._meta
+            change_form_context = {
+                **self.admin_site.each_context(request),  # Add admin context
+                "title": f"Add {opts.verbose_name}",
+                "opts": opts,
+                "original": obj,
+                "save_as": self.save_as,
+                "has_change_permission": self.has_change_permission(request, obj),
+                "add": True,  # Indicate this is an "Add" form
+                "change": False,  # Indicate this is not a "Change" form
+                "is_popup": False,
+                "inline_admin_formsets": [],
+                "save_on_top": self.save_on_top,
+                "show_delete": self.has_delete_permission(request, obj),
+                "obj": obj,
+                "adminform": admin_form,  # Pass the AdminForm instance
+                "media": media,
+                "errors": None,
+            }
+            return self.render_change_form(
+                request,
+                context=change_form_context,
+                add=True,
+                change=False,
+                obj=obj,
+            )
+        return super().response_add(request, obj, post_url_continue)
 
 
 class PortfolioInvitationAdmin(ListHeaderAdmin):
@@ -1523,35 +1625,10 @@ class PortfolioInvitationAdmin(ListHeaderAdmin):
                     messages.warning(request, "User is already a member of this portfolio.")
             except Exception as e:
                 # when exception is raised, handle and do not save the model
-                self._handle_exceptions(e, request, obj)
+                handle_invitation_exceptions(request, e, requested_email)
                 return
         # Call the parent save method to save the object
         super().save_model(request, obj, form, change)
-
-    def _handle_exceptions(self, exception, request, obj):
-        """Handle exceptions raised during the process.
-
-        Log warnings / errors, and message errors to the user.
-        """
-        if isinstance(exception, EmailSendingError):
-            logger.warning(
-                "Could not sent email invitation to %s for portfolio %s (EmailSendingError)",
-                obj.email,
-                obj.portfolio,
-                exc_info=True,
-            )
-            messages.error(request, "Could not send email invitation. Portfolio invitation not saved.")
-        elif isinstance(exception, MissingEmailError):
-            messages.error(request, str(exception))
-            logger.error(
-                f"Can't send email to '{obj.email}' for portfolio '{obj.portfolio}'. "
-                f"No email exists for the requestor.",
-                exc_info=True,
-            )
-
-        else:
-            logger.warning("Could not send email invitation (Other Exception)", exc_info=True)
-            messages.error(request, "Could not send email invitation. Portfolio invitation not saved.")
 
     def response_add(self, request, obj, post_url_continue=None):
         """

--- a/src/registrar/admin.py
+++ b/src/registrar/admin.py
@@ -1594,7 +1594,7 @@ class PortfolioInvitationAdmin(BaseInvitationAdmin):
     # Search
     search_fields = [
         "email",
-        "portfolio__name",
+        "portfolio__organization_name",
     ]
 
     # Filters

--- a/src/registrar/assets/src/sass/_theme/_tooltips.scss
+++ b/src/registrar/assets/src/sass/_theme/_tooltips.scss
@@ -66,9 +66,9 @@
     text-align: center;
     font-size: inherit; //inherit tooltip fontsize of .93rem
     max-width: fit-content;
+    display: block;
     @include at-media('desktop') {
       width: 70vw;
     }
-    display: block;
   }
 }

--- a/src/registrar/models/domain_invitation.py
+++ b/src/registrar/models/domain_invitation.py
@@ -56,6 +56,8 @@ class DomainInvitation(TimeStampedModel):
         Raises:
             RuntimeError if no matching user can be found.
         """
+        # NOTE: this is currently not accounting for scenario when User.objects.get matches
+        # multiple user accounts with the same email address
 
         # get a user with this email address
         User = get_user_model()

--- a/src/registrar/models/domain_invitation.py
+++ b/src/registrar/models/domain_invitation.py
@@ -56,8 +56,6 @@ class DomainInvitation(TimeStampedModel):
         Raises:
             RuntimeError if no matching user can be found.
         """
-        # NOTE: this is currently not accounting for scenario when User.objects.get matches
-        # multiple user accounts with the same email address
 
         # get a user with this email address
         User = get_user_model()

--- a/src/registrar/models/utility/portfolio_helper.py
+++ b/src/registrar/models/utility/portfolio_helper.py
@@ -153,7 +153,9 @@ def validate_user_portfolio_permission(user_portfolio_permission):
                 "Based on current waffle flag settings, users cannot be assigned to multiple portfolios."
             )
 
-        existing_invitations = PortfolioInvitation.objects.filter(email=user_portfolio_permission.user.email)
+        existing_invitations = PortfolioInvitation.objects.exclude(
+            portfolio=user_portfolio_permission.portfolio
+        ).filter(email=user_portfolio_permission.user.email)
         if existing_invitations.exists():
             raise ValidationError(
                 "This user is already assigned to a portfolio invitation. "

--- a/src/registrar/templates/emails/domain_invitation.txt
+++ b/src/registrar/templates/emails/domain_invitation.txt
@@ -1,36 +1,46 @@
 {% autoescape off %}{# In a text file, we don't want to have HTML entities escaped #}
-Hi.
+{% if requested_user and requested_user.first_name %}
+Hi, {{ requested_user.first_name }}.
+{% else %}
+Hi,
+{% endif %}
 
-{{ requestor_email }} has added you as a manager on {{ domain.name }}.
+{{ requestor_email }} has invited you to manage:
+{% for domain in domains %}
+{{ domain.name }}
+{% endfor %}
 
-You can manage this domain on the .gov registrar <https://manage.get.gov>.
+To manage domain information, visit the .gov registrar <https://manage.get.gov>.
 
 ----------------------------------------------------------------
+{% if not requested_user %}
 
 YOU NEED A LOGIN.GOV ACCOUNT
-You’ll need a Login.gov account to manage your .gov domain. Login.gov provides
-a simple and secure process for signing in to many government services with one
-account. 
+You’ll need a Login.gov account to access the .gov registrar. That account needs to be
+associated with the following email address: {{ invitee_email_address }}
 
-If you don’t already have one, follow these steps to create your
-Login.gov account <https://login.gov/help/get-started/create-your-account/>.
+Login.gov provides a simple and secure process for signing in to many government
+services with one account. If you don’t already have one, follow these steps to create
+your Login.gov account <https://login.gov/help/get-started/create-your-account/>.
+{% endif %}
 
 
 DOMAIN MANAGEMENT
-As a .gov domain manager, you can add or update information about your domain.
-You’ll also serve as a contact for your .gov domain. Please keep your contact
-information updated. 
+As a .gov domain manager, you can add or update information like name servers. You’ll
+also serve as a contact for the domains you manage. Please keep your contact
+information updated.
 
 Learn more about domain management <https://get.gov/help/domain-management>. 
 
 
 SOMETHING WRONG?
-If you’re not affiliated with {{ domain.name }} or think you received this
-message in error, reply to this email.
+If you’re not affiliated with the .gov domains mentioned in this invitation or think you
+received this message in error, reply to this email.
 
 
 THANK YOU
-.Gov helps the public identify official, trusted information. Thank you for using a .gov domain.
+.Gov helps the public identify official, trusted information. Thank you for using a .gov
+domain.
 
 ----------------------------------------------------------------
 
@@ -38,5 +48,6 @@ The .gov team
 Contact us: <https://get.gov/contact/>
 Learn about .gov <https://get.gov>
 
-The .gov registry is a part of the Cybersecurity and Infrastructure Security Agency (CISA) <https://cisa.gov/>
+The .gov registry is a part of the Cybersecurity and Infrastructure Security Agency
+(CISA) <https://cisa.gov/>
 {% endautoescape %}

--- a/src/registrar/templates/emails/domain_invitation.txt
+++ b/src/registrar/templates/emails/domain_invitation.txt
@@ -1,15 +1,9 @@
 {% autoescape off %}{# In a text file, we don't want to have HTML entities escaped #}
-{% if requested_user and requested_user.first_name %}
-Hi, {{ requested_user.first_name }}.
-{% else %}
-Hi,
-{% endif %}
+Hi,{% if requested_user and requested_user.first_name %} {{ requested_user.first_name }}.{% endif %}
 
 {{ requestor_email }} has invited you to manage:
-{% for domain in domains %}
-{{ domain.name }}
+{% for domain in domains %}{{ domain.name }}
 {% endfor %}
-
 To manage domain information, visit the .gov registrar <https://manage.get.gov>.
 
 ----------------------------------------------------------------

--- a/src/registrar/templates/emails/domain_invitation_subject.txt
+++ b/src/registrar/templates/emails/domain_invitation_subject.txt
@@ -1,1 +1,1 @@
-You’ve been added to a .gov domain
+You've been invited to manage {% if domains|length > 1 %}.gov domains{% else %}{{ domains.0.name }}{% endif %}

--- a/src/registrar/tests/test_admin.py
+++ b/src/registrar/tests/test_admin.py
@@ -1002,8 +1002,6 @@ class TestUserPortfolioPermissionAdmin(TestCase):
 
     def setUp(self):
         """Create a client object"""
-        self.factory = RequestFactory()
-        self.admin = ListHeaderAdmin(model=UserPortfolioPermissionAdmin, admin_site=AdminSite())
         self.client = Client(HTTP_HOST="localhost:8080")
         self.superuser = create_superuser()
         self.portfolio = Portfolio.objects.create(organization_name="Test Portfolio", creator=self.superuser)
@@ -1011,77 +1009,9 @@ class TestUserPortfolioPermissionAdmin(TestCase):
     def tearDown(self):
         """Delete all DomainInvitation objects"""
         Portfolio.objects.all().delete()
-        PortfolioInvitation.objects.all().delete()
         Contact.objects.all().delete()
         User.objects.all().delete()
-
-    @less_console_noise_decorator
-    def test_clean_user_portfolio_permission(self):
-        """Tests validation of user portfolio permission"""
-
-        # Test validation fails when portfolio missing but permissions are present
-        permission = UserPortfolioPermission(user=self.superuser, roles=["organization_admin"], portfolio=None)
-        with self.assertRaises(ValidationError) as err:
-            permission.clean()
-            self.assertEqual(
-                str(err.exception),
-                "When portfolio roles or additional permissions are assigned, portfolio is required.",
-            )
-
-        # Test validation fails when portfolio present but no permissions are present
-        permission = UserPortfolioPermission(user=self.superuser, roles=None, portfolio=self.portfolio)
-        with self.assertRaises(ValidationError) as err:
-            permission.clean()
-            self.assertEqual(
-                str(err.exception),
-                "When portfolio is assigned, portfolio roles or additional permissions are required.",
-            )
-
-        # Test validation fails with forbidden permissions for single role
-        forbidden_member_roles = UserPortfolioPermission.FORBIDDEN_PORTFOLIO_ROLE_PERMISSIONS.get(
-            UserPortfolioRoleChoices.ORGANIZATION_MEMBER
-        )
-        permission = UserPortfolioPermission(
-            user=self.superuser,
-            roles=[UserPortfolioRoleChoices.ORGANIZATION_MEMBER],
-            additional_permissions=forbidden_member_roles,
-            portfolio=self.portfolio,
-        )
-        with self.assertRaises(ValidationError) as err:
-            permission.clean()
-            self.assertEqual(
-                str(err.exception),
-                "These permissions cannot be assigned to Member: "
-                "<Create and edit members, View all domains and domain reports, View members>",
-            )
-
-    @less_console_noise_decorator
-    def test_get_forbidden_permissions_with_multiple_roles(self):
-        """Tests that forbidden permissions are properly handled when a user has multiple roles"""
-        # Get forbidden permissions for member role
-        member_forbidden = UserPortfolioPermission.FORBIDDEN_PORTFOLIO_ROLE_PERMISSIONS.get(
-            UserPortfolioRoleChoices.ORGANIZATION_MEMBER
-        )
-
-        # Test with both admin and member roles
-        roles = [UserPortfolioRoleChoices.ORGANIZATION_ADMIN, UserPortfolioRoleChoices.ORGANIZATION_MEMBER]
-
-        # These permissions would be forbidden for member alone, but should be allowed
-        # when combined with admin role
-        permissions = UserPortfolioPermission.get_forbidden_permissions(
-            roles=roles, additional_permissions=member_forbidden
-        )
-
-        # Should return empty set since no permissions are commonly forbidden between admin and member
-        self.assertEqual(permissions, set())
-
-        # Verify the same permissions are forbidden when only member role is present
-        member_only_permissions = UserPortfolioPermission.get_forbidden_permissions(
-            roles=[UserPortfolioRoleChoices.ORGANIZATION_MEMBER], additional_permissions=member_forbidden
-        )
-
-        # Should return the forbidden permissions for member role
-        self.assertEqual(member_only_permissions, set(member_forbidden))
+        UserPortfolioPermission.objects.all().delete()
 
     @less_console_noise_decorator
     def test_has_change_form_description(self):
@@ -1136,112 +1066,6 @@ class TestPortfolioInvitationAdmin(TestCase):
     @classmethod
     def tearDownClass(self):
         User.objects.all().delete()
-
-    @less_console_noise_decorator
-    @override_flag("multiple_portfolios", active=False)
-    def test_clean_multiple_portfolios_inactive(self):
-        """Tests that users cannot have multiple portfolios or invitations when flag is inactive"""
-        # Create the first portfolio permission
-        UserPortfolioPermission.objects.create(
-            user=self.superuser, portfolio=self.portfolio, roles=[UserPortfolioRoleChoices.ORGANIZATION_ADMIN]
-        )
-
-        # Test a second portfolio permission object (should fail)
-        second_portfolio = Portfolio.objects.create(organization_name="Second Portfolio", creator=self.superuser)
-        second_permission = UserPortfolioPermission(
-            user=self.superuser, portfolio=second_portfolio, roles=[UserPortfolioRoleChoices.ORGANIZATION_ADMIN]
-        )
-
-        with self.assertRaises(ValidationError) as err:
-            second_permission.clean()
-        self.assertIn("users cannot be assigned to multiple portfolios", str(err.exception))
-
-        # Test that adding a new portfolio invitation also fails
-        third_portfolio = Portfolio.objects.create(organization_name="Third Portfolio", creator=self.superuser)
-        invitation = PortfolioInvitation(
-            email=self.superuser.email, portfolio=third_portfolio, roles=[UserPortfolioRoleChoices.ORGANIZATION_ADMIN]
-        )
-
-        with self.assertRaises(ValidationError) as err:
-            invitation.clean()
-        self.assertIn("users cannot be assigned to multiple portfolios", str(err.exception))
-
-    @less_console_noise_decorator
-    @override_flag("multiple_portfolios", active=True)
-    def test_clean_multiple_portfolios_active(self):
-        """Tests that users can have multiple portfolios and invitations when flag is active"""
-        # Create first portfolio permission
-        UserPortfolioPermission.objects.create(
-            user=self.superuser, portfolio=self.portfolio, roles=[UserPortfolioRoleChoices.ORGANIZATION_ADMIN]
-        )
-
-        # Second portfolio permission should succeed
-        second_portfolio = Portfolio.objects.create(organization_name="Second Portfolio", creator=self.superuser)
-        second_permission = UserPortfolioPermission(
-            user=self.superuser, portfolio=second_portfolio, roles=[UserPortfolioRoleChoices.ORGANIZATION_ADMIN]
-        )
-        second_permission.clean()
-        second_permission.save()
-
-        # Verify both permissions exist
-        user_permissions = UserPortfolioPermission.objects.filter(user=self.superuser)
-        self.assertEqual(user_permissions.count(), 2)
-
-        # Portfolio invitation should also succeed
-        third_portfolio = Portfolio.objects.create(organization_name="Third Portfolio", creator=self.superuser)
-        invitation = PortfolioInvitation(
-            email=self.superuser.email, portfolio=third_portfolio, roles=[UserPortfolioRoleChoices.ORGANIZATION_ADMIN]
-        )
-        invitation.clean()
-        invitation.save()
-
-        # Verify invitation exists
-        self.assertTrue(
-            PortfolioInvitation.objects.filter(
-                email=self.superuser.email,
-                portfolio=third_portfolio,
-            ).exists()
-        )
-
-    @less_console_noise_decorator
-    def test_clean_portfolio_invitation(self):
-        """Tests validation of portfolio invitation permissions"""
-
-        # Test validation fails when portfolio missing but permissions present
-        invitation = PortfolioInvitation(email="test@example.com", roles=["organization_admin"], portfolio=None)
-        with self.assertRaises(ValidationError) as err:
-            invitation.clean()
-            self.assertEqual(
-                str(err.exception),
-                "When portfolio roles or additional permissions are assigned, portfolio is required.",
-            )
-
-        # Test validation fails when portfolio present but no permissions
-        invitation = PortfolioInvitation(email="test@example.com", roles=None, portfolio=self.portfolio)
-        with self.assertRaises(ValidationError) as err:
-            invitation.clean()
-            self.assertEqual(
-                str(err.exception),
-                "When portfolio is assigned, portfolio roles or additional permissions are required.",
-            )
-
-        # Test validation fails with forbidden permissions
-        forbidden_member_roles = UserPortfolioPermission.FORBIDDEN_PORTFOLIO_ROLE_PERMISSIONS.get(
-            UserPortfolioRoleChoices.ORGANIZATION_MEMBER
-        )
-        invitation = PortfolioInvitation(
-            email="test@example.com",
-            roles=[UserPortfolioRoleChoices.ORGANIZATION_MEMBER],
-            additional_permissions=forbidden_member_roles,
-            portfolio=self.portfolio,
-        )
-        with self.assertRaises(ValidationError) as err:
-            invitation.clean()
-            self.assertEqual(
-                str(err.exception),
-                "These permissions cannot be assigned to Member: "
-                "<View all domains and domain reports, Create and edit members, View members>",
-            )
 
     @less_console_noise_decorator
     def test_has_model_description(self):

--- a/src/registrar/tests/test_admin.py
+++ b/src/registrar/tests/test_admin.py
@@ -28,7 +28,6 @@ from registrar.admin import (
     TransitionDomainAdmin,
     UserGroupAdmin,
     PortfolioAdmin,
-    UserPortfolioPermissionAdmin,
 )
 from registrar.models import (
     Domain,
@@ -70,8 +69,6 @@ from django.contrib.auth import get_user_model
 from django.contrib import messages
 
 from unittest.mock import ANY, call, patch, Mock
-from django.forms import ValidationError
-
 
 import logging
 
@@ -199,7 +196,9 @@ class TestDomainInvitationAdmin(TestCase):
     @patch("registrar.admin.send_domain_invitation_email")
     @patch("registrar.admin.send_portfolio_invitation_email")
     @patch("django.contrib.messages.success")
-    def test_add_domain_invitation_success_when_user_not_portfolio_member(self, mock_messages_success, mock_send_portfolio_email, mock_send_domain_email):
+    def test_add_domain_invitation_success_when_user_not_portfolio_member(
+        self, mock_messages_success, mock_send_portfolio_email, mock_send_domain_email
+    ):
         """Test saving a domain invitation when the user exists and is not a portfolio member.
 
         Should send out domain and portfolio invites.
@@ -235,10 +234,12 @@ class TestDomainInvitationAdmin(TestCase):
         )
 
         # Assert success message
-        mock_messages_success.assert_has_calls([
-            call(request, "test@example.com has been invited to the organization: new portfolio"),
-            call(request, "test@example.com has been invited to the domain: example.com"),
-        ])
+        mock_messages_success.assert_has_calls(
+            [
+                call(request, "test@example.com has been invited to the organization: new portfolio"),
+                call(request, "test@example.com has been invited to the domain: example.com"),
+            ]
+        )
 
         # Assert the invitations were saved
         self.assertEqual(DomainInvitation.objects.count(), 1)
@@ -262,7 +263,9 @@ class TestDomainInvitationAdmin(TestCase):
     @patch("registrar.admin.send_domain_invitation_email")
     @patch("registrar.admin.send_portfolio_invitation_email")
     @patch("django.contrib.messages.success")
-    def test_add_domain_invitation_success_when_user_not_portfolio_member_and_organization_feature_off(self, mock_messages_success, mock_send_portfolio_email, mock_send_domain_email):
+    def test_add_domain_invitation_success_when_user_not_portfolio_member_and_organization_feature_off(
+        self, mock_messages_success, mock_send_portfolio_email, mock_send_domain_email
+    ):
         """Test saving a domain invitation when the user exists and organization_feature flag is off.
 
         Should send out a domain invitation.
@@ -270,7 +273,7 @@ class TestDomainInvitationAdmin(TestCase):
         Should trigger success message for the domain invitation.
         Should retrieve the domain invitation.
         Should not create a portfolio invitation."""
-        
+
         user = User.objects.create_user(email="test@example.com", username="username")
 
         # Create a domain invitation instance
@@ -322,7 +325,9 @@ class TestDomainInvitationAdmin(TestCase):
     @patch("registrar.admin.send_domain_invitation_email")
     @patch("registrar.admin.send_portfolio_invitation_email")
     @patch("django.contrib.messages.success")
-    def test_add_domain_invitation_success_when_user_not_portfolio_member_and_multiple_portfolio_feature_on(self, mock_messages_success, mock_send_portfolio_email, mock_send_domain_email):
+    def test_add_domain_invitation_success_when_user_not_portfolio_member_and_multiple_portfolio_feature_on(
+        self, mock_messages_success, mock_send_portfolio_email, mock_send_domain_email
+    ):
         """Test saving a domain invitation when the user exists and multiple_portfolio flag is on.
 
         Should send out a domain invitation.
@@ -330,7 +335,7 @@ class TestDomainInvitationAdmin(TestCase):
         Should trigger success message for the domain invitation.
         Should retrieve the domain invitation.
         Should not create a portfolio invitation."""
-        
+
         user = User.objects.create_user(email="test@example.com", username="username")
 
         # Create a domain invitation instance
@@ -381,7 +386,9 @@ class TestDomainInvitationAdmin(TestCase):
     @patch("registrar.admin.send_domain_invitation_email")
     @patch("registrar.admin.send_portfolio_invitation_email")
     @patch("django.contrib.messages.success")
-    def test_add_domain_invitation_success_when_user_existing_portfolio_member(self, mock_messages_success, mock_send_portfolio_email, mock_send_domain_email):
+    def test_add_domain_invitation_success_when_user_existing_portfolio_member(
+        self, mock_messages_success, mock_send_portfolio_email, mock_send_domain_email
+    ):
         """Test saving a domain invitation when the user exists and a portfolio invitation exists.
 
         Should send out domain invitation only.
@@ -393,7 +400,9 @@ class TestDomainInvitationAdmin(TestCase):
         # Create a domain invitation instance
         invitation = DomainInvitation(email="test@example.com", domain=self.domain)
 
-        UserPortfolioPermission.objects.create(user=user, portfolio=self.portfolio, roles=[UserPortfolioRoleChoices.ORGANIZATION_MEMBER])
+        UserPortfolioPermission.objects.create(
+            user=user, portfolio=self.portfolio, roles=[UserPortfolioRoleChoices.ORGANIZATION_MEMBER]
+        )
 
         admin_instance = DomainInvitationAdmin(DomainInvitation, admin_site=None)
 
@@ -429,14 +438,17 @@ class TestDomainInvitationAdmin(TestCase):
         self.assertEqual(DomainInvitation.objects.count(), 1)
         self.assertEqual(DomainInvitation.objects.first().email, "test@example.com")
         self.assertEqual(PortfolioInvitation.objects.count(), 0)
-    
+
     @less_console_noise_decorator
     @override_flag("organization_feature", active=True)
     @patch("registrar.admin.send_domain_invitation_email")
     @patch("registrar.admin.send_portfolio_invitation_email")
     @patch("django.contrib.messages.error")
-    def test_add_domain_invitation_when_user_not_portfolio_member_raises_exception_sending_portfolio_email(self, mock_messages_error, mock_send_portfolio_email, mock_send_domain_email):
-        """Test saving a domain invitation when the user exists and is not a portfolio member raises sending portfolio email exception.
+    def test_add_domain_invitation_when_user_not_portfolio_member_raises_exception_sending_portfolio_email(
+        self, mock_messages_error, mock_send_portfolio_email, mock_send_domain_email
+    ):
+        """Test saving a domain invitation when the user exists and is not a portfolio member raises
+        sending portfolio email exception.
 
         Should only attempt to send the portfolio invitation.
         Should trigger error message on portfolio invitation.
@@ -455,7 +467,7 @@ class TestDomainInvitationAdmin(TestCase):
         request = self.factory.post("/admin/registrar/DomainInvitation/add/")
         request.user = self.superuser
 
-       # Patch the retrieve method to ensure it is not called
+        # Patch the retrieve method to ensure it is not called
         with patch.object(DomainInvitation, "retrieve") as domain_invitation_mock_retrieve:
             with patch.object(PortfolioInvitation, "retrieve") as portfolio_invitation_mock_retrieve:
                 admin_instance.save_model(request, invitation, form=None, change=False)
@@ -487,8 +499,11 @@ class TestDomainInvitationAdmin(TestCase):
     @patch("registrar.admin.send_portfolio_invitation_email")
     @patch("django.contrib.messages.success")
     @patch("django.contrib.messages.error")
-    def test_add_domain_invitation_when_user_not_portfolio_member_raises_exception_sending_domain_email(self, mock_messages_error, mock_messages_success, mock_send_portfolio_email, mock_send_domain_email):
-        """Test saving a domain invitation when the user exists and is not a portfolio member raises sending domain email exception.
+    def test_add_domain_invitation_when_user_not_portfolio_member_raises_exception_sending_domain_email(
+        self, mock_messages_error, mock_messages_success, mock_send_portfolio_email, mock_send_domain_email
+    ):
+        """Test saving a domain invitation when the user exists and is not a portfolio member raises
+        sending domain email exception.
 
         Should send out the portfolio invitation and attempt to send the domain invitation.
         Should trigger portfolio invitation success message.
@@ -552,8 +567,11 @@ class TestDomainInvitationAdmin(TestCase):
     @patch("registrar.admin.send_portfolio_invitation_email")
     @patch("django.contrib.messages.success")
     @patch("django.contrib.messages.error")
-    def test_add_domain_invitation_when_user_existing_portfolio_member_raises_exception_sending_domain_email(self, mock_messages_error, mock_messages_success, mock_send_portfolio_email, mock_send_domain_email):
-        """Test saving a domain invitation when the user exists and is not a portfolio member raises sending domain email exception.
+    def test_add_domain_invitation_when_user_existing_portfolio_member_raises_exception_sending_domain_email(
+        self, mock_messages_error, mock_messages_success, mock_send_portfolio_email, mock_send_domain_email
+    ):
+        """Test saving a domain invitation when the user exists and is not a portfolio member raises
+        sending domain email exception.
 
         Should send out the portfolio invitation and attempt to send the domain invitation.
         Should trigger portfolio invitation success message.
@@ -614,7 +632,9 @@ class TestDomainInvitationAdmin(TestCase):
     @patch("registrar.admin.send_domain_invitation_email")
     @patch("registrar.admin.send_portfolio_invitation_email")
     @patch("django.contrib.messages.success")
-    def test_add_domain_invitation_success_when_email_not_portfolio_member(self, mock_messages_success, mock_send_portfolio_email, mock_send_domain_email):
+    def test_add_domain_invitation_success_when_email_not_portfolio_member(
+        self, mock_messages_success, mock_send_portfolio_email, mock_send_domain_email
+    ):
         """Test saving a domain invitation when the user does not exist.
 
         Should send out domain and portfolio invitations.
@@ -654,10 +674,12 @@ class TestDomainInvitationAdmin(TestCase):
         portfolio_invitation_mock_retrieve.assert_not_called()
 
         # Assert success message
-        mock_messages_success.assert_has_calls([
-            call(request, "nonexistent@example.com has been invited to the organization: new portfolio"),
-            call(request, "nonexistent@example.com has been invited to the domain: example.com"),
-        ])
+        mock_messages_success.assert_has_calls(
+            [
+                call(request, "nonexistent@example.com has been invited to the organization: new portfolio"),
+                call(request, "nonexistent@example.com has been invited to the domain: example.com"),
+            ]
+        )
 
         # Assert the invitations were saved
         self.assertEqual(DomainInvitation.objects.count(), 1)
@@ -670,7 +692,9 @@ class TestDomainInvitationAdmin(TestCase):
     @patch("registrar.admin.send_domain_invitation_email")
     @patch("registrar.admin.send_portfolio_invitation_email")
     @patch("django.contrib.messages.success")
-    def test_add_domain_invitation_success_when_email_not_portfolio_member_and_organization_feature_off(self, mock_messages_success, mock_send_portfolio_email, mock_send_domain_email):
+    def test_add_domain_invitation_success_when_email_not_portfolio_member_and_organization_feature_off(
+        self, mock_messages_success, mock_send_portfolio_email, mock_send_domain_email
+    ):
         """Test saving a domain invitation when the user does not exist and organization_feature flag is off.
 
         Should send out a domain invitation.
@@ -722,7 +746,9 @@ class TestDomainInvitationAdmin(TestCase):
     @patch("registrar.admin.send_domain_invitation_email")
     @patch("registrar.admin.send_portfolio_invitation_email")
     @patch("django.contrib.messages.success")
-    def test_add_domain_invitation_success_when_email_not_portfolio_member_and_multiple_portfolio_feature_on(self, mock_messages_success, mock_send_portfolio_email, mock_send_domain_email):
+    def test_add_domain_invitation_success_when_email_not_portfolio_member_and_multiple_portfolio_feature_on(
+        self, mock_messages_success, mock_send_portfolio_email, mock_send_domain_email
+    ):
         """Test saving a domain invitation when the user does not exist and multiple_portfolio flag is on.
 
         Should send out a domain invitation.
@@ -773,7 +799,9 @@ class TestDomainInvitationAdmin(TestCase):
     @patch("registrar.admin.send_domain_invitation_email")
     @patch("registrar.admin.send_portfolio_invitation_email")
     @patch("django.contrib.messages.success")
-    def test_add_domain_invitation_success_when_email_existing_portfolio_invitation(self, mock_messages_success, mock_send_portfolio_email, mock_send_domain_email):
+    def test_add_domain_invitation_success_when_email_existing_portfolio_invitation(
+        self, mock_messages_success, mock_send_portfolio_email, mock_send_domain_email
+    ):
         """Test saving a domain invitation when the user does not exist and a portfolio invitation exists.
 
         Should send out domain invitation only.
@@ -781,7 +809,11 @@ class TestDomainInvitationAdmin(TestCase):
         Should not attempt to retrieve the domain invitation.
         Should not attempt to retrieve the portfolio invitation."""
 
-        PortfolioInvitation.objects.create(email="nonexistent@example.com", portfolio=self.portfolio, roles=[UserPortfolioRoleChoices.ORGANIZATION_MEMBER])
+        PortfolioInvitation.objects.create(
+            email="nonexistent@example.com",
+            portfolio=self.portfolio,
+            roles=[UserPortfolioRoleChoices.ORGANIZATION_MEMBER],
+        )
 
         # Create a domain invitation instance
         invitation = DomainInvitation(email="nonexistent@example.com", domain=self.domain)
@@ -827,8 +859,11 @@ class TestDomainInvitationAdmin(TestCase):
     @patch("registrar.admin.send_domain_invitation_email")
     @patch("registrar.admin.send_portfolio_invitation_email")
     @patch("django.contrib.messages.error")
-    def test_add_domain_invitation_when_user_not_portfolio_email_raises_exception_sending_portfolio_email(self, mock_messages_error, mock_send_portfolio_email, mock_send_domain_email):
-        """Test saving a domain invitation when the user exists and is not a portfolio member raises sending portfolio email exception.
+    def test_add_domain_invitation_when_user_not_portfolio_email_raises_exception_sending_portfolio_email(
+        self, mock_messages_error, mock_send_portfolio_email, mock_send_domain_email
+    ):
+        """Test saving a domain invitation when the user exists and is not a portfolio member raises
+        sending portfolio email exception.
 
         Should only attempt to send the portfolio invitation.
         Should trigger error message on portfolio invitation.
@@ -846,7 +881,7 @@ class TestDomainInvitationAdmin(TestCase):
         request = self.factory.post("/admin/registrar/DomainInvitation/add/")
         request.user = self.superuser
 
-       # Patch the retrieve method to ensure it is not called
+        # Patch the retrieve method to ensure it is not called
         with patch.object(DomainInvitation, "retrieve") as domain_invitation_mock_retrieve:
             with patch.object(PortfolioInvitation, "retrieve") as portfolio_invitation_mock_retrieve:
                 admin_instance.save_model(request, invitation, form=None, change=False)
@@ -878,8 +913,11 @@ class TestDomainInvitationAdmin(TestCase):
     @patch("registrar.admin.send_portfolio_invitation_email")
     @patch("django.contrib.messages.success")
     @patch("django.contrib.messages.error")
-    def test_add_domain_invitation_when_user_not_portfolio_email_raises_exception_sending_domain_email(self, mock_messages_error, mock_messages_success, mock_send_portfolio_email, mock_send_domain_email):
-        """Test saving a domain invitation when the user exists and is not a portfolio member raises sending domain email exception.
+    def test_add_domain_invitation_when_user_not_portfolio_email_raises_exception_sending_domain_email(
+        self, mock_messages_error, mock_messages_success, mock_send_portfolio_email, mock_send_domain_email
+    ):
+        """Test saving a domain invitation when the user exists and is not a portfolio member
+        raises sending domain email exception.
 
         Should send out the portfolio invitation and attempt to send the domain invitation.
         Should trigger portfolio invitation success message.
@@ -941,8 +979,11 @@ class TestDomainInvitationAdmin(TestCase):
     @patch("registrar.admin.send_portfolio_invitation_email")
     @patch("django.contrib.messages.success")
     @patch("django.contrib.messages.error")
-    def test_add_domain_invitation_when_user_existing_portfolio_email_raises_exception_sending_domain_email(self, mock_messages_error, mock_messages_success, mock_send_portfolio_email, mock_send_domain_email):
-        """Test saving a domain invitation when the user exists and is not a portfolio member raises sending domain email exception.
+    def test_add_domain_invitation_when_user_existing_portfolio_email_raises_exception_sending_domain_email(
+        self, mock_messages_error, mock_messages_success, mock_send_portfolio_email, mock_send_domain_email
+    ):
+        """Test saving a domain invitation when the user exists and is not a portfolio member
+        raises sending domain email exception.
 
         Should send out the portfolio invitation and attempt to send the domain invitation.
         Should trigger portfolio invitation success message.
@@ -953,7 +994,9 @@ class TestDomainInvitationAdmin(TestCase):
         mock_send_domain_email.side_effect = MissingEmailError("craving a burger")
 
         PortfolioInvitation.objects.create(
-            email="nonexistent@example.com", portfolio=self.portfolio, roles=[UserPortfolioRoleChoices.ORGANIZATION_MEMBER]
+            email="nonexistent@example.com",
+            portfolio=self.portfolio,
+            roles=[UserPortfolioRoleChoices.ORGANIZATION_MEMBER],
         )
 
         # Create a domain invitation instance
@@ -1208,7 +1251,9 @@ class TestPortfolioInvitationAdmin(TestCase):
     @less_console_noise_decorator
     @patch("registrar.admin.send_portfolio_invitation_email")
     @patch("django.contrib.messages.success")  # Mock the `messages.warning` call
-    def test_add_portfolio_invitation_auto_retrieves_invitation_when_user_exists(self, mock_messages_success, mock_send_email):
+    def test_add_portfolio_invitation_auto_retrieves_invitation_when_user_exists(
+        self, mock_messages_success, mock_send_email
+    ):
         """On save_model, we create and retrieve a portfolio invitation if the user exists."""
 
         # Create an instance of the admin class
@@ -1247,11 +1292,13 @@ class TestPortfolioInvitationAdmin(TestCase):
 
         # The invitation is not retrieved
         portfolio_invitation_mock_retrieve.assert_called_once()
-        
+
     @less_console_noise_decorator
     @patch("registrar.admin.send_portfolio_invitation_email")
     @patch("django.contrib.messages.success")  # Mock the `messages.warning` call
-    def test_add_portfolio_invitation_does_not_retrieve_invitation_when_no_user(self, mock_messages_success, mock_send_email):
+    def test_add_portfolio_invitation_does_not_retrieve_invitation_when_no_user(
+        self, mock_messages_success, mock_send_email
+    ):
         """On save_model, we create but do not retrieve a portfolio invitation if the user does not exist."""
 
         # Create an instance of the admin class
@@ -1317,9 +1364,7 @@ class TestPortfolioInvitationAdmin(TestCase):
         admin_instance.save_model(request, portfolio_invitation, None, None)
 
         # Assert that messages.error was called with the correct message
-        mock_messages_error.assert_called_once_with(
-            request, "Email service unavailable"
-        )
+        mock_messages_error.assert_called_once_with(request, "Email service unavailable")
 
     @less_console_noise_decorator
     @patch("registrar.admin.send_portfolio_invitation_email")
@@ -1382,9 +1427,7 @@ class TestPortfolioInvitationAdmin(TestCase):
         admin_instance.save_model(request, portfolio_invitation, None, None)
 
         # Assert that messages.error was called with the correct message
-        mock_messages_error.assert_called_once_with(
-            request, "Could not send email invitation."
-        )
+        mock_messages_error.assert_called_once_with(request, "Could not send email invitation.")
 
 
 class TestHostAdmin(TestCase):

--- a/src/registrar/tests/test_admin.py
+++ b/src/registrar/tests/test_admin.py
@@ -335,7 +335,7 @@ class TestDomainInvitationAdmin(TestCase):
         Should trigger success message for the domain invitation.
         Should retrieve the domain invitation.
         Should not create a portfolio invitation.
-        
+
         NOTE: This test may need to be reworked when the multiple_portfolio flag is fully fleshed out.
         """
 

--- a/src/registrar/tests/test_admin.py
+++ b/src/registrar/tests/test_admin.py
@@ -131,13 +131,11 @@ class TestDomainInvitationAdmin(TestCase):
       tests have available superuser, client, and admin
     """
 
-    @classmethod
-    def setUpClass(cls):
-        cls.factory = RequestFactory()
-        cls.admin = ListHeaderAdmin(model=DomainInvitationAdmin, admin_site=AdminSite())
-        cls.superuser = create_superuser()
-
     def setUp(self):
+        self.factory = RequestFactory()
+        self.admin = ListHeaderAdmin(model=DomainInvitationAdmin, admin_site=AdminSite())
+        self.superuser = create_superuser()
+        self.domain = Domain.objects.create(name="example.com")
         """Create a client object"""
         self.client = Client(HTTP_HOST="localhost:8080")
 
@@ -145,9 +143,6 @@ class TestDomainInvitationAdmin(TestCase):
         """Delete all DomainInvitation objects"""
         DomainInvitation.objects.all().delete()
         Contact.objects.all().delete()
-
-    @classmethod
-    def tearDownClass(self):
         User.objects.all().delete()
 
     @less_console_noise_decorator
@@ -168,6 +163,7 @@ class TestDomainInvitationAdmin(TestCase):
         )
         self.assertContains(response, "Show more")
 
+    @less_console_noise_decorator
     def test_get_filters(self):
         """Ensures that our filters are displaying correctly"""
         with less_console_noise():
@@ -191,6 +187,59 @@ class TestDomainInvitationAdmin(TestCase):
 
             self.assertContains(response, invited_html, count=1)
             self.assertContains(response, retrieved_html, count=1)
+
+    @less_console_noise_decorator
+    def test_save_model_user_exists(self):
+        """Test saving a domain invitation when the user exists.
+        
+        Should attempt to retrieve the domain invitation."""
+        # Create a user with the same email
+        User.objects.create_user(email="test@example.com", password="password", username="username")
+
+        # Create a domain invitation instance
+        invitation = DomainInvitation(email="test@example.com", domain=self.domain)
+
+        admin_instance = DomainInvitationAdmin(DomainInvitation, admin_site=None)
+
+        # Create a request object
+        request = self.factory.post("/admin/registrar/DomainInvitation/add/")
+        request.user = self.superuser
+
+        # Patch the retrieve method
+        with patch.object(DomainInvitation, "retrieve") as mock_retrieve:
+            admin_instance.save_model(request, invitation, form=None, change=False)
+
+        # Assert retrieve was called
+        mock_retrieve.assert_called_once()
+
+        # Assert the invitation was saved
+        self.assertEqual(DomainInvitation.objects.count(), 1)
+        self.assertEqual(DomainInvitation.objects.first().email, "test@example.com")
+
+    @less_console_noise_decorator
+    def test_save_model_user_does_not_exist(self):
+        """Test saving a domain invitation when the user does not exist.
+        
+        Should not attempt to retrieve the domain invitation."""
+        # Create a domain invitation instance
+        invitation = DomainInvitation(email="nonexistent@example.com", domain=self.domain)
+
+        admin_instance = DomainInvitationAdmin(DomainInvitation, admin_site=None)
+
+        # Create a request object
+        request = self.factory.post("/admin/registrar/DomainInvitation/add/")
+        request.user = self.superuser
+
+        # Patch the retrieve method to ensure it is not called
+        with patch.object(DomainInvitation, "retrieve") as mock_retrieve:
+            admin_instance.save_model(request, invitation, form=None, change=False)
+
+        # Assert retrieve was not called
+        mock_retrieve.assert_not_called()
+
+        # Assert the invitation was saved
+        self.assertEqual(DomainInvitation.objects.count(), 1)
+        self.assertEqual(DomainInvitation.objects.first().email, "nonexistent@example.com")
 
 
 class TestUserPortfolioPermissionAdmin(TestCase):

--- a/src/registrar/tests/test_admin.py
+++ b/src/registrar/tests/test_admin.py
@@ -334,7 +334,10 @@ class TestDomainInvitationAdmin(TestCase):
         Should not send a out portfolio invitation.
         Should trigger success message for the domain invitation.
         Should retrieve the domain invitation.
-        Should not create a portfolio invitation."""
+        Should not create a portfolio invitation.
+        
+        NOTE: This test may need to be reworked when the multiple_portfolio flag is fully fleshed out.
+        """
 
         user = User.objects.create_user(email="test@example.com", username="username")
 

--- a/src/registrar/tests/test_admin.py
+++ b/src/registrar/tests/test_admin.py
@@ -191,10 +191,10 @@ class TestDomainInvitationAdmin(TestCase):
     @less_console_noise_decorator
     def test_save_model_user_exists(self):
         """Test saving a domain invitation when the user exists.
-        
+
         Should attempt to retrieve the domain invitation."""
         # Create a user with the same email
-        User.objects.create_user(email="test@example.com", password="password", username="username")
+        User.objects.create_user(email="test@example.com", username="username")
 
         # Create a domain invitation instance
         invitation = DomainInvitation(email="test@example.com", domain=self.domain)
@@ -219,7 +219,7 @@ class TestDomainInvitationAdmin(TestCase):
     @less_console_noise_decorator
     def test_save_model_user_does_not_exist(self):
         """Test saving a domain invitation when the user does not exist.
-        
+
         Should not attempt to retrieve the domain invitation."""
         # Create a domain invitation instance
         invitation = DomainInvitation(email="nonexistent@example.com", domain=self.domain)

--- a/src/registrar/tests/test_models.py
+++ b/src/registrar/tests/test_models.py
@@ -28,6 +28,7 @@ from registrar.models.verified_by_staff import VerifiedByStaff  # type: ignore
 from .common import (
     MockSESClient,
     completed_domain_request,
+    create_superuser,
     create_test_user,
 )
 from waffle.testutils import override_flag
@@ -155,6 +156,7 @@ class TestPortfolioInvitations(TestCase):
             roles=[self.portfolio_role_base, self.portfolio_role_admin],
             additional_permissions=[self.portfolio_permission_1, self.portfolio_permission_2],
         )
+        self.superuser = create_superuser()
 
     def tearDown(self):
         super().tearDown()
@@ -294,10 +296,159 @@ class TestPortfolioInvitations(TestCase):
         # Verify
         self.assertEquals(self.invitation.get_portfolio_permissions(), perm_list)
 
+    @less_console_noise_decorator
+    @override_flag("multiple_portfolios", active=False)
+    def test_clean_multiple_portfolios_inactive(self):
+        """Tests that users cannot have multiple portfolios or invitations when flag is inactive"""
+        # Create the first portfolio permission
+        UserPortfolioPermission.objects.create(
+            user=self.superuser, portfolio=self.portfolio, roles=[UserPortfolioRoleChoices.ORGANIZATION_ADMIN]
+        )
+
+        # Test a second portfolio permission object (should fail)
+        second_portfolio = Portfolio.objects.create(organization_name="Second Portfolio", creator=self.superuser)
+        second_permission = UserPortfolioPermission(
+            user=self.superuser, portfolio=second_portfolio, roles=[UserPortfolioRoleChoices.ORGANIZATION_ADMIN]
+        )
+
+        with self.assertRaises(ValidationError) as err:
+            second_permission.clean()
+        self.assertIn("users cannot be assigned to multiple portfolios", str(err.exception))
+
+        # Test that adding a new portfolio invitation also fails
+        third_portfolio = Portfolio.objects.create(organization_name="Third Portfolio", creator=self.superuser)
+        invitation = PortfolioInvitation(
+            email=self.superuser.email, portfolio=third_portfolio, roles=[UserPortfolioRoleChoices.ORGANIZATION_ADMIN]
+        )
+
+        with self.assertRaises(ValidationError) as err:
+            invitation.clean()
+        self.assertIn("users cannot be assigned to multiple portfolios", str(err.exception))
+
+    @less_console_noise_decorator
+    @override_flag("multiple_portfolios", active=True)
+    def test_clean_multiple_portfolios_active(self):
+        """Tests that users can have multiple portfolios and invitations when flag is active"""
+        # Create first portfolio permission
+        UserPortfolioPermission.objects.create(
+            user=self.superuser, portfolio=self.portfolio, roles=[UserPortfolioRoleChoices.ORGANIZATION_ADMIN]
+        )
+
+        # Second portfolio permission should succeed
+        second_portfolio = Portfolio.objects.create(organization_name="Second Portfolio", creator=self.superuser)
+        second_permission = UserPortfolioPermission(
+            user=self.superuser, portfolio=second_portfolio, roles=[UserPortfolioRoleChoices.ORGANIZATION_ADMIN]
+        )
+        second_permission.clean()
+        second_permission.save()
+
+        # Verify both permissions exist
+        user_permissions = UserPortfolioPermission.objects.filter(user=self.superuser)
+        self.assertEqual(user_permissions.count(), 2)
+
+        # Portfolio invitation should also succeed
+        third_portfolio = Portfolio.objects.create(organization_name="Third Portfolio", creator=self.superuser)
+        invitation = PortfolioInvitation(
+            email=self.superuser.email, portfolio=third_portfolio, roles=[UserPortfolioRoleChoices.ORGANIZATION_ADMIN]
+        )
+        invitation.clean()
+        invitation.save()
+
+        # Verify invitation exists
+        self.assertTrue(
+            PortfolioInvitation.objects.filter(
+                email=self.superuser.email,
+                portfolio=third_portfolio,
+            ).exists()
+        )
+    
+    @less_console_noise_decorator
+    def test_clean_portfolio_invitation(self):
+        """Tests validation of portfolio invitation permissions"""
+
+        # Test validation fails when portfolio missing but permissions present
+        invitation = PortfolioInvitation(email="test@example.com", roles=["organization_admin"], portfolio=None)
+        with self.assertRaises(ValidationError) as err:
+            invitation.clean()
+            self.assertEqual(
+                str(err.exception),
+                "When portfolio roles or additional permissions are assigned, portfolio is required.",
+            )
+
+        # Test validation fails when portfolio present but no permissions
+        invitation = PortfolioInvitation(email="test@example.com", roles=None, portfolio=self.portfolio)
+        with self.assertRaises(ValidationError) as err:
+            invitation.clean()
+            self.assertEqual(
+                str(err.exception),
+                "When portfolio is assigned, portfolio roles or additional permissions are required.",
+            )
+
+        # Test validation fails with forbidden permissions
+        forbidden_member_roles = UserPortfolioPermission.FORBIDDEN_PORTFOLIO_ROLE_PERMISSIONS.get(
+            UserPortfolioRoleChoices.ORGANIZATION_MEMBER
+        )
+        invitation = PortfolioInvitation(
+            email="test@example.com",
+            roles=[UserPortfolioRoleChoices.ORGANIZATION_MEMBER],
+            additional_permissions=forbidden_member_roles,
+            portfolio=self.portfolio,
+        )
+        with self.assertRaises(ValidationError) as err:
+            invitation.clean()
+            self.assertEqual(
+                str(err.exception),
+                "These permissions cannot be assigned to Member: "
+                "<View all domains and domain reports, Create and edit members, View members>",
+            )
+
+    @less_console_noise_decorator
+    @override_flag("multiple_portfolios", active=False)
+    def test_clean_user_portfolio_permission_multiple_portfolios_flag_off_and_duplicate_permission(self):
+        """MISSING TEST: Test validation of multiple_portfolios flag.
+        Scenario 1: Flag is inactive, and the user has existing portfolio permissions
+        
+        NOTE: Refer to the same test under TestUserPortfolioPermission"""
+
+        pass
+
+    @less_console_noise_decorator
+    @override_flag("multiple_portfolios", active=False)
+    def test_clean_user_portfolio_permission_multiple_portfolios_flag_off_and_existing_invitation(self):
+        """MISSING TEST: Test validation of multiple_portfolios flag.
+        Scenario 2: Flag is inactive, and the user has existing portfolio invitation to another portfolio
+        
+        NOTE: Refer to the same test under TestUserPortfolioPermission"""
+
+        pass
+
+    @less_console_noise_decorator
+    @override_flag("multiple_portfolios", active=True)
+    def test_clean_user_portfolio_permission_multiple_portfolios_flag_on_and_duplicate_permission(self):
+        """MISSING TEST: Test validation of multiple_portfolios flag.
+        Scenario 3: Flag is active, and the user has existing portfolio invitation
+        
+        NOTE: Refer to the same test under TestUserPortfolioPermission"""
+
+        pass
+
+
+    @less_console_noise_decorator
+    @override_flag("multiple_portfolios", active=True)
+    def test_clean_user_portfolio_permission_multiple_portfolios_flag_on_and_existing_invitation(self):
+        """MISSING TEST: Test validation of multiple_portfolios flag.
+        Scenario 4: Flag is active, and the user has existing portfolio invitation to another portfolio
+        
+        NOTE: Refer to the same test under TestUserPortfolioPermission"""
+
+        pass
+
 
 class TestUserPortfolioPermission(TestCase):
     @less_console_noise_decorator
     def setUp(self):
+        self.superuser = create_superuser()
+        self.portfolio = Portfolio.objects.create(organization_name="Test Portfolio", creator=self.superuser)
         self.user, _ = User.objects.get_or_create(email="mayor@igorville.gov")
         self.user2, _ = User.objects.get_or_create(email="user2@igorville.gov", username="user2")
         super().setUp()
@@ -311,6 +462,7 @@ class TestUserPortfolioPermission(TestCase):
         Portfolio.objects.all().delete()
         User.objects.all().delete()
         UserDomainRole.objects.all().delete()
+        PortfolioInvitation.objects.all().delete()
 
     @less_console_noise_decorator
     @override_flag("multiple_portfolios", active=True)
@@ -426,6 +578,179 @@ class TestUserPortfolioPermission(TestCase):
 
         # Assert
         self.assertEqual(portfolio_permission.get_managed_domains_count(), 1)
+
+    @less_console_noise_decorator
+    def test_clean_user_portfolio_permission(self):
+        """Tests validation of user portfolio permission"""
+
+        # Test validation fails when portfolio missing but permissions are present
+        permission = UserPortfolioPermission(user=self.superuser, roles=["organization_admin"], portfolio=None)
+        with self.assertRaises(ValidationError) as err:
+            permission.clean()
+            self.assertEqual(
+                str(err.exception),
+                "When portfolio roles or additional permissions are assigned, portfolio is required.",
+            )
+
+        # Test validation fails when portfolio present but no permissions are present
+        permission = UserPortfolioPermission(user=self.superuser, roles=None, portfolio=self.portfolio)
+        with self.assertRaises(ValidationError) as err:
+            permission.clean()
+            self.assertEqual(
+                str(err.exception),
+                "When portfolio is assigned, portfolio roles or additional permissions are required.",
+            )
+
+        # Test validation fails with forbidden permissions for single role
+        forbidden_member_roles = UserPortfolioPermission.FORBIDDEN_PORTFOLIO_ROLE_PERMISSIONS.get(
+            UserPortfolioRoleChoices.ORGANIZATION_MEMBER
+        )
+        permission = UserPortfolioPermission(
+            user=self.superuser,
+            roles=[UserPortfolioRoleChoices.ORGANIZATION_MEMBER],
+            additional_permissions=forbidden_member_roles,
+            portfolio=self.portfolio,
+        )
+        with self.assertRaises(ValidationError) as err:
+            permission.clean()
+            self.assertEqual(
+                str(err.exception),
+                "These permissions cannot be assigned to Member: "
+                "<Create and edit members, View all domains and domain reports, View members>",
+            )
+
+    @less_console_noise_decorator
+    @override_flag("multiple_portfolios", active=False)
+    def test_clean_user_portfolio_permission_multiple_portfolios_flag_off_and_duplicate_permission(self):
+        """Test validation of multiple_portfolios flag.
+        Scenario 1: Flag is inactive, and the user has existing portfolio permissions"""
+
+        #existing permission
+        UserPortfolioPermission.objects.create(
+            user=self.superuser,
+            roles=[UserPortfolioRoleChoices.ORGANIZATION_ADMIN],
+            portfolio=self.portfolio,
+        )
+
+        permission = UserPortfolioPermission(
+            user=self.superuser,
+            roles=[UserPortfolioRoleChoices.ORGANIZATION_ADMIN],
+            portfolio=self.portfolio,
+        )
+
+        with self.assertRaises(ValidationError) as err:
+            permission.clean()
+
+        self.assertEqual(
+            str(err.exception.messages[0]),
+            "This user is already assigned to a portfolio. "
+            "Based on current waffle flag settings, users cannot be assigned to multiple portfolios.",
+        )
+
+    @less_console_noise_decorator
+    @override_flag("multiple_portfolios", active=False)
+    def test_clean_user_portfolio_permission_multiple_portfolios_flag_off_and_existing_invitation(self):
+        """Test validation of multiple_portfolios flag.
+        Scenario 2: Flag is inactive, and the user has existing portfolio invitation to another portfolio"""
+
+        portfolio2 = Portfolio.objects.create(creator=self.superuser, organization_name="Joey go away")
+
+        PortfolioInvitation.objects.create(
+            email=self.superuser.email, roles=[UserPortfolioRoleChoices.ORGANIZATION_ADMIN], portfolio=portfolio2
+        )
+
+        permission = UserPortfolioPermission(
+            user=self.superuser,
+            roles=[UserPortfolioRoleChoices.ORGANIZATION_ADMIN],
+            portfolio=self.portfolio,
+        )
+
+        with self.assertRaises(ValidationError) as err:
+            permission.clean()
+
+        self.assertEqual(
+            str(err.exception.messages[0]),
+            "This user is already assigned to a portfolio invitation. "
+            "Based on current waffle flag settings, users cannot be assigned to multiple portfolios.",
+        )
+
+    @less_console_noise_decorator
+    @override_flag("multiple_portfolios", active=True)
+    def test_clean_user_portfolio_permission_multiple_portfolios_flag_on_and_duplicate_permission(self):
+        """Test validation of multiple_portfolios flag.
+        Scenario 3: Flag is active, and the user has existing portfolio invitation"""
+
+        # existing permission
+        UserPortfolioPermission.objects.create(
+            user=self.superuser,
+            roles=[UserPortfolioRoleChoices.ORGANIZATION_ADMIN],
+            portfolio=self.portfolio,
+        )
+
+        permission = UserPortfolioPermission(
+            user=self.superuser,
+            roles=[UserPortfolioRoleChoices.ORGANIZATION_ADMIN],
+            portfolio=self.portfolio,
+        )
+
+        # Should not raise any exceptions
+        try:
+            permission.clean()
+        except ValidationError:
+            self.fail("ValidationError was raised unexpectedly when flag is active.")
+
+
+    @less_console_noise_decorator
+    @override_flag("multiple_portfolios", active=True)
+    def test_clean_user_portfolio_permission_multiple_portfolios_flag_on_and_existing_invitation(self):
+        """Test validation of multiple_portfolios flag.
+        Scenario 4: Flag is active, and the user has existing portfolio invitation to another portfolio"""
+
+        portfolio2 = Portfolio.objects.create(creator=self.superuser, organization_name="Joey go away")
+
+        PortfolioInvitation.objects.create(
+            email=self.superuser.email, roles=[UserPortfolioRoleChoices.ORGANIZATION_ADMIN], portfolio=portfolio2
+        )
+
+        permission = UserPortfolioPermission(
+            user=self.superuser,
+            roles=[UserPortfolioRoleChoices.ORGANIZATION_ADMIN],
+            portfolio=self.portfolio,
+        )
+
+        # Should not raise any exceptions
+        try:
+            permission.clean()
+        except ValidationError:
+            self.fail("ValidationError was raised unexpectedly when flag is active.")
+
+    @less_console_noise_decorator
+    def test_get_forbidden_permissions_with_multiple_roles(self):
+        """Tests that forbidden permissions are properly handled when a user has multiple roles"""
+        # Get forbidden permissions for member role
+        member_forbidden = UserPortfolioPermission.FORBIDDEN_PORTFOLIO_ROLE_PERMISSIONS.get(
+            UserPortfolioRoleChoices.ORGANIZATION_MEMBER
+        )
+
+        # Test with both admin and member roles
+        roles = [UserPortfolioRoleChoices.ORGANIZATION_ADMIN, UserPortfolioRoleChoices.ORGANIZATION_MEMBER]
+
+        # These permissions would be forbidden for member alone, but should be allowed
+        # when combined with admin role
+        permissions = UserPortfolioPermission.get_forbidden_permissions(
+            roles=roles, additional_permissions=member_forbidden
+        )
+
+        # Should return empty set since no permissions are commonly forbidden between admin and member
+        self.assertEqual(permissions, set())
+
+        # Verify the same permissions are forbidden when only member role is present
+        member_only_permissions = UserPortfolioPermission.get_forbidden_permissions(
+            roles=[UserPortfolioRoleChoices.ORGANIZATION_MEMBER], additional_permissions=member_forbidden
+        )
+
+        # Should return the forbidden permissions for member role
+        self.assertEqual(member_only_permissions, set(member_forbidden))
 
 
 class TestUser(TestCase):

--- a/src/registrar/tests/test_models.py
+++ b/src/registrar/tests/test_models.py
@@ -361,7 +361,7 @@ class TestPortfolioInvitations(TestCase):
                 portfolio=third_portfolio,
             ).exists()
         )
-    
+
     @less_console_noise_decorator
     def test_clean_portfolio_invitation(self):
         """Tests validation of portfolio invitation permissions"""
@@ -407,7 +407,7 @@ class TestPortfolioInvitations(TestCase):
     def test_clean_user_portfolio_permission_multiple_portfolios_flag_off_and_duplicate_permission(self):
         """MISSING TEST: Test validation of multiple_portfolios flag.
         Scenario 1: Flag is inactive, and the user has existing portfolio permissions
-        
+
         NOTE: Refer to the same test under TestUserPortfolioPermission"""
 
         pass
@@ -417,7 +417,7 @@ class TestPortfolioInvitations(TestCase):
     def test_clean_user_portfolio_permission_multiple_portfolios_flag_off_and_existing_invitation(self):
         """MISSING TEST: Test validation of multiple_portfolios flag.
         Scenario 2: Flag is inactive, and the user has existing portfolio invitation to another portfolio
-        
+
         NOTE: Refer to the same test under TestUserPortfolioPermission"""
 
         pass
@@ -427,18 +427,17 @@ class TestPortfolioInvitations(TestCase):
     def test_clean_user_portfolio_permission_multiple_portfolios_flag_on_and_duplicate_permission(self):
         """MISSING TEST: Test validation of multiple_portfolios flag.
         Scenario 3: Flag is active, and the user has existing portfolio invitation
-        
+
         NOTE: Refer to the same test under TestUserPortfolioPermission"""
 
         pass
-
 
     @less_console_noise_decorator
     @override_flag("multiple_portfolios", active=True)
     def test_clean_user_portfolio_permission_multiple_portfolios_flag_on_and_existing_invitation(self):
         """MISSING TEST: Test validation of multiple_portfolios flag.
         Scenario 4: Flag is active, and the user has existing portfolio invitation to another portfolio
-        
+
         NOTE: Refer to the same test under TestUserPortfolioPermission"""
 
         pass
@@ -625,7 +624,7 @@ class TestUserPortfolioPermission(TestCase):
         """Test validation of multiple_portfolios flag.
         Scenario 1: Flag is inactive, and the user has existing portfolio permissions"""
 
-        #existing permission
+        # existing permission
         UserPortfolioPermission.objects.create(
             user=self.superuser,
             roles=[UserPortfolioRoleChoices.ORGANIZATION_ADMIN],
@@ -698,7 +697,6 @@ class TestUserPortfolioPermission(TestCase):
             permission.clean()
         except ValidationError:
             self.fail("ValidationError was raised unexpectedly when flag is active.")
-
 
     @less_console_noise_decorator
     @override_flag("multiple_portfolios", active=True)

--- a/src/registrar/tests/test_views_domain.py
+++ b/src/registrar/tests/test_views_domain.py
@@ -665,7 +665,7 @@ class TestDomainManagers(TestDomainOverview):
         self.assertEqual(portfolio_invitation.portfolio, self.portfolio)
         self.assertEqual(portfolio_invitation.status, PortfolioInvitation.PortfolioInvitationStatus.RETRIEVED)
 
-        #Assert that the UserPortfolioPermission is created
+        # Assert that the UserPortfolioPermission is created
         user_portfolio_permission = UserPortfolioPermission.objects.filter(
             user=self.user, portfolio=self.portfolio
         ).first()
@@ -680,7 +680,9 @@ class TestDomainManagers(TestDomainOverview):
     @less_console_noise_decorator
     @patch("registrar.views.domain.send_portfolio_invitation_email")
     @patch("registrar.views.domain.send_domain_invitation_email")
-    def test_domain_user_add_form_sends_portfolio_invitation_to_new_email(self, mock_send_domain_email, mock_send_portfolio_email):
+    def test_domain_user_add_form_sends_portfolio_invitation_to_new_email(
+        self, mock_send_domain_email, mock_send_portfolio_email
+    ):
         """Adding an email not associated with a user works and sends portfolio invitation."""
         add_page = self.app.get(reverse("domain-users-add", kwargs={"pk": self.domain.id}))
         session_id = self.app.cookies[settings.SESSION_COOKIE_NAME]
@@ -720,7 +722,7 @@ class TestDomainManagers(TestDomainOverview):
         self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
         success_page = success_result.follow()
         self.assertContains(success_page, "notauser@igorville.gov")
-    
+
     @boto3_mocking.patching
     @override_flag("organization_feature", active=True)
     @less_console_noise_decorator

--- a/src/registrar/tests/test_views_domain.py
+++ b/src/registrar/tests/test_views_domain.py
@@ -758,7 +758,7 @@ class TestDomainManagers(TestDomainOverview):
         call_args = mock_send_domain_email.call_args.kwargs
         self.assertEqual(call_args["email"], "mayor@igorville.gov")
         self.assertEqual(call_args["requestor"], self.user)
-        self.assertEqual(call_args["domain"], self.domain)
+        self.assertEqual(call_args["domains"], self.domain)
         self.assertIsNone(call_args.get("is_member_of_different_org"))
 
         # Assert that no PortfolioInvitation is created

--- a/src/registrar/tests/test_views_portfolio.py
+++ b/src/registrar/tests/test_views_portfolio.py
@@ -2324,7 +2324,10 @@ class TestPortfolioMemberDomainsEditView(TestPortfolioMemberDomainsView):
         self.assertRedirects(response, reverse("member-domains-edit", kwargs={"pk": self.portfolio_permission.pk}))
         messages = list(response.wsgi_request._messages)
         self.assertEqual(len(messages), 1)
-        self.assertEqual(str(messages[0]), "An unexpected error occurred: Failed to send email. If the issue persists, please contact help@get.gov.")
+        self.assertEqual(
+            str(messages[0]),
+            "An unexpected error occurred: Failed to send email. If the issue persists, please contact help@get.gov.",
+        )
 
 
 class TestPortfolioInvitedMemberEditDomainsView(TestPortfolioInvitedMemberDomainsView):
@@ -2432,7 +2435,6 @@ class TestPortfolioInvitedMemberEditDomainsView(TestPortfolioInvitedMemberDomain
         self.assertEqual(call_args["requestor"], self.user)
         self.assertEqual(list(call_args["domains"]), list(expected_domains))
         self.assertFalse(call_args.get("is_member_of_different_org"))
-
 
     @less_console_noise_decorator
     @override_flag("organization_feature", active=True)
@@ -2607,7 +2609,10 @@ class TestPortfolioInvitedMemberEditDomainsView(TestPortfolioInvitedMemberDomain
         self.assertRedirects(response, reverse("invitedmember-domains-edit", kwargs={"pk": self.invitation.pk}))
         messages = list(response.wsgi_request._messages)
         self.assertEqual(len(messages), 1)
-        self.assertEqual(str(messages[0]), "An unexpected error occurred: Failed to send email. If the issue persists, please contact help@get.gov.")
+        self.assertEqual(
+            str(messages[0]),
+            "An unexpected error occurred: Failed to send email. If the issue persists, please contact help@get.gov.",
+        )
 
 
 class TestRequestingEntity(WebTest):
@@ -3320,8 +3325,6 @@ class TestPortfolioInviteNewMemberView(TestWithUser, WebTest):
         # Simulate a session to ensure continuity
         session_id = self.client.session.session_key
         self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
-
-        invite_count_before = PortfolioInvitation.objects.count()
 
         new_user = User.objects.create(email="newuser@example.com")
 

--- a/src/registrar/tests/test_views_portfolio.py
+++ b/src/registrar/tests/test_views_portfolio.py
@@ -2390,7 +2390,6 @@ class TestPortfolioInvitedMemberEditDomainsView(TestWithUser, WebTest):
         cls.domain1 = Domain.objects.create(name="1.gov")
         cls.domain2 = Domain.objects.create(name="2.gov")
         cls.domain3 = Domain.objects.create(name="3.gov")
-        
 
     @classmethod
     def tearDownClass(cls):
@@ -2540,10 +2539,14 @@ class TestPortfolioInvitedMemberEditDomainsView(TestWithUser, WebTest):
         DomainInvitation.objects.bulk_create(
             [
                 DomainInvitation(
-                    domain=self.domain1, email="invited@example.com", status=DomainInvitation.DomainInvitationStatus.CANCELED
+                    domain=self.domain1,
+                    email="invited@example.com",
+                    status=DomainInvitation.DomainInvitationStatus.CANCELED,
                 ),
                 DomainInvitation(
-                    domain=self.domain2, email="invited@example.com", status=DomainInvitation.DomainInvitationStatus.INVITED
+                    domain=self.domain2,
+                    email="invited@example.com",
+                    status=DomainInvitation.DomainInvitationStatus.INVITED,
                 ),
             ]
         )
@@ -2581,10 +2584,14 @@ class TestPortfolioInvitedMemberEditDomainsView(TestWithUser, WebTest):
         DomainInvitation.objects.bulk_create(
             [
                 DomainInvitation(
-                    domain=self.domain1, email="invited@example.com", status=DomainInvitation.DomainInvitationStatus.INVITED
+                    domain=self.domain1,
+                    email="invited@example.com",
+                    status=DomainInvitation.DomainInvitationStatus.INVITED,
                 ),
                 DomainInvitation(
-                    domain=self.domain2, email="invited@example.com", status=DomainInvitation.DomainInvitationStatus.INVITED
+                    domain=self.domain2,
+                    email="invited@example.com",
+                    status=DomainInvitation.DomainInvitationStatus.INVITED,
                 ),
             ]
         )

--- a/src/registrar/utility/email_invitations.py
+++ b/src/registrar/utility/email_invitations.py
@@ -48,7 +48,10 @@ def normalize_domains(domains):
 
 
 def get_requestor_email(requestor, domains):
-    """Get the requestor's email or raise an error if it's missing."""
+    """Get the requestor's email or raise an error if it's missing.
+
+    If the requestor is staff, default email is returned.
+    """
     if requestor.is_staff:
         return settings.DEFAULT_FROM_EMAIL
 

--- a/src/registrar/utility/email_invitations.py
+++ b/src/registrar/utility/email_invitations.py
@@ -35,7 +35,6 @@ def send_domain_invitation_email(email: str, requestor, domains: Domain | list[D
         OutsideOrgMemberError: If the requested_user is part of a different organization.
         EmailSendingError: If there is an error while sending the email.
     """
-    print('send_domain_invitation_email')
     # Normalize domains
     if isinstance(domains, Domain):
         domains = [domains]
@@ -88,7 +87,6 @@ def send_domain_invitation_email(email: str, requestor, domains: Domain | list[D
             },
         )
     except EmailSendingError as err:
-        print('point of failure test')
         domain_names = ", ".join([domain.name for domain in domains])
         raise EmailSendingError(
             f"Could not send email invitation to {email} for domains: {domain_names}"

--- a/src/registrar/utility/errors.py
+++ b/src/registrar/utility/errors.py
@@ -46,8 +46,17 @@ class AlreadyDomainInvitedError(InvitationError):
 class MissingEmailError(InvitationError):
     """Raised when the requestor has no email associated with their account."""
 
-    def __init__(self):
-        super().__init__("Can't send invitation email. No email is associated with your user account.")
+    def __init__(self, email=None, domain=None, portfolio=None):
+        # Default message if no additional info is provided
+        message = "Can't send invitation email. No email is associated with your user account."
+
+        # Customize message based on provided arguments
+        if email and domain:
+            message = f"Can't send email to '{email}' on domain '{domain}'. No email exists for the requestor."
+        elif email and portfolio:
+            message = f"Can't send email to '{email}' for portfolio '{portfolio}'. No email exists for the requestor."
+
+        super().__init__(message)
 
 
 class OutsideOrgMemberError(ValueError):

--- a/src/registrar/views/domain.py
+++ b/src/registrar/views/domain.py
@@ -1168,9 +1168,10 @@ class DomainAddUserView(DomainFormBaseView):
 
         member_of_a_different_org, member_of_this_org = get_org_membership(domain_org, requested_email, requested_user)
         try:
+            # COMMENT: this code does not take into account multiple portfolios flag being set to TRUE
+
             # determine portfolio of the domain (code currently is looking at requestor's portfolio)
             # if requested_email/user is not member or invited member of this portfolio
-            # COMMENT: this code does not take into account multiple portfolios flag
             #   send portfolio invitation email
             #   create portfolio invitation
             #   create message to view

--- a/src/registrar/views/domain.py
+++ b/src/registrar/views/domain.py
@@ -1182,9 +1182,12 @@ class DomainAddUserView(DomainFormBaseView):
                 and not member_of_this_org
             ):
                 send_portfolio_invitation_email(email=requested_email, requestor=requestor, portfolio=domain_org)
-                PortfolioInvitation.objects.get_or_create(
+                portfolio_invitation, _ = PortfolioInvitation.objects.get_or_create(
                     email=requested_email, portfolio=domain_org, roles=[UserPortfolioRoleChoices.ORGANIZATION_MEMBER]
                 )
+                if requested_user is not None:
+                    portfolio_invitation.retrieve()
+                    portfolio_invitation.save()
                 messages.success(self.request, f"{requested_email} has been invited to the organization: {domain_org}")
 
             if requested_user is None:

--- a/src/registrar/views/domain.py
+++ b/src/registrar/views/domain.py
@@ -1186,6 +1186,7 @@ class DomainAddUserView(DomainFormBaseView):
                 portfolio_invitation, _ = PortfolioInvitation.objects.get_or_create(
                     email=requested_email, portfolio=domain_org, roles=[UserPortfolioRoleChoices.ORGANIZATION_MEMBER]
                 )
+                # if user exists for email, immediately retrieve portfolio invitation upon creation
                 if requested_user is not None:
                     portfolio_invitation.retrieve()
                     portfolio_invitation.save()

--- a/src/registrar/views/domain.py
+++ b/src/registrar/views/domain.py
@@ -10,7 +10,6 @@ import logging
 import requests
 from django.contrib import messages
 from django.contrib.messages.views import SuccessMessageMixin
-from django.db import IntegrityError
 from django.http import HttpResponseRedirect
 from django.shortcuts import redirect
 from django.urls import reverse
@@ -31,22 +30,23 @@ from registrar.models.user_portfolio_permission import UserPortfolioPermission
 from registrar.models.utility.portfolio_helper import UserPortfolioRoleChoices
 from registrar.utility.enums import DefaultEmail
 from registrar.utility.errors import (
-    AlreadyDomainInvitedError,
-    AlreadyDomainManagerError,
     GenericError,
     GenericErrorCodes,
-    MissingEmailError,
     NameserverError,
     NameserverErrorCodes as nsErrorCodes,
     DsDataError,
     DsDataErrorCodes,
     SecurityEmailError,
     SecurityEmailErrorCodes,
-    OutsideOrgMemberError,
 )
 from registrar.models.utility.contact_error import ContactError
 from registrar.views.utility.permission_views import UserDomainRolePermissionDeleteView
 from registrar.utility.waffle import flag_is_active_for_user
+from registrar.views.utility.portfolio_helper import (
+    get_org_membership,
+    get_requested_user,
+    handle_invitation_exceptions,
+)
 
 from ..forms import (
     SeniorOfficialContactForm,
@@ -1149,43 +1149,13 @@ class DomainAddUserView(DomainFormBaseView):
     def get_success_url(self):
         return reverse("domain-users", kwargs={"pk": self.object.pk})
 
-    def _get_org_membership(self, requestor_org, requested_email, requested_user):
-        """
-        Verifies if an email belongs to a different organization as a member or invited member.
-        Verifies if an email belongs to this organization as a member or invited member.
-        User does not belong to any org can be deduced from the tuple returned.
-
-        Returns a tuple (member_of_a_different_org, member_of_this_org).
-        """
-
-        # COMMENT: this code does not take into account multiple portfolios flag
-
-        # COMMENT: shouldn't this code be based on the organization of the domain, not the org
-        # of the requestor? requestor could have multiple portfolios
-
-        # Check for existing permissions or invitations for the requested user
-        existing_org_permission = UserPortfolioPermission.objects.filter(user=requested_user).first()
-        existing_org_invitation = PortfolioInvitation.objects.filter(email=requested_email).first()
-
-        # Determine membership in a different organization
-        member_of_a_different_org = (
-            existing_org_permission and existing_org_permission.portfolio != requestor_org
-        ) or (existing_org_invitation and existing_org_invitation.portfolio != requestor_org)
-
-        # Determine membership in the same organization
-        member_of_this_org = (existing_org_permission and existing_org_permission.portfolio == requestor_org) or (
-            existing_org_invitation and existing_org_invitation.portfolio == requestor_org
-        )
-
-        return member_of_a_different_org, member_of_this_org
-
     def form_valid(self, form):
         """Add the specified user to this domain."""
         requested_email = form.cleaned_data["email"]
         requestor = self.request.user
 
         # Look up a user with that email
-        requested_user = self._get_requested_user(requested_email)
+        requested_user = get_requested_user(requested_email)
         # NOTE: This does not account for multiple portfolios flag being set to True
         domain_org = self.object.domain_info.portfolio
 
@@ -1196,48 +1166,35 @@ class DomainAddUserView(DomainFormBaseView):
             or requestor.is_staff
         )
 
-        member_of_a_different_org, member_of_this_org = self._get_org_membership(
-            domain_org, requested_email, requested_user
-        )
-
-        # determine portfolio of the domain (code currently is looking at requestor's portfolio)
-        # if requested_email/user is not member or invited member of this portfolio
-        # COMMENT: this code does not take into account multiple portfolios flag
-        #   send portfolio invitation email
-        #   create portfolio invitation
-        #   create message to view
-        if (
-            flag_is_active_for_user(requestor, "organization_feature")
-            and not flag_is_active_for_user(requestor, "multiple_portfolios")
-            and domain_org is not None
-            and requestor_can_update_portfolio
-            and not member_of_this_org
-        ):
-            try:
-                send_portfolio_invitation_email(email=requested_email, requestor=requestor, portfolio=domain_org)
-                PortfolioInvitation.objects.get_or_create(email=requested_email, portfolio=domain_org)
-                messages.success(self.request, f"{requested_email} has been invited to the organization: {domain_org}")
-            except Exception as e:
-                self._handle_portfolio_exceptions(e, requested_email, domain_org)
-                # If that first invite does not succeed take an early exit
-                return redirect(self.get_success_url())
-
+        member_of_a_different_org, member_of_this_org = get_org_membership(domain_org, requested_email, requested_user)
         try:
+            # determine portfolio of the domain (code currently is looking at requestor's portfolio)
+            # if requested_email/user is not member or invited member of this portfolio
+            # COMMENT: this code does not take into account multiple portfolios flag
+            #   send portfolio invitation email
+            #   create portfolio invitation
+            #   create message to view
+            if (
+                flag_is_active_for_user(requestor, "organization_feature")
+                and not flag_is_active_for_user(requestor, "multiple_portfolios")
+                and domain_org is not None
+                and requestor_can_update_portfolio
+                and not member_of_this_org
+            ):
+                send_portfolio_invitation_email(email=requested_email, requestor=requestor, portfolio=domain_org)
+                PortfolioInvitation.objects.get_or_create(
+                    email=requested_email, portfolio=domain_org, roles=[UserPortfolioRoleChoices.ORGANIZATION_MEMBER]
+                )
+                messages.success(self.request, f"{requested_email} has been invited to the organization: {domain_org}")
+
             if requested_user is None:
                 self._handle_new_user_invitation(requested_email, requestor, member_of_a_different_org)
             else:
                 self._handle_existing_user(requested_email, requestor, requested_user, member_of_a_different_org)
         except Exception as e:
-            self._handle_exceptions(e, requested_email)
+            handle_invitation_exceptions(self.request, e, requested_email)
 
         return redirect(self.get_success_url())
-
-    def _get_requested_user(self, email):
-        """Retrieve a user by email or return None if the user doesn't exist."""
-        try:
-            return User.objects.get(email=email)
-        except User.DoesNotExist:
-            return None
 
     def _handle_new_user_invitation(self, email, requestor, member_of_different_org):
         """Handle invitation for a new user who does not exist in the system."""
@@ -1264,57 +1221,6 @@ class DomainAddUserView(DomainFormBaseView):
             role=UserDomainRole.Roles.MANAGER,
         )
         messages.success(self.request, f"Added user {email}.")
-
-    def _handle_exceptions(self, exception, email):
-        """Handle exceptions raised during the process."""
-        if isinstance(exception, EmailSendingError):
-            logger.warning(
-                "Could not send email invitation to %s for domain %s (EmailSendingError)",
-                email,
-                self.object,
-                exc_info=True,
-            )
-            messages.warning(self.request, "Could not send email invitation.")
-        elif isinstance(exception, OutsideOrgMemberError):
-            logger.warning(
-                "Could not send email. Can not invite member of a .gov organization to a different organization.",
-                self.object,
-                exc_info=True,
-            )
-            messages.error(
-                self.request,
-                f"{email} is already a member of another .gov organization.",
-            )
-        elif isinstance(exception, AlreadyDomainManagerError):
-            messages.warning(self.request, str(exception))
-        elif isinstance(exception, AlreadyDomainInvitedError):
-            messages.warning(self.request, str(exception))
-        elif isinstance(exception, MissingEmailError):
-            messages.error(self.request, str(exception))
-            logger.error(
-                f"Can't send email to '{email}' on domain '{self.object}'. No email exists for the requestor.",
-                exc_info=True,
-            )
-        elif isinstance(exception, IntegrityError):
-            messages.warning(self.request, f"{email} is already a manager for this domain")
-        else:
-            logger.warning("Could not send email invitation (Other Exception)", exc_info=True)
-            messages.warning(self.request, "Could not send email invitation.")
-
-    def _handle_portfolio_exceptions(self, exception, email, portfolio):
-        """Handle exceptions raised during the process."""
-        if isinstance(exception, EmailSendingError):
-            logger.warning("Could not send email invitation (EmailSendingError)", exc_info=True)
-            messages.warning(self.request, "Could not send email invitation.")
-        elif isinstance(exception, MissingEmailError):
-            messages.error(self.request, str(exception))
-            logger.error(
-                f"Can't send email to '{email}' for portfolio '{portfolio}'. No email exists for the requestor.",
-                exc_info=True,
-            )
-        else:
-            logger.warning("Could not send email invitation (Other Exception)", exc_info=True)
-            messages.warning(self.request, "Could not send email invitation.")
 
 
 class DomainInvitationCancelView(SuccessMessageMixin, DomainInvitationPermissionCancelView):

--- a/src/registrar/views/domain.py
+++ b/src/registrar/views/domain.py
@@ -1204,7 +1204,7 @@ class DomainAddUserView(DomainFormBaseView):
         send_domain_invitation_email(
             email=email,
             requestor=requestor,
-            domain=self.object,
+            domains=self.object,
             is_member_of_different_org=member_of_different_org,
         )
         DomainInvitation.objects.get_or_create(email=email, domain=self.object)
@@ -1215,8 +1215,9 @@ class DomainAddUserView(DomainFormBaseView):
         send_domain_invitation_email(
             email=email,
             requestor=requestor,
-            domain=self.object,
+            domains=self.object,
             is_member_of_different_org=member_of_different_org,
+            requested_user=requested_user,
         )
         UserDomainRole.objects.create(
             user=requested_user,

--- a/src/registrar/views/domain.py
+++ b/src/registrar/views/domain.py
@@ -42,7 +42,7 @@ from registrar.utility.errors import (
 from registrar.models.utility.contact_error import ContactError
 from registrar.views.utility.permission_views import UserDomainRolePermissionDeleteView
 from registrar.utility.waffle import flag_is_active_for_user
-from registrar.views.utility.portfolio_helper import (
+from registrar.views.utility.invitation_helper import (
     get_org_membership,
     get_requested_user,
     handle_invitation_exceptions,

--- a/src/registrar/views/portfolios.py
+++ b/src/registrar/views/portfolios.py
@@ -296,7 +296,7 @@ class PortfolioMemberDomainsEditView(PortfolioMemberDomainsEditPermissionView, V
         Processes added domains by bulk creating UserDomainRole instances.
         """
         if added_domain_ids:
-            print('_process_added_domains')
+            # get added_domains from ids to pass to send email method and bulk create
             added_domains = Domain.objects.filter(id__in=added_domain_ids)
             member_of_a_different_org, _ = get_org_membership(portfolio, member.email, member)
             send_domain_invitation_email(
@@ -514,14 +514,15 @@ class PortfolioInvitedMemberDomainsEditView(PortfolioMemberDomainsEditPermission
         or creating new ones.
         """
         if added_domain_ids:
+            # get added_domains from ids to pass to send email method and bulk create
             added_domains = Domain.objects.filter(id__in=added_domain_ids)
             member_of_a_different_org, _ = get_org_membership(portfolio, email, None)
             send_domain_invitation_email(
-                    email=email,
-                    requestor=requestor,
-                    domains=added_domains,
-                    is_member_of_different_org=member_of_a_different_org,
-                )
+                email=email,
+                requestor=requestor,
+                domains=added_domains,
+                is_member_of_different_org=member_of_a_different_org,
+            )
 
             # Update existing invitations from CANCELED to INVITED
             existing_invitations = DomainInvitation.objects.filter(domain__in=added_domains, email=email)
@@ -542,7 +543,7 @@ class PortfolioInvitedMemberDomainsEditView(PortfolioMemberDomainsEditPermission
                     for domain_id in new_domain_ids
                 ]
             )
-        
+
     def _process_removed_domains(self, removed_domain_ids, email):
         """
         Processes removed domain invitations by updating their status to CANCELED.
@@ -777,6 +778,7 @@ class PortfolioAddMemberView(PortfolioMembersPermissionView, FormMixin):
             if not requested_user or not permission_exists:
                 send_portfolio_invitation_email(email=requested_email, requestor=requestor, portfolio=portfolio)
                 portfolio_invitation = form.save()
+                # if user exists for email, immediately retrieve portfolio invitation upon creation
                 if requested_user is not None:
                     portfolio_invitation.retrieve()
                     portfolio_invitation.save()

--- a/src/registrar/views/portfolios.py
+++ b/src/registrar/views/portfolios.py
@@ -754,7 +754,9 @@ class PortfolioAddMemberView(PortfolioMembersPermissionView, FormMixin):
         try:
             if not requested_user or not permission_exists:
                 send_portfolio_invitation_email(email=requested_email, requestor=requestor, portfolio=portfolio)
-                form.save()
+                portfolio_invitation = form.save()
+                portfolio_invitation.retrieve()
+                portfolio_invitation.save()
                 messages.success(self.request, f"{requested_email} has been invited.")
             else:
                 if permission_exists:

--- a/src/registrar/views/portfolios.py
+++ b/src/registrar/views/portfolios.py
@@ -8,13 +8,14 @@ from django.utils.safestring import mark_safe
 from django.contrib import messages
 from registrar.forms import portfolio as portfolioForms
 from registrar.models import Portfolio, User
+from registrar.models.domain import Domain
 from registrar.models.domain_invitation import DomainInvitation
 from registrar.models.portfolio_invitation import PortfolioInvitation
 from registrar.models.user_domain_role import UserDomainRole
 from registrar.models.user_portfolio_permission import UserPortfolioPermission
 from registrar.models.utility.portfolio_helper import UserPortfolioPermissionChoices, UserPortfolioRoleChoices
 from registrar.utility.email import EmailSendingError
-from registrar.utility.email_invitations import send_portfolio_invitation_email
+from registrar.utility.email_invitations import send_domain_invitation_email, send_portfolio_invitation_email
 from registrar.utility.errors import MissingEmailError
 from registrar.utility.enums import DefaultUserValues
 from registrar.views.utility.mixins import PortfolioMemberPermission
@@ -32,6 +33,8 @@ from registrar.views.utility.permission_views import (
 from django.views.generic import View
 from django.views.generic.edit import FormMixin
 from django.db import IntegrityError
+
+from registrar.views.utility.portfolio_helper import get_org_membership
 
 
 logger = logging.getLogger(__name__)
@@ -237,6 +240,7 @@ class PortfolioMemberDomainsEditView(PortfolioMemberDomainsEditPermissionView, V
         removed_domains = request.POST.get("removed_domains")
         portfolio_permission = get_object_or_404(UserPortfolioPermission, pk=pk)
         member = portfolio_permission.user
+        portfolio = portfolio_permission.portfolio
 
         added_domain_ids = self._parse_domain_ids(added_domains, "added domains")
         if added_domain_ids is None:
@@ -248,7 +252,7 @@ class PortfolioMemberDomainsEditView(PortfolioMemberDomainsEditPermissionView, V
 
         if added_domain_ids or removed_domain_ids:
             try:
-                self._process_added_domains(added_domain_ids, member)
+                self._process_added_domains(added_domain_ids, member, request.user, portfolio)
                 self._process_removed_domains(removed_domain_ids, member)
                 messages.success(request, "The domain assignment changes have been saved.")
                 return redirect(reverse("member-domains", kwargs={"pk": pk}))
@@ -263,7 +267,7 @@ class PortfolioMemberDomainsEditView(PortfolioMemberDomainsEditPermissionView, V
             except Exception as e:
                 messages.error(
                     request,
-                    "An unexpected error occurred: {str(e)}. If the issue persists, "
+                    f"An unexpected error occurred: {str(e)}. If the issue persists, "
                     f"please contact {DefaultUserValues.HELP_EMAIL}.",
                 )
                 logger.error(f"An unexpected error occurred: {str(e)}")
@@ -287,16 +291,26 @@ class PortfolioMemberDomainsEditView(PortfolioMemberDomainsEditPermissionView, V
             logger.error(f"Invalid data for {domain_type}")
             return None
 
-    def _process_added_domains(self, added_domain_ids, member):
+    def _process_added_domains(self, added_domain_ids, member, requestor, portfolio):
         """
         Processes added domains by bulk creating UserDomainRole instances.
         """
         if added_domain_ids:
+            print('_process_added_domains')
+            added_domains = Domain.objects.filter(id__in=added_domain_ids)
+            member_of_a_different_org, _ = get_org_membership(portfolio, member.email, member)
+            send_domain_invitation_email(
+                email=member.email,
+                requestor=requestor,
+                domains=added_domains,
+                is_member_of_different_org=member_of_a_different_org,
+                requested_user=member,
+            )
             # Bulk create UserDomainRole instances for added domains
             UserDomainRole.objects.bulk_create(
                 [
-                    UserDomainRole(domain_id=domain_id, user=member, role=UserDomainRole.Roles.MANAGER)
-                    for domain_id in added_domain_ids
+                    UserDomainRole(domain=domain, user=member, role=UserDomainRole.Roles.MANAGER)
+                    for domain in added_domains
                 ],
                 ignore_conflicts=True,  # Avoid duplicate entries
             )
@@ -443,6 +457,7 @@ class PortfolioInvitedMemberDomainsEditView(PortfolioMemberDomainsEditPermission
         removed_domains = request.POST.get("removed_domains")
         portfolio_invitation = get_object_or_404(PortfolioInvitation, pk=pk)
         email = portfolio_invitation.email
+        portfolio = portfolio_invitation.portfolio
 
         added_domain_ids = self._parse_domain_ids(added_domains, "added domains")
         if added_domain_ids is None:
@@ -454,7 +469,7 @@ class PortfolioInvitedMemberDomainsEditView(PortfolioMemberDomainsEditPermission
 
         if added_domain_ids or removed_domain_ids:
             try:
-                self._process_added_domains(added_domain_ids, email)
+                self._process_added_domains(added_domain_ids, email, request.user, portfolio)
                 self._process_removed_domains(removed_domain_ids, email)
                 messages.success(request, "The domain assignment changes have been saved.")
                 return redirect(reverse("invitedmember-domains", kwargs={"pk": pk}))
@@ -469,7 +484,7 @@ class PortfolioInvitedMemberDomainsEditView(PortfolioMemberDomainsEditPermission
             except Exception as e:
                 messages.error(
                     request,
-                    "An unexpected error occurred: {str(e)}. If the issue persists, "
+                    f"An unexpected error occurred: {str(e)}. If the issue persists, "
                     f"please contact {DefaultUserValues.HELP_EMAIL}.",
                 )
                 logger.error(f"An unexpected error occurred: {str(e)}.")
@@ -493,34 +508,41 @@ class PortfolioInvitedMemberDomainsEditView(PortfolioMemberDomainsEditPermission
             logger.error(f"Invalid data for {domain_type}.")
             return None
 
-    def _process_added_domains(self, added_domain_ids, email):
+    def _process_added_domains(self, added_domain_ids, email, requestor, portfolio):
         """
         Processes added domain invitations by updating existing invitations
         or creating new ones.
         """
-        if not added_domain_ids:
-            return
-
-        # Update existing invitations from CANCELED to INVITED
-        existing_invitations = DomainInvitation.objects.filter(domain_id__in=added_domain_ids, email=email)
-        existing_invitations.update(status=DomainInvitation.DomainInvitationStatus.INVITED)
-
-        # Determine which domains need new invitations
-        existing_domain_ids = existing_invitations.values_list("domain_id", flat=True)
-        new_domain_ids = set(added_domain_ids) - set(existing_domain_ids)
-
-        # Bulk create new invitations
-        DomainInvitation.objects.bulk_create(
-            [
-                DomainInvitation(
-                    domain_id=domain_id,
+        if added_domain_ids:
+            added_domains = Domain.objects.filter(id__in=added_domain_ids)
+            member_of_a_different_org, _ = get_org_membership(portfolio, email, None)
+            send_domain_invitation_email(
                     email=email,
-                    status=DomainInvitation.DomainInvitationStatus.INVITED,
+                    requestor=requestor,
+                    domains=added_domains,
+                    is_member_of_different_org=member_of_a_different_org,
                 )
-                for domain_id in new_domain_ids
-            ]
-        )
 
+            # Update existing invitations from CANCELED to INVITED
+            existing_invitations = DomainInvitation.objects.filter(domain__in=added_domains, email=email)
+            existing_invitations.update(status=DomainInvitation.DomainInvitationStatus.INVITED)
+
+            # Determine which domains need new invitations
+            existing_domain_ids = existing_invitations.values_list("domain_id", flat=True)
+            new_domain_ids = set(added_domain_ids) - set(existing_domain_ids)
+
+            # Bulk create new invitations
+            DomainInvitation.objects.bulk_create(
+                [
+                    DomainInvitation(
+                        domain_id=domain_id,
+                        email=email,
+                        status=DomainInvitation.DomainInvitationStatus.INVITED,
+                    )
+                    for domain_id in new_domain_ids
+                ]
+            )
+        
     def _process_removed_domains(self, removed_domain_ids, email):
         """
         Processes removed domain invitations by updating their status to CANCELED.
@@ -755,8 +777,9 @@ class PortfolioAddMemberView(PortfolioMembersPermissionView, FormMixin):
             if not requested_user or not permission_exists:
                 send_portfolio_invitation_email(email=requested_email, requestor=requestor, portfolio=portfolio)
                 portfolio_invitation = form.save()
-                portfolio_invitation.retrieve()
-                portfolio_invitation.save()
+                if requested_user is not None:
+                    portfolio_invitation.retrieve()
+                    portfolio_invitation.save()
                 messages.success(self.request, f"{requested_email} has been invited.")
             else:
                 if permission_exists:

--- a/src/registrar/views/portfolios.py
+++ b/src/registrar/views/portfolios.py
@@ -34,7 +34,7 @@ from django.views.generic import View
 from django.views.generic.edit import FormMixin
 from django.db import IntegrityError
 
-from registrar.views.utility.portfolio_helper import get_org_membership
+from registrar.views.utility.invitation_helper import get_org_membership
 
 
 logger = logging.getLogger(__name__)

--- a/src/registrar/views/portfolios.py
+++ b/src/registrar/views/portfolios.py
@@ -262,7 +262,7 @@ class PortfolioMemberDomainsEditView(PortfolioMemberDomainsEditPermissionView, V
                     "A database error occurred while saving changes. If the issue persists, "
                     f"please contact {DefaultUserValues.HELP_EMAIL}.",
                 )
-                logger.error("A database error occurred while saving changes.")
+                logger.error("A database error occurred while saving changes.", exc_info=True)
                 return redirect(reverse("member-domains-edit", kwargs={"pk": pk}))
             except Exception as e:
                 messages.error(
@@ -270,7 +270,7 @@ class PortfolioMemberDomainsEditView(PortfolioMemberDomainsEditPermissionView, V
                     f"An unexpected error occurred: {str(e)}. If the issue persists, "
                     f"please contact {DefaultUserValues.HELP_EMAIL}.",
                 )
-                logger.error(f"An unexpected error occurred: {str(e)}")
+                logger.error(f"An unexpected error occurred: {str(e)}", exc_info=True)
                 return redirect(reverse("member-domains-edit", kwargs={"pk": pk}))
         else:
             messages.info(request, "No changes detected.")
@@ -479,7 +479,7 @@ class PortfolioInvitedMemberDomainsEditView(PortfolioMemberDomainsEditPermission
                     "A database error occurred while saving changes. If the issue persists, "
                     f"please contact {DefaultUserValues.HELP_EMAIL}.",
                 )
-                logger.error("A database error occurred while saving changes.")
+                logger.error("A database error occurred while saving changes.", exc_info=True)
                 return redirect(reverse("invitedmember-domains-edit", kwargs={"pk": pk}))
             except Exception as e:
                 messages.error(
@@ -487,7 +487,7 @@ class PortfolioInvitedMemberDomainsEditView(PortfolioMemberDomainsEditPermission
                     f"An unexpected error occurred: {str(e)}. If the issue persists, "
                     f"please contact {DefaultUserValues.HELP_EMAIL}.",
                 )
-                logger.error(f"An unexpected error occurred: {str(e)}.")
+                logger.error(f"An unexpected error occurred: {str(e)}.", exc_info=True)
                 return redirect(reverse("invitedmember-domains-edit", kwargs={"pk": pk}))
         else:
             messages.info(request, "No changes detected.")

--- a/src/registrar/views/utility/invitation_helper.py
+++ b/src/registrar/views/utility/invitation_helper.py
@@ -19,6 +19,7 @@ logger = logging.getLogger(__name__)
 # when creating invitations and sending associated emails. These can be reused in
 # any view, and were initially developed for domain.py, portfolios.py and admin.py
 
+
 def get_org_membership(requestor_org, requested_email, requested_user):
     """
     Verifies if an email belongs to a different organization as a member or invited member.

--- a/src/registrar/views/utility/invitation_helper.py
+++ b/src/registrar/views/utility/invitation_helper.py
@@ -28,7 +28,7 @@ def get_org_membership(requestor_org, requested_email, requested_user):
     Returns a tuple (member_of_a_different_org, member_of_this_org).
     """
 
-    # COMMENT: this code does not take into account multiple portfolios flag
+    # COMMENT: this code does not take into account when multiple portfolios flag is set to true
 
     # COMMENT: shouldn't this code be based on the organization of the domain, not the org
     # of the requestor? requestor could have multiple portfolios

--- a/src/registrar/views/utility/invitation_helper.py
+++ b/src/registrar/views/utility/invitation_helper.py
@@ -15,6 +15,9 @@ from registrar.utility.errors import (
 
 logger = logging.getLogger(__name__)
 
+# These methods are used by multiple views which share similar logic and function
+# when creating invitations and sending associated emails. These can be reused in
+# any view, and were initially developed for domain.py, portfolios.py and admin.py
 
 def get_org_membership(requestor_org, requested_email, requested_user):
     """

--- a/src/registrar/views/utility/portfolio_helper.py
+++ b/src/registrar/views/utility/portfolio_helper.py
@@ -1,0 +1,83 @@
+from django.contrib import messages
+from django.db import IntegrityError
+from registrar.models.portfolio_invitation import PortfolioInvitation
+from registrar.models.user import User
+from registrar.models.user_portfolio_permission import UserPortfolioPermission
+from registrar.utility.email import EmailSendingError
+import logging
+
+from registrar.utility.errors import (
+    AlreadyDomainInvitedError,
+    AlreadyDomainManagerError,
+    MissingEmailError,
+    OutsideOrgMemberError,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def get_org_membership(requestor_org, requested_email, requested_user):
+    """
+    Verifies if an email belongs to a different organization as a member or invited member.
+    Verifies if an email belongs to this organization as a member or invited member.
+    User does not belong to any org can be deduced from the tuple returned.
+
+    Returns a tuple (member_of_a_different_org, member_of_this_org).
+    """
+
+    # COMMENT: this code does not take into account multiple portfolios flag
+
+    # COMMENT: shouldn't this code be based on the organization of the domain, not the org
+    # of the requestor? requestor could have multiple portfolios
+
+    # Check for existing permissions or invitations for the requested user
+    existing_org_permission = UserPortfolioPermission.objects.filter(user=requested_user).first()
+    existing_org_invitation = PortfolioInvitation.objects.filter(email=requested_email).first()
+
+    # Determine membership in a different organization
+    member_of_a_different_org = (existing_org_permission and existing_org_permission.portfolio != requestor_org) or (
+        existing_org_invitation and existing_org_invitation.portfolio != requestor_org
+    )
+
+    # Determine membership in the same organization
+    member_of_this_org = (existing_org_permission and existing_org_permission.portfolio == requestor_org) or (
+        existing_org_invitation and existing_org_invitation.portfolio == requestor_org
+    )
+
+    return member_of_a_different_org, member_of_this_org
+
+
+def get_requested_user(email):
+    """Retrieve a user by email or return None if the user doesn't exist."""
+    try:
+        return User.objects.get(email=email)
+    except User.DoesNotExist:
+        return None
+
+
+def handle_invitation_exceptions(request, exception, email):
+    """Handle exceptions raised during the process."""
+    if isinstance(exception, EmailSendingError):
+        logger.warning(str(exception), exc_info=True)
+        messages.error(request, str(exception))
+    elif isinstance(exception, MissingEmailError):
+        messages.error(request, str(exception))
+        logger.error(str(exception), exc_info=True)
+    elif isinstance(exception, OutsideOrgMemberError):
+        logger.warning(
+            "Could not send email. Can not invite member of a .gov organization to a different organization.",
+            exc_info=True,
+        )
+        messages.error(
+            request,
+            f"{email} is already a member of another .gov organization.",
+        )
+    elif isinstance(exception, AlreadyDomainManagerError):
+        messages.warning(request, str(exception))
+    elif isinstance(exception, AlreadyDomainInvitedError):
+        messages.warning(request, str(exception))
+    elif isinstance(exception, IntegrityError):
+        messages.warning(request, f"{email} is already a manager for this domain")
+    else:
+        logger.warning("Could not send email invitation (Other Exception)", exc_info=True)
+        messages.warning(request, "Could not send email invitation.")


### PR DESCRIPTION
## Ticket

<!-- PR title format: `#issue_number: Descriptive name ideally matching ticket name - [sandbox]`-->
Resolves #2960 
Resolves #3295 

## Changes

<!-- What was added, updated, or removed in this PR. -->
- Functional changes:
  - In DJA, domain invitation adds send email for the domain invitation
  - In DJA, domain invitation adds conditionally create a portfolio invitation and send email for the portfolio invitation
  - In portfolio member domain assignment, single email sent to member for all newly invited domains
  - In portfolio member domain assignment (for invited member), single email sent to invited member for all newly invited  domains
  - When portfolio invitation is created, if user already exists for email, portfolio invitation is automatically retrieved. (This solves a bug where domains for existing users with portfolio invitations were not properly being displayed or edited in portfolio member views)
  - Fixed a bug we found where UserPortfolioPermissions were not allowed to be edited if there was a retrieved invitation for that same email for that same portfolio.
  - Fixed a bug in DJA portfolio invitation change list when attempting to execute a query. Was throwing a 500, now working properly.
- Notable code changes:
  - Consolidated exception handling for invitation methods throughout views into a helper file
  - Customized some exception classes so messages could be varied based on usage, but still handled in consolidate fashion
  - Consolidated shared logic for invitation methods throughout views into a helper file
  - Domain invitation template extended to conditionally handle an invitation to single domain or multiple domains

<!--
    Please add/remove/edit any of the template below to fit the needs
    of this specific PR.
--->

## Context for reviewers

<!--Background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers.  -->

## Setup

<!--  Add any steps or code to run in this section to help others run your code.
    
    Example 1:
    ```sh
    echo "Code goes here"
    ``` 
    
    Example 2: If the PR was to add a new link with a redirect, this section could simply be:
    -go to /path/to/start/page
    -click the blue link in the <insert location>
    -notice user is redirected to <proper end location>
-->

## Code Review Verification Steps

### As the original developer, I have

#### Satisfied acceptance criteria and met development standards

- [x] Met the acceptance criteria, or will meet them in a subsequent PR
- [x] Created/modified automated tests
- [x] Update documentation in READMEs and/or onboarding guide

#### Ensured code standards are met (Original Developer)
<!-- Mark "- N/A" and check at the end of each check that is not applicable to your PR -->
- [x] If any updated dependencies on Pipfile, also update dependencies in requirements.txt.
- [x] Interactions with external systems are wrapped in try/except
- [x] Error handling exists for unusual or missing values

#### Validated user-facing changes (if applicable)

- [x] Tag @dotgov-designers in this PR's Reviewers for design review. If code is not user-facing, delete design reviewer checklist
- [x] Verify new pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [x] Checked keyboard navigability
- [x] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)

### As a code reviewer, I have

#### Reviewed, tested, and left feedback about the changes

- [ ] Pulled this branch locally and tested it
- [ ] Verified code meets all checks above. Address any checks that are not satisfied
- [ ] Reviewed this code and left comments. Indicate if comments must be addressed before code is merged
- [ ] Checked that all code is adequately covered by tests
- [ ] Verify migrations are valid and do not conflict with existing migrations

#### Validated user-facing changes as a developer
**Note:** Multiple code reviewers can share the checklists above, a second reviewer should not make a duplicate checklist. All checks should be checked before approving, even those labeled N/A. 

- [ ] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Checked keyboard navigability
- [ ] Meets all designs and user flows provided by design/product
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)
- [ ] (Rarely needed) Tested as both an analyst and applicant user

### As a designer reviewer, I have

#### Verified that the changes match the design intention

- [ ] Checked that the design translated visually
- [ ] Checked behavior. Comment any found issues or broken flows.
- [ ] Checked different states (empty, one, some, error)
- [ ] Checked for landmarks, page heading structure, and links

#### Validated user-facing changes as a designer

- [ ] Checked keyboard navigability
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)
- [ ] Tested with multiple browsers (check off which ones were used)
  - [ ] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari
- [ ] (Rarely needed) Tested as both an analyst and applicant user

### References
- [Code review best practices](../docs/dev-practices/code_review.md)

## Screenshots

<!-- If this PR makes visible interface changes, an image of the finished interface can help reviewers
and casual observers understand the context of the changes.
A before image is optional and can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow.
You may want to use [GIPHY Capture](https://giphy.com/apps/giphycapture) for this! 📸

_Please frame images to show useful context but also highlight the affected regions._
--->
