### PR TITLE
#3357: Position action kebobs on the left on desktops - [RJM]

### DIFF
--- a/src/registrar/assets/src/sass/_theme/_accordions.scss
+++ b/src/registrar/assets/src/sass/_theme/_accordions.scss
@@ -15,7 +15,6 @@
         // Note, width is determined by a custom width class on one of the children
         position: absolute;
         z-index: 1;
-        left: 0;
         border-radius: 4px;
         border: solid 1px color('base-lighter');
         padding: units(2) units(2) units(3) units(2);
@@ -32,6 +31,14 @@
     }
 }
 
+// This will work in responsive tables IF we overwrite the overflow value on the table container
+// Works with styles in _tables
+@include at-media(desktop) {
+    .usa-accordion--more-actions .usa-accordion__content {
+        left: 0;
+    }
+}
+
 .usa-accordion--select .usa-accordion__content {
     top: 33.88px;
 }
@@ -44,10 +51,12 @@
 // This won't work on the Members table rows because that table has show-more rows
 // Currently, that's not an issue since that Members table is not wrapped in the
 // reponsive wrapper.
-tr:last-of-type .usa-accordion--more-actions .usa-accordion__content {
-    top: auto;
-    bottom: -10px;
-    right: 30px;
+@media screen and (max-width: 1023px) {
+    tr:last-of-type .usa-accordion--more-actions .usa-accordion__content {
+        top: auto;
+        bottom: -10px;
+        right: 30px;
+    }
 }
 
 // A CSS only show-more/show-less based on usa-accordion

--- a/src/registrar/assets/src/sass/_theme/_base.scss
+++ b/src/registrar/assets/src/sass/_theme/_base.scss
@@ -226,11 +226,6 @@ abbr[title] {
   }
 }
 
-// Boost this USWDS utility class for the accordions in the portfolio requests table
-.left-auto {
-  left: auto!important;
-}
-
 .usa-banner__inner--widescreen  {
   max-width: $widescreen-max-width;
 }

--- a/src/registrar/assets/src/sass/_theme/_tables.scss
+++ b/src/registrar/assets/src/sass/_theme/_tables.scss
@@ -152,3 +152,12 @@ th {
 .usa-table--full-borderless th {
   border: none !important;
 }
+
+// This is an override to overflow on certain tables (note the custom class)
+// so that a popup menu can appear and starddle the edge of the table on large
+// screen sizes. Works with styles in _accordions
+@include at-media(desktop) {
+  .usa-table-container--scrollable.usa-table-container--override-overflow {
+      overflow-y: visible;
+  }
+}

--- a/src/registrar/templates/includes/domain_requests_table.html
+++ b/src/registrar/templates/includes/domain_requests_table.html
@@ -163,7 +163,7 @@
     </div>
     {% endif %}
 
-    <div class="display-none usa-table-container--scrollable margin-top-0" tabindex="0" id="domain-requests__table-wrapper">
+    <div class="display-none usa-table-container--scrollable usa-table-container--override-overflow margin-top-0" tabindex="0" id="domain-requests__table-wrapper">
         <table class="usa-table usa-table--borderless usa-table--stacked dotgov-table dotgov-table--stacked">
             <caption class="sr-only">Your domain requests</caption>
             <thead>

--- a/src/registrar/templates/includes/domains_table.html
+++ b/src/registrar/templates/includes/domains_table.html
@@ -198,7 +198,7 @@
       </svg>
     </button>
   </div>
-  <div class="display-none usa-table-container--scrollable margin-top-0" tabindex="0" id="domains__table-wrapper">
+  <div class="display-none usa-table-container--scrollable usa-table-container--override-overflow margin-top-0" tabindex="0" id="domains__table-wrapper">
     <table class="usa-table usa-table--borderless usa-table--stacked dotgov-table dotgov-table--stacked">
       <caption class="sr-only">Your registered domains</caption>
       <thead>


### PR DESCRIPTION
## Ticket

<!-- PR title format: `#issue_number: Descriptive name ideally matching ticket name - [sandbox]`-->
Resolves #3357 

## Changes

<!-- What was added, updated, or removed in this PR. -->
- Move action kebobs from the right to the left on desktops

<!--
    Please add/remove/edit any of the template below to fit the needs
    of this specific PR.
--->

## Context for reviewers

<!--Background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers.  -->

- This is possible because of an override to the overflow prop of the responsive table wrapper on desktop. If we overwrite in on mobile, we break the responsiveness. I used a custom class for the override to leave out-of-the-box tables alone.
- Note that on the last row on domain requests, I still needed to hack the positioning of that kebob: On smaller than desktop, I want that kebob to ride up instead of down because the bottom of the table can still cause clipping at those screen sizes
- The code for repositioning just works on member table even though it is not responsive
- The whole UI will look better once 3281 gets merged in. There are UI tweaks on margins, buttons, etc. 

## Setup

<!--  Add any steps or code to run in this section to help others run your code.
    
    Example 1:
    ```sh
    echo "Code goes here"
    ``` 
    
    Example 2: If the PR was to add a new link with a redirect, this section could simply be:
    -go to /path/to/start/page
    -click the blue link in the <insert location>
    -notice user is redirected to <proper end location>
-->

## Code Review Verification Steps

### As the original developer, I have

#### Satisfied acceptance criteria and met development standards

- [x] Met the acceptance criteria, or will meet them in a subsequent PR
- [x] Created/modified automated tests
- [x] Update documentation in READMEs and/or onboarding guide

#### Ensured code standards are met (Original Developer)
<!-- Mark "- N/A" and check at the end of each check that is not applicable to your PR -->
- [x] If any updated dependencies on Pipfile, also update dependencies in requirements.txt.
- [x] Interactions with external systems are wrapped in try/except
- [x] Error handling exists for unusual or missing values

#### Validated user-facing changes (if applicable)

- [x] Tag @dotgov-designers in this PR's Reviewers for design review. If code is not user-facing, delete design reviewer checklist
- [x] Verify new pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [x] Checked keyboard navigability
- [x] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)

### As a code reviewer, I have

#### Reviewed, tested, and left feedback about the changes

- [ ] Pulled this branch locally and tested it
- [ ] Verified code meets all checks above. Address any checks that are not satisfied
- [ ] Reviewed this code and left comments. Indicate if comments must be addressed before code is merged
- [ ] Checked that all code is adequately covered by tests
- [ ] Verify migrations are valid and do not conflict with existing migrations

#### Validated user-facing changes as a developer
**Note:** Multiple code reviewers can share the checklists above, a second reviewer should not make a duplicate checklist. All checks should be checked before approving, even those labeled N/A. 

- [ ] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Checked keyboard navigability
- [ ] Meets all designs and user flows provided by design/product
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)
- [ ] (Rarely needed) Tested as both an analyst and applicant user

### As a designer reviewer, I have

#### Verified that the changes match the design intention

- [ ] Checked that the design translated visually
- [ ] Checked behavior. Comment any found issues or broken flows.
- [ ] Checked different states (empty, one, some, error)
- [ ] Checked for landmarks, page heading structure, and links

#### Validated user-facing changes as a designer

- [ ] Checked keyboard navigability
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)
- [ ] Tested with multiple browsers (check off which ones were used)
  - [ ] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari
- [ ] (Rarely needed) Tested as both an analyst and applicant user

### References
- [Code review best practices](../docs/dev-practices/code_review.md)

## Screenshots

<!-- If this PR makes visible interface changes, an image of the finished interface can help reviewers
and casual observers understand the context of the changes.
A before image is optional and can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow.
You may want to use [GIPHY Capture](https://giphy.com/apps/giphycapture) for this! 📸

_Please frame images to show useful context but also highlight the affected regions._
--->
