### PR TITLE
#3171: fix auditlog errors

### DIFF
--- a/src/registrar/admin.py
+++ b/src/registrar/admin.py
@@ -2785,7 +2785,7 @@ class DomainRequestAdmin(ListHeaderAdmin, ImportExportModelAdmin):
             audit_log_entries = LogEntry.objects.filter(
                 object_id=object_id, content_type__model="domainrequest"
             ).order_by("-timestamp")
-            
+
             # Process each log entry to filter based on the change criteria
             for log_entry in audit_log_entries:
                 entry = self.process_log_entry(log_entry)

--- a/src/registrar/admin.py
+++ b/src/registrar/admin.py
@@ -2782,8 +2782,10 @@ class DomainRequestAdmin(ListHeaderAdmin, ImportExportModelAdmin):
 
         try:
             # Retrieve and order audit log entries by timestamp in descending order
-            audit_log_entries = LogEntry.objects.filter(object_id=object_id).order_by("-timestamp")
-
+            audit_log_entries = LogEntry.objects.filter(
+                object_id=object_id, content_type__model="domainrequest"
+            ).order_by("-timestamp")
+            
             # Process each log entry to filter based on the change criteria
             for log_entry in audit_log_entries:
                 entry = self.process_log_entry(log_entry)


### PR DESCRIPTION
## Ticket

<!-- PR title format: `#issue_number: Descriptive name ideally matching ticket name - [sandbox]`-->
Resolves #3171 

## Changes

<!-- What was added, updated, or removed in this PR. -->
- Small fix on the filter for auditlogs in the domain request admin page

<!--
    Please add/remove/edit any of the template below to fit the needs
    of this specific PR.
--->

## Context for reviewers
Error logs have been showing up on stable that we couldn't explain. Turns out they were caused by an insufficiently specific database query that was pulling in some auditlogs for unrelated objects that happened to have the same object id. The hard part for this PR is just testing, see below for details.

<!--Background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers.  -->

## Setup

<!--  Add any steps or code to run in this section to help others run your code.
    
    Example 1:
    ```sh
    echo "Code goes here"
    ``` 
    
    Example 2: If the PR was to add a new link with a redirect, this section could simply be:
    -go to /path/to/start/page
    -click the blue link in the <insert location>
    -notice user is redirected to <proper end location>
-->

## Code Review Verification Steps
This issue is caused by auditlogs existing for a domainrequest object and a domaininvitation object that have the same object_id. I have manually created such a situation for stay-year-relate.gov on MS. To test this, you must navigate to that domain in the domain request admin panel, and then observe logs (for example by searching on logs.fr.cloud.gov using the filter `@cf.app: getgov-ms AND @source.type: APP` over the last X minutes. Initially you should see no errors like "An error occurred during change_view: 'invited' is not a valid DomainRequest.DomainRequestStatus". Note that it can take a few minutes for logs to populate, so maybe get coffee or something first. The error should not be there because the fix is deployed. If you want to be thorough, deploy main to MS and repeat this behavior to prove that the log appears without the fix.

### As the original developer, I have

#### Satisfied acceptance criteria and met development standards

- [x] Met the acceptance criteria, or will meet them in a subsequent PR
- [ ] Created/modified automated tests
- [ ] Update documentation in READMEs and/or onboarding guide

#### Ensured code standards are met (Original Developer)
<!-- Mark "- N/A" and check at the end of each check that is not applicable to your PR -->
- [ ] If any updated dependencies on Pipfile, also update dependencies in requirements.txt.
- [ ] Interactions with external systems are wrapped in try/except
- [ ] Error handling exists for unusual or missing values

#### Validated user-facing changes (if applicable)

- [ ] Tag @dotgov-designers in this PR's Reviewers for design review. If code is not user-facing, delete design reviewer checklist
- [ ] Verify new pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Checked keyboard navigability
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)

### As a code reviewer, I have

#### Reviewed, tested, and left feedback about the changes

- [ ] Pulled this branch locally and tested it
- [x] Verified code meets all checks above. Address any checks that are not satisfied
- [x] Reviewed this code and left comments. Indicate if comments must be addressed before code is merged
- [x] Checked that all code is adequately covered by tests
- [ ] Verify migrations are valid and do not conflict with existing migrations

#### Validated user-facing changes as a developer
**Note:** Multiple code reviewers can share the checklists above, a second reviewer should not make a duplicate checklist. All checks should be checked before approving, even those labeled N/A. 

- [ ] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Checked keyboard navigability
- [ ] Meets all designs and user flows provided by design/product
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)
- [ ] (Rarely needed) Tested as both an analyst and applicant user

### As a designer reviewer, I have

#### Verified that the changes match the design intention

- [ ] Checked that the design translated visually
- [ ] Checked behavior. Comment any found issues or broken flows.
- [ ] Checked different states (empty, one, some, error)
- [ ] Checked for landmarks, page heading structure, and links

#### Validated user-facing changes as a designer

- [ ] Checked keyboard navigability
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)
- [ ] Tested with multiple browsers (check off which ones were used)
  - [ ] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari
- [ ] (Rarely needed) Tested as both an analyst and applicant user

### References
- [Code review best practices](../docs/dev-practices/code_review.md)

## Screenshots

<!-- If this PR makes visible interface changes, an image of the finished interface can help reviewers
and casual observers understand the context of the changes.
A before image is optional and can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow.
You may want to use [GIPHY Capture](https://giphy.com/apps/giphycapture) for this! 📸

_Please frame images to show useful context but also highlight the affected regions._
--->
