### PR TITLE
#2559: Delete "Retrieved" invitation from the table once the user has been removed as a domain manager [dg]

### DIFF
--- a/src/registrar/apps.py
+++ b/src/registrar/apps.py
@@ -5,3 +5,6 @@ class RegistrarConfig(AppConfig):
     """Configure signal handling for our registrar Django application."""
 
     name = "registrar"
+
+    def ready(self):
+        import registrar.signals  # noqa

--- a/src/registrar/config/settings.py
+++ b/src/registrar/config/settings.py
@@ -119,7 +119,7 @@ INSTALLED_APPS = [
     # otherwise Django would find the default template
     # provided by django.contrib.admin first and use
     # that instead of our custom templates.
-    "registrar",
+    "registrar.apps.RegistrarConfig",
     # Django automatic admin interface reads metadata
     # from database models to provide a quick, model-centric
     # interface where trusted users can manage content

--- a/src/registrar/signals.py
+++ b/src/registrar/signals.py
@@ -1,0 +1,17 @@
+# registrar/signals.py
+from django.db.models.signals import post_delete
+from django.dispatch import receiver
+
+from .models import UserDomainRole, DomainInvitation
+
+
+@receiver(post_delete, sender=UserDomainRole)
+def cleanup_retrieved_domain_invitations(sender, instance, **kwargs):
+    """
+    Automatically clean up retrieved domain invitations when a UserDomainRole is deleted.
+    This ensures invitation and permission systems stay synchronized and resolves
+    issues where retrieved invitations block re-adding users to domains.
+    """
+    DomainInvitation.objects.filter(
+        email=instance.user.email, domain=instance.domain, status=DomainInvitation.DomainInvitationStatus.RETRIEVED
+    ).delete()

--- a/src/registrar/tests/test_admin.py
+++ b/src/registrar/tests/test_admin.py
@@ -343,7 +343,7 @@ class TestDomainInvitationAdmin(WebTest):
             # Assert that the filters are added
             self.assertContains(response, "invited", count=5)
             self.assertContains(response, "Invited", count=2)
-            self.assertContains(response, "retrieved", count=3)
+            self.assertContains(response, "retrieved", count=4)
             self.assertContains(response, "Retrieved", count=2)
 
             # Check for the HTML context specificially
@@ -1439,7 +1439,7 @@ class TestPortfolioInvitationAdmin(TestCase):
         # Assert that the filters are added
         self.assertContains(response, "invited", count=5)
         self.assertContains(response, "Invited", count=2)
-        self.assertContains(response, "retrieved", count=3)
+        self.assertContains(response, "retrieved", count=4)
         self.assertContains(response, "Retrieved", count=2)
 
         # Check for the HTML context specificially

--- a/src/registrar/tests/test_email_invitations.py
+++ b/src/registrar/tests/test_email_invitations.py
@@ -26,6 +26,8 @@ from registrar.utility.email_invitations import (
 
 from api.tests.common import less_console_noise_decorator
 from registrar.utility.errors import MissingEmailError
+from django.test import TestCase
+from registrar.models import DomainInvitation
 
 
 class DomainInvitationEmail(unittest.TestCase):
@@ -1329,3 +1331,60 @@ class TestSendPortfolioOrganizationUpdateEmail(unittest.TestCase):
             context=ANY,
         )
         self.assertTrue(result)
+
+
+class TestDomainInvitationCleanupSignal(TestCase):
+    """Integration tests for the signal that cleans up retrieved invitations when UserDomainRole is deleted."""
+
+    def setUp(self):
+        """Set up test data."""
+        self.user = User.objects.create_user(email="test@example.com", username="testuser")
+        self.domain = Domain.objects.create(name="test.gov")
+
+    def test_retrieved_invitation_cleaned_up_when_role_deleted(self):
+        """Test that retrieved invitations are deleted when UserDomainRole is deleted."""
+        # Create and retrieve an invitation
+        invitation = DomainInvitation.objects.create(
+            email=self.user.email, domain=self.domain, status=DomainInvitation.DomainInvitationStatus.INVITED
+        )
+        invitation.retrieve()
+        invitation.save()
+
+        # Verify setup
+        self.assertEqual(invitation.status, DomainInvitation.DomainInvitationStatus.RETRIEVED)
+        role = UserDomainRole.objects.get(user=self.user, domain=self.domain)
+        self.assertTrue(DomainInvitation.objects.filter(id=invitation.id).exists())
+
+        # Delete the role (this should trigger the new signal)
+        role.delete()
+
+        # Verify the invitation was cleaned up
+        self.assertFalse(DomainInvitation.objects.filter(id=invitation.id).exists())
+
+    def test_bug_fix_can_re_add_user_after_removal(self):
+        """Test the complete flow that reproduces and verifies the fix for ticket #3678."""
+        invitation = DomainInvitation.objects.create(
+            email=self.user.email, domain=self.domain, status=DomainInvitation.DomainInvitationStatus.INVITED
+        )
+        invitation.retrieve()
+        invitation.save()
+
+        # Remove the user (simulating admin removing domain manager)
+        role = UserDomainRole.objects.get(user=self.user, domain=self.domain)
+        role.delete()
+
+        self.assertFalse(DomainInvitation.objects.filter(id=invitation.id).exists())
+
+        # Create another invitation
+        invitation = DomainInvitation.objects.create(
+            email=self.user.email, domain=self.domain, status=DomainInvitation.DomainInvitationStatus.INVITED
+        )
+        invitation.retrieve()
+        invitation.save()
+
+        # Verify setup
+        self.assertEqual(invitation.status, DomainInvitation.DomainInvitationStatus.RETRIEVED)
+        role = UserDomainRole.objects.get(user=self.user, domain=self.domain)
+        self.assertTrue(DomainInvitation.objects.filter(id=invitation.id).exists())
+
+        self.assertTrue(UserDomainRole.objects.filter(user=self.user, domain=self.domain).exists())


### PR DESCRIPTION
## Ticket

<!-- PR title format: `#issue_number: Descriptive name ideally matching ticket name - [sandbox]`-->
Resolves #2559  

## Changes

<!-- What was added, updated, or removed in this PR. -->
- Explicitly defined the registrar conifig so we can easily add others (e.g. testing, no-ssl) + the old way is deprecated https://docs.djangoproject.com/en/dev/internals/deprecation/ 
- Added a post_delete signal for UserDomainRole

<!--
    Please add/remove/edit any of the template below to fit the needs
    of this specific PR.
--->

## Context for reviewers

<!--Background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers.  -->
This is a short term fix as this area is being re-designed in "https://github.com/cisagov/manage.get.gov/issues/3553 where we're planning a more holistic change in the invitations and domain roles. However, we expect that will be a longer-term resolution, and so this issue is still relevant for a more immediate improvement for what users see and how managers can be re-invited."

Also, please view https://github.com/cisagov/manage.get.gov/issues/3678 my comment states this won't occur now that with this fix.

## Setup

<!--  Add any steps or code to run in this section to help others run your code.    
    Example 2: If the PR was to add a new link with a redirect, this section could simply be:
    -go to /path/to/start/page
    -click the blue link in the <insert location>
    -notice user is redirected to <proper end location>
-->

Setup a CLI view of the database table registrar_domaininvitation (Select * from registrar_domaininvitation;) OR use Beekeeper to connect to the getgov-dg.app.cloud.gov db

1. As an Admin login to https://getgov-dg.app.cloud.gov/admin   
2. Click on domain invitation (L. Menu)
3. Click on Add domain invitation + (R. Side)
4. Enter your email (for this Admin user)
5. Domain > about-space-key.gov (or another one)
6. Click Save
7. Go to User Domain Roles (L. Menu)
8. Search for yourself and you should see yourself as Manager for the new domain
9. View the db table registrar_domaininvitation, you should see the new entry
10. Open a new tab and Go to https://getgov-dg.app.cloud.gov
11. Click on Manage next to the domain you just sent yourself an invite for
12. In Domain Overview you should see yourself under the list of Domain Managers, click Edit
13. Remove yourself
14. Go to your Admin tab and Refresh
15. You should no longer see yourself as a manager
16. Check your table again, you should no longer see the entry

## Code Review Verification Steps

### As the original developer, I have

#### Satisfied acceptance criteria and met development standards

- [x] Met the acceptance criteria, or will meet them in a subsequent PR
- [x] Created/modified automated tests
- [ ] Update documentation in READMEs and/or onboarding guide

#### Ensured code standards are met (Original Developer)
<!-- Mark "- N/A" and check at the end of each check that is not applicable to your PR -->
- [ ] If any updated dependencies on Pipfile, also update dependencies in requirements.txt.
- [ ] Interactions with external systems are wrapped in try/except
- [ ] Error handling exists for unusual or missing values

#### Validated user-facing changes (if applicable)

- [ ] Tag gov-designers in this PR's Reviewers section for design review. If code is not user-facing, delete design reviewer checklist
- [ ] Verify new pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Checked keyboard navigability
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)

### As a code reviewer, I have

#### Reviewed, tested, and left feedback about the changes

- [x] Pulled this branch locally and tested it
- [x] Verified code meets all checks above. Address any checks that are not satisfied
- [ ] Reviewed this code and left comments. Indicate if comments must be addressed before code is merged
- [ ] Checked that all code is adequately covered by tests
- [ ] Verify migrations are valid and do not conflict with existing migrations

#### Validated user-facing changes as a developer
**Note:** Multiple code reviewers can share the checklists above, a second reviewer should not make a duplicate checklist. All checks should be checked before approving, even those labeled N/A. 

- [ ] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Checked keyboard navigability
- [ ] Meets all designs and user flows provided by design/product
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)
- [ ] (Rarely needed) Tested as both an analyst and applicant user

### As a designer reviewer, I have

#### Verified that the changes match the design intention

- [ ] Checked that the design translated visually
- [ ] Checked behavior. Comment any found issues or broken flows.
- [ ] Checked different states (empty, one, some, error)
- [ ] Checked for landmarks, page heading structure, and links

#### Validated user-facing changes as a designer

- [ ] Checked keyboard navigability
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)
- [ ] Tested with multiple browsers (check off which ones were used)
  - [ ] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari
- [ ] (Rarely needed) Tested as both an analyst and applicant user

### References
- [Code review best practices](../docs/dev-practices/code_review.md)

## Screenshots

<!-- If this PR makes visible interface changes, an image of the finished interface can help reviewers
and casual observers understand the context of the changes.
A before image is optional and can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow.
You may want to use [GIPHY Capture](https://giphy.com/apps/giphycapture) for this! 📸

_Please frame images to show useful context but also highlight the affected regions._
--->
