### PR TITLE
#3543: Update validation check to logger check on members page - [RH]

### DIFF
--- a/src/registrar/models/utility/portfolio_helper.py
+++ b/src/registrar/models/utility/portfolio_helper.py
@@ -354,7 +354,7 @@ def validate_portfolio_invitation(portfolio_invitation):
         raise ValidationError("When portfolio roles or additional permissions are assigned, portfolio is required.")
 
     if has_portfolio and not portfolio_permissions:
-        raise ValidationError("When portfolio is assigned, portfolio roles or additional permissions are required.")
+        logger.info("When portfolio is assigned, portfolio roles or additional permissions are required.")
 
     # == Validate role permissions. Compares existing permissions to forbidden ones. == #
     roles = portfolio_invitation.roles if portfolio_invitation.roles is not None else []


### PR DESCRIPTION
## Ticket

<!-- PR title format: `#issue_number: Descriptive name ideally matching ticket name - [sandbox]`-->
Resolves #3543 

## Changes

<!-- What was added, updated, or removed in this PR. -->
* Change the validation error (which showed up on the form) to a logger error 

## Context for reviewers

We have a validation error showing up that we don't want to display to the end user and to instead display to us so we changed it to a logger.

## Setup

1. In `/admin` go to Waffle Flags -> And turn on `organization_feature` and `organization_member`
2. Go to the Members section (top right by Domains)
3. Click "Add a new member" 
5. Don't fill anything out in the form and click "Invite member"
6. 2 errors should pop up instead of 3 AND you can also go to `cloud.gov` logs and see that the logger is now showing up there instead (see screenshots)

## Code Review Verification Steps

### As the original developer, I have

#### Satisfied acceptance criteria and met development standards

- [ ] Met the acceptance criteria, or will meet them in a subsequent PR
- [ ] Created/modified automated tests
- [ ] Update documentation in READMEs and/or onboarding guide

#### Ensured code standards are met (Original Developer)
<!-- Mark "- N/A" and check at the end of each check that is not applicable to your PR -->
- [ ] If any updated dependencies on Pipfile, also update dependencies in requirements.txt.
- [ ] Interactions with external systems are wrapped in try/except
- [ ] Error handling exists for unusual or missing values

#### Validated user-facing changes (if applicable)

- [ ] Tag gov-designers in this PR's Reviewers section for design review. If code is not user-facing, delete design reviewer checklist
- [ ] Verify new pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Checked keyboard navigability
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)

### As a code reviewer, I have

#### Reviewed, tested, and left feedback about the changes

- [ ] Pulled this branch locally and tested it
- [ ] Verified code meets all checks above. Address any checks that are not satisfied
- [ ] Reviewed this code and left comments. Indicate if comments must be addressed before code is merged
- [ ] Checked that all code is adequately covered by tests
- [ ] Verify migrations are valid and do not conflict with existing migrations

#### Validated user-facing changes as a developer
**Note:** Multiple code reviewers can share the checklists above, a second reviewer should not make a duplicate checklist. All checks should be checked before approving, even those labeled N/A. 

- [ ] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Checked keyboard navigability
- [ ] Meets all designs and user flows provided by design/product
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)
- [ ] (Rarely needed) Tested as both an analyst and applicant user

### As a designer reviewer, I have

#### Verified that the changes match the design intention

- [ ] Checked that the design translated visually
- [ ] Checked behavior. Comment any found issues or broken flows.
- [ ] Checked different states (empty, one, some, error)
- [ ] Checked for landmarks, page heading structure, and links

#### Validated user-facing changes as a designer

- [ ] Checked keyboard navigability
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)
- [ ] Tested with multiple browsers (check off which ones were used)
  - [ ] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari
- [ ] (Rarely needed) Tested as both an analyst and applicant user

### References
- [Code review best practices](../docs/dev-practices/code_review.md)

## Screenshots
<img width="1036" alt="screenshot img 2025-06-20 at 3 08 28 PM" src="https://github.com/user-attachments/assets/7bd3c6f3-3602-4e54-8d98-854f45725f41" />
<img width="933" alt="screenshot img 2025-06-20 at 3 08 35 PM" src="https://github.com/user-attachments/assets/e728f56b-550a-43bd-a2e4-77c936489b40" />
