### PR TITLE
#3387 - Members link in header only shows with permissions [HOTGOV]

### DIFF
--- a/src/registrar/templates/includes/header_extended.html
+++ b/src/registrar/templates/includes/header_extended.html
@@ -92,11 +92,13 @@
             {% endif %}
 
             {% if has_organization_members_flag %}
+                {% if has_view_members_portfolio_permission %}
                 <li class="usa-nav__primary-item">
                     <a href="{% url 'members' %}" class="usa-nav-link {% if path|is_members_subpage %} usa-current{% endif %}">
                         Members
                     </a>
                 </li>
+                {% endif %}
             {% endif %}
 
             <li class="usa-nav__primary-item">

--- a/src/registrar/tests/test_views_portfolio.py
+++ b/src/registrar/tests/test_views_portfolio.py
@@ -1097,8 +1097,10 @@ class TestPortfolio(WebTest):
     @less_console_noise_decorator
     @override_flag("organization_feature", active=True)
     @override_flag("organization_requests", active=True)
+    @override_flag("organization_members", active=True)
     def test_main_nav_when_user_has_no_permissions(self):
-        """Test the nav contains a link to the no requests page"""
+        """Test the nav contains a link to the no requests page
+        Also test that members link not present"""
         UserPortfolioPermission.objects.get_or_create(
             user=self.user, portfolio=self.portfolio, roles=[UserPortfolioRoleChoices.ORGANIZATION_MEMBER]
         )
@@ -1118,20 +1120,23 @@ class TestPortfolio(WebTest):
         self.assertNotContains(portfolio_landing_page, "basic-nav-section-two")
         # link to requests
         self.assertNotContains(portfolio_landing_page, 'href="/requests/')
-        # link to create
+        # link to create request
         self.assertNotContains(portfolio_landing_page, 'href="/request/')
+        # link to members
+        self.assertNotContains(portfolio_landing_page, 'href="/members/')
 
     @less_console_noise_decorator
     @override_flag("organization_feature", active=True)
     @override_flag("organization_requests", active=True)
+    @override_flag("organization_members", active=True)
     def test_main_nav_when_user_has_all_permissions(self):
         """Test the nav contains a dropdown with a link to create and another link to view requests
-        Also test for the existence of the Create a new request btn on the requests page"""
+        Also test for the existence of the Create a new request btn on the requests page
+        Also test for the existence of the members link"""
         UserPortfolioPermission.objects.get_or_create(
             user=self.user,
             portfolio=self.portfolio,
             roles=[UserPortfolioRoleChoices.ORGANIZATION_ADMIN],
-            additional_permissions=[UserPortfolioPermissionChoices.EDIT_REQUESTS],
         )
         self.client.force_login(self.user)
         # create and submit a domain request
@@ -1151,6 +1156,8 @@ class TestPortfolio(WebTest):
         self.assertContains(portfolio_landing_page, 'href="/requests/')
         # link to create
         self.assertContains(portfolio_landing_page, 'href="/request/')
+        # link to members
+        self.assertContains(portfolio_landing_page, 'href="/members/')
 
         requests_page = self.client.get(reverse("domain-requests"))
 
@@ -1160,15 +1167,18 @@ class TestPortfolio(WebTest):
     @less_console_noise_decorator
     @override_flag("organization_feature", active=True)
     @override_flag("organization_requests", active=True)
+    @override_flag("organization_members", active=True)
     def test_main_nav_when_user_has_view_but_not_edit_permissions(self):
         """Test the nav contains a simple link to view requests
-        Also test for the existence of the Create a new request btn on the requests page"""
+        Also test for the existence of the Create a new request btn on the requests page
+        Also test for the existence of members link"""
         UserPortfolioPermission.objects.get_or_create(
             user=self.user,
             portfolio=self.portfolio,
             additional_permissions=[
                 UserPortfolioPermissionChoices.VIEW_PORTFOLIO,
                 UserPortfolioPermissionChoices.VIEW_ALL_REQUESTS,
+                UserPortfolioPermissionChoices.VIEW_MEMBERS,
             ],
         )
         self.client.force_login(self.user)
@@ -1189,6 +1199,8 @@ class TestPortfolio(WebTest):
         self.assertContains(portfolio_landing_page, 'href="/requests/')
         # link to create
         self.assertNotContains(portfolio_landing_page, 'href="/request/')
+        # link to members
+        self.assertContains(portfolio_landing_page, 'href="/members/')
 
         requests_page = self.client.get(reverse("domain-requests"))
 


### PR DESCRIPTION
## Ticket

<!-- PR title format: `#issue_number: Descriptive name ideally matching ticket name - [sandbox]`-->
Resolves #3387 

## Changes

<!-- What was added, updated, or removed in this PR. -->
- Members link in header only shows with proper permissions
- Proper permissions include Basic member + View members --OR-- Admin member

<!--
    Please add/remove/edit any of the template below to fit the needs
    of this specific PR.
--->

## Context for reviewers

<!--Background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers.  -->

## Setup

<!--  Add any steps or code to run in this section to help others run your code.
    
    Example 1:
    ```sh
    echo "Code goes here"
    ``` 
    
    Example 2: If the PR was to add a new link with a redirect, this section could simply be:
    -go to /path/to/start/page
    -click the blue link in the <insert location>
    -notice user is redirected to <proper end location>
-->

## Code Review Verification Steps

### As the original developer, I have

#### Satisfied acceptance criteria and met development standards

- [x] Met the acceptance criteria, or will meet them in a subsequent PR
- [x] Created/modified automated tests
- [x] Update documentation in READMEs and/or onboarding guide

#### Ensured code standards are met (Original Developer)
<!-- Mark "- N/A" and check at the end of each check that is not applicable to your PR -->
- [x] If any updated dependencies on Pipfile, also update dependencies in requirements.txt.
- [x] Interactions with external systems are wrapped in try/except
- [x] Error handling exists for unusual or missing values

#### Validated user-facing changes (if applicable)

- [x] Tag @dotgov-designers in this PR's Reviewers for design review. If code is not user-facing, delete design reviewer checklist
- [x] Verify new pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [x] Checked keyboard navigability
- [x] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)

### As a code reviewer, I have

#### Reviewed, tested, and left feedback about the changes

- [x] Pulled this branch locally and tested it
- [x] Verified code meets all checks above. Address any checks that are not satisfied
- [x] Reviewed this code and left comments. Indicate if comments must be addressed before code is merged
- [x] Checked that all code is adequately covered by tests
- [x] Verify migrations are valid and do not conflict with existing migrations

#### Validated user-facing changes as a developer
**Note:** Multiple code reviewers can share the checklists above, a second reviewer should not make a duplicate checklist. All checks should be checked before approving, even those labeled N/A. 

- [x] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [x] Checked keyboard navigability
- [x] Meets all designs and user flows provided by design/product
- [x] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)
- [x] (Rarely needed) Tested as both an analyst and applicant user

### As a designer reviewer, I have

#### Verified that the changes match the design intention

- [ ] Checked that the design translated visually
- [ ] Checked behavior. Comment any found issues or broken flows.
- [ ] Checked different states (empty, one, some, error)
- [ ] Checked for landmarks, page heading structure, and links

#### Validated user-facing changes as a designer

- [ ] Checked keyboard navigability
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)
- [ ] Tested with multiple browsers (check off which ones were used)
  - [ ] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari
- [ ] (Rarely needed) Tested as both an analyst and applicant user

### References
- [Code review best practices](../docs/dev-practices/code_review.md)

## Screenshots

<!-- If this PR makes visible interface changes, an image of the finished interface can help reviewers
and casual observers understand the context of the changes.
A before image is optional and can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow.
You may want to use [GIPHY Capture](https://giphy.com/apps/giphycapture) for this! 📸

_Please frame images to show useful context but also highlight the affected regions._
--->
