### PR TITLE
Remove VDP form link

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,4 +1,4 @@
-* If you've found a security or privacy issue on the **.gov top-level domain infrastructure**, submit it to our [vulnerabilty disclosure form](https://forms.office.com/Pages/ResponsePage.aspx?id=bOfNPG2UEkq7evydCEI1SqHke9Gh6wJEl3kQ5EjWUKlUMTZZS1lBVkxHUzZURFpLTkE2NEJFVlhVRi4u) or email help@get.gov.
+* If you've found a security or privacy issue on the **.gov top-level domain infrastructure**, email us at help@get.gov.
 * If you see a security or privacy issue on **an individual .gov domain**, check [current-full.csv](https://flatgithub.com/cisagov/dotgov-data/blob/main/?filename=current-full.csv) to see whether the domain has a security contact to report your finding directly. You are welcome to Cc help@get.gov on the email.
   * If you are unable to find a contact or receive no response from the security contact, email help@get.gov.
 


### PR DESCRIPTION
Forms are disabled. This PR removes the form link in the README.