### PR TITLE
Update sandbox list with current sandboxes

### DIFF
--- a/.github/workflows/deploy-manual.yaml
+++ b/.github/workflows/deploy-manual.yaml
@@ -12,27 +12,30 @@ on:
         default: 'backup'
         type: 'choice'
         options:
-          - ab
-          - backup
           - aa
-          - el
+          - ab
+          - ad
+          - ag
+          - backup
+          - bob
           - cb
-          - kma
+          - dg
+          - el
           - es
           - gd
+          - hotgov
+          - kma
           - ko
           - ky
+          - litterbox
+          - meoward
           - nl
+          - product
           - rb
           - rh
           - rjm
-          - meoward
-          - bob
-          - hotgov
-          - litterbox
-          - ad
-          - ag
-          - dg
+          - za
+
       # GitHub Actions has no "good" way yet to dynamically input branches
       branch:
         description: 'Branch to deploy'


### PR DESCRIPTION
No ticket

## Changes

<!-- What was added, updated, or removed in this PR. -->
- Updated the list of sandbox choices for the manual build & deploy workflow, to include all current sandboxes
- Put the list in alphabetical order.

This change only impacts the sandbox options list for the GitHub workflow.