### PR TITLE
WIP commit. Something seems off with the old admin test...checking

### DIFF
--- a/src/registrar/apps.py
+++ b/src/registrar/apps.py
@@ -5,3 +5,5 @@ class RegistrarConfig(AppConfig):
     """Configure signal handling for our registrar Django application."""
 
     name = "registrar"
+    def ready(self):
+            import registrar.signals  # noqa

--- a/src/registrar/config/settings.py
+++ b/src/registrar/config/settings.py
@@ -119,7 +119,7 @@ INSTALLED_APPS = [
     # otherwise Django would find the default template
     # provided by django.contrib.admin first and use
     # that instead of our custom templates.
-    "registrar",
+    "registrar.apps.RegistrarConfig",
     # Django automatic admin interface reads metadata
     # from database models to provide a quick, model-centric
     # interface where trusted users can manage content

--- a/src/registrar/signals.py
+++ b/src/registrar/signals.py
@@ -1,0 +1,30 @@
+# registrar/signals.py
+from django.db.models.signals import post_delete
+from django.dispatch import receiver
+import logging
+
+from .models import UserDomainRole, DomainInvitation
+
+logger = logging.getLogger(__name__)
+
+@receiver(post_delete, sender=UserDomainRole)
+def cleanup_retrieved_domain_invitations(sender, instance, **kwargs):
+    """
+    Automatically clean up retrieved domain invitations when a UserDomainRole is deleted.
+    """
+    print(f"🔥 SIGNAL FIRED: UserDomainRole deleted for {instance.user.email} on {instance.domain.name}")
+    
+    matching_invitations = DomainInvitation.objects.filter(
+        email=instance.user.email,
+        domain=instance.domain,
+        status=DomainInvitation.DomainInvitationStatus.RETRIEVED
+    )
+    
+    count = matching_invitations.count()
+    print(f"🧹 Found {count} retrieved invitations to clean up")
+    
+    if count > 0:
+        matching_invitations.delete()
+        print(f"✅ Deleted {count} retrieved invitations")
+    else:
+        print("ℹ️  No retrieved invitations to clean up")

--- a/src/registrar/tests/test_admin.py
+++ b/src/registrar/tests/test_admin.py
@@ -343,7 +343,7 @@ class TestDomainInvitationAdmin(WebTest):
             # Assert that the filters are added
             self.assertContains(response, "invited", count=5)
             self.assertContains(response, "Invited", count=2)
-            self.assertContains(response, "retrieved", count=3)
+            self.assertContains(response, "retrieved", count=4)
             self.assertContains(response, "Retrieved", count=2)
 
             # Check for the HTML context specificially
@@ -1439,7 +1439,7 @@ class TestPortfolioInvitationAdmin(TestCase):
         # Assert that the filters are added
         self.assertContains(response, "invited", count=5)
         self.assertContains(response, "Invited", count=2)
-        self.assertContains(response, "retrieved", count=3)
+        self.assertContains(response, "retrieved", count=4)
         self.assertContains(response, "Retrieved", count=2)
 
         # Check for the HTML context specificially

--- a/src/registrar/views/domain.py
+++ b/src/registrar/views/domain.py
@@ -1255,7 +1255,12 @@ class DomainUsersView(DomainBaseView):
         # Prepare a list to store invitations with an admin flag
         invitations = []
 
-        for domain_invitation in self.object.invitations.all():
+        for domain_invitation in self.object.invitations.filter(
+            status__in=[
+                DomainInvitation.DomainInvitationStatus.INVITED,
+                DomainInvitation.DomainInvitationStatus.CANCELED
+            ]
+        ):
             # Check if there are any PortfolioInvitations linked to the same portfolio with the ORGANIZATION_ADMIN role
             has_admin_flag = False
 
@@ -1273,10 +1278,7 @@ class DomainUsersView(DomainBaseView):
                     has_admin_flag = True
                     break  # Once we find one match, no need to check further
 
-            # Add the role along with the computed flag to the list if the domain invitation
-            # if the status is not canceled
-            if domain_invitation.status != "canceled":
-                invitations.append({"domain_invitation": domain_invitation, "has_admin_flag": has_admin_flag})
+            invitations.append({"domain_invitation": domain_invitation, "has_admin_flag": has_admin_flag})
 
         # Pass roles_with_flags to the context
         context["invitations"] = invitations


### PR DESCRIPTION
## Ticket

<!-- PR title format: `#issue_number: Descriptive name ideally matching ticket name - [sandbox]`-->
Resolves #00

## Changes

<!-- What was added, updated, or removed in this PR. -->
- Explicitly defined the registrar conifig so we can easily add others (e.g. testing, no-ssl) + the old way is deprecated https://docs.djangoproject.com/en/dev/internals/deprecation/ 
- Added a post_delete signal for UserDomainRole

<!--
    Please add/remove/edit any of the template below to fit the needs
    of this specific PR.
--->

## Context for reviewers

<!--Background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers.  -->
This is a short term fix as this area is being re-designed in "https://github.com/cisagov/manage.get.gov/issues/3553 where we're planning a more holistic change in the invitations and domain roles. However, we expect that will be a longer-term resolution, and so this issue is still relevant for a more immediate improvement for what users see and how managers can be re-invited."

Also, please view https://github.com/cisagov/manage.get.gov/issues/3678 my comment states this won't occur now that with this fix.

## Setup

<!--  Add any steps or code to run in this section to help others run your code.    
    Example 2: If the PR was to add a new link with a redirect, this section could simply be:
    -go to /path/to/start/page
    -click the blue link in the <insert location>
    -notice user is redirected to <proper end location>
-->

Setup a CLI view of the database table registrar_domaininvitation (Select * from registrar_domaininvitation;) OR use Beekeeper to connect to the getgov-dg.app.cloud.gov db

1. As an Admin login to https://getgov-dg.app.cloud.gov/admin   
2. Click on domain invitation (L. Menu)
3. Click on Add domain invitation + (R. Side)
4. Enter your email (for this Admin user)
5. Domain > about-space-key.gov (or another one)
6. Click Save
7. Go to User Domain Roles (L. Menu)
8. Search for yourself and you should see yourself as Manager for the new domain
9. View the db table registrar_domaininvitation, you should see the new entry
10. Open a new tab and Go to https://getgov-dg.app.cloud.gov
11. Click on Manage next to the domain you just sent yourself an invite for
12. In Domain Overview you should see yourself under the list of Domain Managers, click Edit
13. Remove yourself
14. Go to your Admin tab and Refresh
15. You should no longer see yourself as a manager
16. Check your table again, you should no longer see the entry

## Code Review Verification Steps

### As the original developer, I have

#### Satisfied acceptance criteria and met development standards

- [x] Met the acceptance criteria, or will meet them in a subsequent PR
- [x] Created/modified automated tests
- [ ] Update documentation in READMEs and/or onboarding guide

#### Ensured code standards are met (Original Developer)
<!-- Mark "- N/A" and check at the end of each check that is not applicable to your PR -->
- [ ] If any updated dependencies on Pipfile, also update dependencies in requirements.txt.
- [ ] Interactions with external systems are wrapped in try/except
- [ ] Error handling exists for unusual or missing values

#### Validated user-facing changes (if applicable)

- [ ] Tag gov-designers in this PR's Reviewers section for design review. If code is not user-facing, delete design reviewer checklist
- [ ] Verify new pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Checked keyboard navigability
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)

### As a code reviewer, I have

#### Reviewed, tested, and left feedback about the changes

- [ ] Pulled this branch locally and tested it
- [ ] Verified code meets all checks above. Address any checks that are not satisfied
- [ ] Reviewed this code and left comments. Indicate if comments must be addressed before code is merged
- [ ] Checked that all code is adequately covered by tests
- [ ] Verify migrations are valid and do not conflict with existing migrations

#### Validated user-facing changes as a developer
**Note:** Multiple code reviewers can share the checklists above, a second reviewer should not make a duplicate checklist. All checks should be checked before approving, even those labeled N/A. 

- [ ] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Checked keyboard navigability
- [ ] Meets all designs and user flows provided by design/product
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)
- [ ] (Rarely needed) Tested as both an analyst and applicant user

### As a designer reviewer, I have

#### Verified that the changes match the design intention

- [ ] Checked that the design translated visually
- [ ] Checked behavior. Comment any found issues or broken flows.
- [ ] Checked different states (empty, one, some, error)
- [ ] Checked for landmarks, page heading structure, and links

#### Validated user-facing changes as a designer

- [ ] Checked keyboard navigability
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)
- [ ] Tested with multiple browsers (check off which ones were used)
  - [ ] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari
- [ ] (Rarely needed) Tested as both an analyst and applicant user

### References
- [Code review best practices](../docs/dev-practices/code_review.md)

## Screenshots

<!-- If this PR makes visible interface changes, an image of the finished interface can help reviewers
and casual observers understand the context of the changes.
A before image is optional and can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow.
You may want to use [GIPHY Capture](https://giphy.com/apps/giphycapture) for this! 📸

_Please frame images to show useful context but also highlight the affected regions._
--->
