### PR TITLE
#3608: Making State to be required in Domain Request form - [RH]

### DIFF
--- a/src/registrar/forms/domain_request_wizard.py
+++ b/src/registrar/forms/domain_request_wizard.py
@@ -348,7 +348,7 @@ class OrganizationContactForm(RegistrarForm):
         error_messages={
             "required": ("Select the state, territory, or military post where your organization is located.")
         },
-        widget=ComboboxWidget,
+        widget=ComboboxWidget(attrs={"required": True}),
     )
     zipcode = forms.CharField(
         label="Zip code",


### PR DESCRIPTION
## Ticket

Resolves #3608

## Changes + Context for reviewers

`State, territory, or military post` needed an asterisk to show that it's required and was missing it so that's what this PR is here to fix! Please click on the ticket to see the "before". You can look at screenshots below to see "after" as well as testing it yourself!

## Setup

In non org model mode, create a new domain request and when you get to the organization section make sure that `State, territory, or military post` has a * by it and is also required to fill out for the form otherwise if not filled out should return errors

## Code Review Verification Steps

### As the original developer, I have

#### Satisfied acceptance criteria and met development standards

- [ ] Met the acceptance criteria, or will meet them in a subsequent PR
- [ ] Created/modified automated tests
- [ ] Update documentation in READMEs and/or onboarding guide

#### Ensured code standards are met (Original Developer)
<!-- Mark "- N/A" and check at the end of each check that is not applicable to your PR -->
- [ ] If any updated dependencies on Pipfile, also update dependencies in requirements.txt.
- [ ] Interactions with external systems are wrapped in try/except
- [ ] Error handling exists for unusual or missing values

#### Validated user-facing changes (if applicable)

- [ ] Tag @dotgov-designers in this PR's Reviewers for design review. If code is not user-facing, delete design reviewer checklist
- [ ] Verify new pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Checked keyboard navigability
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)

### As a code reviewer, I have

#### Reviewed, tested, and left feedback about the changes

- [ ] Pulled this branch locally and tested it
- [ ] Verified code meets all checks above. Address any checks that are not satisfied
- [ ] Reviewed this code and left comments. Indicate if comments must be addressed before code is merged
- [ ] Checked that all code is adequately covered by tests
- [ ] Verify migrations are valid and do not conflict with existing migrations

#### Validated user-facing changes as a developer
**Note:** Multiple code reviewers can share the checklists above, a second reviewer should not make a duplicate checklist. All checks should be checked before approving, even those labeled N/A. 

- [ ] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Checked keyboard navigability
- [ ] Meets all designs and user flows provided by design/product
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)
- [ ] (Rarely needed) Tested as both an analyst and applicant user

### As a designer reviewer, I have

#### Verified that the changes match the design intention

- [ ] Checked that the design translated visually
- [ ] Checked behavior. Comment any found issues or broken flows.
- [ ] Checked different states (empty, one, some, error)
- [ ] Checked for landmarks, page heading structure, and links

#### Validated user-facing changes as a designer

- [ ] Checked keyboard navigability
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)
- [ ] Tested with multiple browsers (check off which ones were used)
  - [ ] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari
- [ ] (Rarely needed) Tested as both an analyst and applicant user

### References
- [Code review best practices](../docs/dev-practices/code_review.md)

## Screenshots

With org model:
<img width="692" alt="Screenshot 2025-03-05 at 12 31 18 PM" src="https://github.com/user-attachments/assets/77470a69-7a08-41e3-a453-8d252a62f511" />


Without org model:

<img width="636" alt="Screenshot 2025-03-05 at 12 33 42 PM" src="https://github.com/user-attachments/assets/ff4d965e-f30f-4df0-a838-252b27d132b3" />
<img width="723" alt="Screenshot 2025-03-05 at 12 34 37 PM" src="https://github.com/user-attachments/assets/ee8be9e3-7bd4-44e4-ac75-21032f547815" />
