### PR TITLE
#3766: Prevent registry domain creation on /admin domain page - [KMA]

### DIFF
--- a/src/registrar/admin.py
+++ b/src/registrar/admin.py
@@ -4126,13 +4126,13 @@ class DomainAdmin(ListHeaderAdmin, ImportExportRegistrarModelAdmin):
         return obj.domain_info.state_territory if obj.domain_info else None
 
     def dnssecdata(self, obj):
-        return "Yes" if obj.dnssecdata else "No"
+        return "No" if obj.state == Domain.State.UNKNOWN or not obj.dnssecdata else "Yes"
 
     dnssecdata.short_description = "DNSSEC enabled"  # type: ignore
 
     # Custom method to display formatted nameservers
     def nameservers(self, obj):
-        if not obj.nameservers:
+        if obj.state == Domain.State.UNKNOWN or not obj.nameservers:
             return "No nameservers"
 
         formatted_nameservers = []

--- a/src/registrar/models/domain.py
+++ b/src/registrar/models/domain.py
@@ -1557,7 +1557,7 @@ class Domain(TimeStampedModel, DomainHelper):
     # ForeignKey on DomainInvitation creates an "invitations" member for
     # all of the invitations that have been sent for this domain
 
-    def _get_or_create_domain(self):
+    def _get_or_create_domain_in_registry(self):
         """Try to fetch info about this domain. Create it if it does not exist."""
         already_tried_to_create = False
         exitEarly = False
@@ -2059,7 +2059,7 @@ class Domain(TimeStampedModel, DomainHelper):
     def _fetch_cache(self, fetch_hosts=False, fetch_contacts=False):
         """Contact registry for info about a domain."""
         try:
-            data_response = self._get_or_create_domain()
+            data_response = self._get_or_create_domain_in_registry()
             cache = self._extract_data_from_response(data_response)
             cleaned = self._clean_cache(cache, data_response)
             self._update_hosts_and_contacts(cleaned, fetch_hosts, fetch_contacts)

--- a/src/registrar/tests/test_admin.py
+++ b/src/registrar/tests/test_admin.py
@@ -4627,10 +4627,10 @@ class TestDomainAdminState(TestCase):
         self.client.login(username="superuser", password=p)
 
     def test_domain_state_remains_unknown_on_refresh(self):
-        '''
+        """
         Making sure we do NOT do a domain registry lookup or creation
         when we click into the domain in /admin
-        '''
+        """
 
         # 1. Create domain request
         domain_request = completed_domain_request(


### PR DESCRIPTION
## Ticket

<!-- PR title format: `#issue_number: Descriptive name ideally matching ticket name - [sandbox]`-->
Resolves #3766

## Changes

<!-- What was added, updated, or removed in this PR. -->
- Updates two properties that we get from the registry such that if they are in an UNKNOWN state, they do not do a domain registry lookup or creation.

<!--
    Please add/remove/edit any of the template below to fit the needs
    of this specific PR.
--->

## Context for reviewers

<!--Background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers.  -->
Please see ticket #3897 for additional context

One question that came up was whether registry domain creation only happens on the domain page in the registrar, or if it happens on the `/domains` page as well. Through investigation, I've learned that it does NOT get created if someone goes to the `/domains` page. When a user goes to the `/domain/:id` page, the `contacts` lookup triggers creation of the registry domain.

~Unfortunately, looks like there are not any tests for DomainAdmin in `test_admin.py`, where I'd expect to find existing ones. So I'm unable to write any quickly. ~Putting this in a draft PR~ Labeling as DRAFT so that if it's deemed important, someone can pick this up and add some, and if not it's available to be worked on (not sure if others are able to undraft).~

## Setup

<!--  Add any steps or code to run in this section to help others run your code.
    
This can only be tested in a sandbox, not locally, as it needs to be able to contact the test registry.


    
    Example 2: If the PR was to add a new link with a redirect, this section could simply be:
    -go to /path/to/start/page
    -click the blue link in the <insert location>
    -notice user is redirected to <proper end location>
-->



## Code Review Verification Steps

1. In [my kma sandbox](https://getgov-kma.app.cloud.gov/admin), go to `/admin`
2. Go to a domain request and change the Status to "Approved" and add yourself as the investigator ('Assign to me'). Take note of the domain name.
3. In `/admin` Domains, find the accepted domain and go to it. You should see that it is in the `Domain state` 'Unknown'.
4. Refresh the page. The Domain state should not change (it did before the fix).
5. Now click "Manage domain" which takes you to the domain in the Registrar. Here you should see the status as "Dns needed"
6. Go back to the domain in /admin. Refresh the page. You should see the updated Domain state.
7. 
### As the original developer, I have

#### Satisfied acceptance criteria and met development standards

- [ ] Met the acceptance criteria, or will meet them in a subsequent PR
- [ ] Created/modified automated tests
- [ ] Update documentation in READMEs and/or onboarding guide

#### Ensured code standards are met (Original Developer)
<!-- Mark "- N/A" and check at the end of each check that is not applicable to your PR -->
- [ ] If any updated dependencies on Pipfile, also update dependencies in requirements.txt.
- [ ] Interactions with external systems are wrapped in try/except
- [ ] Error handling exists for unusual or missing values

#### Validated user-facing changes (if applicable)

- [ ] Tag gov-designers in this PR's Reviewers section for design review. If code is not user-facing, delete design reviewer checklist
- [ ] Verify new pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Checked keyboard navigability
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)

### As a code reviewer, I have

#### Reviewed, tested, and left feedback about the changes

- [ ] Pulled this branch locally and tested it
- [ ] Verified code meets all checks above. Address any checks that are not satisfied
- [ ] Reviewed this code and left comments. Indicate if comments must be addressed before code is merged
- [ ] Checked that all code is adequately covered by tests
- [ ] Verify migrations are valid and do not conflict with existing migrations

#### Validated user-facing changes as a developer
**Note:** Multiple code reviewers can share the checklists above, a second reviewer should not make a duplicate checklist. All checks should be checked before approving, even those labeled N/A. 

- [ ] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Checked keyboard navigability
- [ ] Meets all designs and user flows provided by design/product
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)
- [ ] (Rarely needed) Tested as both an analyst and applicant user

### As a designer reviewer, I have

#### Verified that the changes match the design intention

- [ ] Checked that the design translated visually
- [ ] Checked behavior. Comment any found issues or broken flows.
- [ ] Checked different states (empty, one, some, error)
- [ ] Checked for landmarks, page heading structure, and links
