### PR TITLE
#2217- Changed federal agency dropdown to ready-only view [-Hotgov]

### DIFF
--- a/src/registrar/templates/domain_org_name_address.html
+++ b/src/registrar/templates/domain_org_name_address.html
@@ -29,7 +29,10 @@
     {% csrf_token %}
 
     {% if domain.domain_info.generic_org_type == 'federal' %}
-      {% input_with_errors form.federal_agency %}
+      <h4 class="margin-bottom-05">Federal Agency</h4>
+      <p class="margin-top-0">
+        {{ domain.domain_info.federal_agency }}
+      </p>
     {% endif %}
 
     {% input_with_errors form.organization_name %}

--- a/src/registrar/tests/test_views_domain.py
+++ b/src/registrar/tests/test_views_domain.py
@@ -2089,62 +2089,6 @@ class TestDomainOrganization(TestDomainOverview):
         self.assertContains(success_result_page, "Faketown")
 
     @less_console_noise_decorator
-    def test_domain_org_name_address_form_federal(self):
-        """
-        Submitting a change to federal_agency is blocked for federal domains
-        """
-
-        fed_org_type = DomainInformation.OrganizationChoices.FEDERAL
-        self.domain_information.generic_org_type = fed_org_type
-        self.domain_information.save()
-        try:
-            federal_agency, _ = FederalAgency.objects.get_or_create(agency="AMTRAK")
-            self.domain_information.federal_agency = federal_agency
-            self.domain_information.save()
-        except ValueError as err:
-            self.fail(f"A ValueError was caught during the test: {err}")
-
-        self.assertEqual(self.domain_information.generic_org_type, fed_org_type)
-
-        org_name_page = self.app.get(reverse("domain-org-name-address", kwargs={"domain_pk": self.domain.id}))
-
-        form = org_name_page.forms[0]
-        # Check the value of the input field
-        agency_input = form.fields["federal_agency"][0]
-        self.assertEqual(agency_input.value, str(federal_agency.id))
-
-        # Check if the input field is disabled
-        self.assertTrue("disabled" in agency_input.attrs)
-        self.assertEqual(agency_input.attrs.get("disabled"), "")
-
-        session_id = self.app.cookies[settings.SESSION_COOKIE_NAME]
-
-        org_name_page.form["federal_agency"] = FederalAgency.objects.filter(agency="Department of State").get().id
-        org_name_page.form["city"] = "Faketown"
-
-        self.app.set_cookie(settings.SESSION_COOKIE_NAME, session_id)
-
-        # Make the change. The agency should be unchanged, but city should be modifiable.
-        success_result_page = org_name_page.form.submit()
-        self.assertEqual(success_result_page.status_code, 200)
-
-        # Check that the agency has not changed
-        self.assertEqual(self.domain_information.federal_agency.agency, "AMTRAK")
-
-        # Do another check on the form itself
-        form = success_result_page.forms[0]
-        # Check the value of the input field
-        organization_name_input = form.fields["federal_agency"][0]
-        self.assertEqual(organization_name_input.value, str(federal_agency.id))
-
-        # Check if the input field is disabled
-        self.assertTrue("disabled" in organization_name_input.attrs)
-        self.assertEqual(organization_name_input.attrs.get("disabled"), "")
-
-        # Check for the value we want to update
-        self.assertContains(success_result_page, "Faketown")
-
-    @less_console_noise_decorator
     def test_federal_agency_submit_blocked(self):
         """
         Submitting a change to federal_agency is blocked for federal domains


### PR DESCRIPTION
## Ticket 2217

<!-- PR title format: `#issue_number: Descriptive name ideally matching ticket name - [sandbox]`-->
Resolves #2217

## Changes

<!-- What was added, updated, or removed in this PR. -->
- Changed federal agency dropdown to view only style on organization name and mailing address page, following the same pattern as on org-model (for portfolio federal agency)

<!--
    Please add/remove/edit any of the template below to fit the needs
    of this specific PR.
--->

## Context for reviewers

<!--Background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers.  -->

## Setup

<!--  Add any steps or code to run in this section to help others run your code.
    
    Example 1:
    ```sh
    echo "Code goes here"
    ``` 
    
    Example 2: If the PR was to add a new link with a redirect, this section could simply be:
    -go to /path/to/start/page
    -click the blue link in the <insert location>
    -notice user is redirected to <proper end location>
-->

## Code Review Verification Steps

### As the original developer, I have

#### Satisfied acceptance criteria and met development standards

- [ ] Met the acceptance criteria, or will meet them in a subsequent PR
- [ ] Created/modified automated tests
- [ ] Update documentation in READMEs and/or onboarding guide

#### Ensured code standards are met (Original Developer)
<!-- Mark "- N/A" and check at the end of each check that is not applicable to your PR -->
- [ ] If any updated dependencies on Pipfile, also update dependencies in requirements.txt.
- [ ] Interactions with external systems are wrapped in try/except
- [ ] Error handling exists for unusual or missing values

#### Validated user-facing changes (if applicable)

- [ ] Tag @dotgov-designers in this PR's Reviewers for design review. If code is not user-facing, delete design reviewer checklist
- [ ] Verify new pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Checked keyboard navigability
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)

### As a code reviewer, I have

#### Reviewed, tested, and left feedback about the changes

- [ ] Pulled this branch locally and tested it
- [ ] Verified code meets all checks above. Address any checks that are not satisfied
- [ ] Reviewed this code and left comments. Indicate if comments must be addressed before code is merged
- [ ] Checked that all code is adequately covered by tests
- [ ] Verify migrations are valid and do not conflict with existing migrations

#### Validated user-facing changes as a developer
**Note:** Multiple code reviewers can share the checklists above, a second reviewer should not make a duplicate checklist. All checks should be checked before approving, even those labeled N/A. 

- [ ] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Checked keyboard navigability
- [ ] Meets all designs and user flows provided by design/product
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)
- [ ] (Rarely needed) Tested as both an analyst and applicant user

### As a designer reviewer, I have

#### Verified that the changes match the design intention

- [ ] Checked that the design translated visually
- [ ] Checked behavior. Comment any found issues or broken flows.
- [ ] Checked different states (empty, one, some, error)
- [ ] Checked for landmarks, page heading structure, and links

#### Validated user-facing changes as a designer

- [ ] Checked keyboard navigability
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)
- [ ] Tested with multiple browsers (check off which ones were used)
  - [ ] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari
- [ ] (Rarely needed) Tested as both an analyst and applicant user

### References
- [Code review best practices](../docs/dev-practices/code_review.md)

## Screenshots

<!-- If this PR makes visible interface changes, an image of the finished interface can help reviewers
and casual observers understand the context of the changes.
A before image is optional and can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow.
You may want to use [GIPHY Capture](https://giphy.com/apps/giphycapture) for this! 📸

_Please frame images to show useful context but also highlight the affected regions._
--->
