### PR TITLE
Email: content updates for email sent to existing domain managers

### DIFF
--- a/src/registrar/templates/emails/domain_manager_notification.txt
+++ b/src/registrar/templates/emails/domain_manager_notification.txt
@@ -2,27 +2,22 @@
 Hi,{% if domain_manager and domain_manager.first_name %} {{ domain_manager.first_name }}.{% endif %}
 
 A domain manager was invited to {{ domain.name }}.
-DOMAIN: {{ domain.name }}
+
 INVITED BY: {{ requestor_email }}
 INVITED ON: {{date}}
 MANAGER INVITED: {{ invited_email_address }}
 
-
 ----------------------------------------------------------------
 
-
 NEXT STEPS
-
 The person who received the invitation will become a domain manager once they log in to the
 .gov registrar. They'll need to access the registrar using a Login.gov account that's
 associated with the invited email address.
 
-If you need to cancel this invitation or remove the domain manager (because they've already
-logged in), you can do that by going to this domain in the .gov registrar <https://manage.get.gov/>.
+If you need to cancel this invitation or remove the domain manager, you can do that by going to this domain in the .gov registrar <https://manage.get.gov/>.
 
 
 WHY DID YOU RECEIVE THIS EMAIL? 
-
 You’re listed as a domain manager for {{ domain.name }}, so you’ll receive a notification whenever
 someone is invited to manage that domain.
 

--- a/src/registrar/templates/emails/domain_manager_notification.txt
+++ b/src/registrar/templates/emails/domain_manager_notification.txt
@@ -14,7 +14,8 @@ The person who received the invitation will become a domain manager once they lo
 .gov registrar. They'll need to access the registrar using a Login.gov account that's
 associated with the invited email address.
 
-If you need to cancel this invitation or remove the domain manager, you can do that by going to this domain in the .gov registrar <https://manage.get.gov/>.
+If you need to cancel this invitation or remove the domain manager, you can do that by going to 
+this domain in the .gov registrar <https://manage.get.gov/>.
 
 
 WHY DID YOU RECEIVE THIS EMAIL? 


### PR DESCRIPTION
## Ticket
[](url)
This is related to my content review for [2831](https://github.com/cisagov/manage.get.gov/issues/2831). This PR should **not** close the ticket, though.

## Changes

<!-- What was added, updated, or removed in this PR. -->
- Adjusted some spacing within the body of the email
- Removed the "DOMAIN" field in the summary section. It was redundant with the prior sentence, which also displays the domain name.
- Updated sentence under "Next steps" to read: 
  - If you need to cancel this invitation or remove the domain manager, you can do that by going to this domain in the .gov registrar < https://manage.get.gov/ >.



