### PR TITLE
#3956: create_federal_portfolio.py should give Basic members permission to view the domain they manage [zion]

### DIFF
--- a/src/registrar/apps.py
+++ b/src/registrar/apps.py
@@ -5,3 +5,5 @@ class RegistrarConfig(AppConfig):
     """Configure signal handling for our registrar Django application."""
 
     name = "registrar"
+    def ready(self):
+            import registrar.signals  # noqa

--- a/src/registrar/apps.py
+++ b/src/registrar/apps.py
@@ -5,5 +5,6 @@ class RegistrarConfig(AppConfig):
     """Configure signal handling for our registrar Django application."""
 
     name = "registrar"
+
     def ready(self):
-            import registrar.signals  # noqa
+        import registrar.signals  # noqa

--- a/src/registrar/config/settings.py
+++ b/src/registrar/config/settings.py
@@ -119,7 +119,7 @@ INSTALLED_APPS = [
     # otherwise Django would find the default template
     # provided by django.contrib.admin first and use
     # that instead of our custom templates.
-    "registrar",
+    "registrar.apps.RegistrarConfig",
     # Django automatic admin interface reads metadata
     # from database models to provide a quick, model-centric
     # interface where trusted users can manage content

--- a/src/registrar/management/commands/create_federal_portfolio.py
+++ b/src/registrar/management/commands/create_federal_portfolio.py
@@ -32,7 +32,7 @@ from registrar.models.user_portfolio_permission import UserPortfolioPermission
 from registrar.models.utility.generic_helper import count_capitals, normalize_string
 from django.db.models import F, Q
 
-from registrar.models.utility.portfolio_helper import UserPortfolioRoleChoices
+from registrar.models.utility.portfolio_helper import UserPortfolioRoleChoices, UserPortfolioPermissionChoices
 from registrar.management.commands.utility.fuzzy_string_matcher import create_federal_agency_matcher
 
 logger = logging.getLogger(__name__)
@@ -322,9 +322,21 @@ class Command(BaseCommand):
                 logger.error(err, exc_info=True)
 
         # == Handle managers (no bulk_create) == #
-        if parse_managers and not self.dry_run:
-            domain_infos = DomainInformation.objects.filter(portfolio__in=portfolios_to_use)
-            domains = Domain.objects.filter(domain_info__in=domain_infos)
+        if parse_managers:
+            if self.dry_run:
+                # In dry run mode, we can't filter by portfolios_to_use since they're not saved
+                # So we need to get domains from the domain_infos that were identified for updates
+                domains = []
+                for domain_info in self.domain_info_changes.update:
+                    try:
+                        domain = Domain.objects.get(domain_info=domain_info)
+                        domains.append(domain)
+                    except Domain.DoesNotExist:
+                        continue
+                logger.info(f"Found {len(domains)} domains for manager processing in dry run mode")
+            else:
+                domain_infos = DomainInformation.objects.filter(portfolio__in=portfolios_to_use)
+                domains = Domain.objects.filter(domain_info__in=domain_infos)
 
             # Create UserPortfolioPermission
             self.create_user_portfolio_permissions(domains)
@@ -836,20 +848,190 @@ class Command(BaseCommand):
                 logger.info(f"Set federal agency on started domain request '{domain_request}' to None.")
 
     def create_user_portfolio_permissions(self, domains):
+        """
+        Ensures domain managers retain their VIEW_MANAGED_DOMAINS permission
+        when portfolios are created or updated.
+
+        Args:
+            domains: List of Domain objects that belong to portfolios being processed
+        """
+        if not domains:
+            logger.info("No domains found for portfolio permission processing")
+            return
+
+        logger.info(f"Processing {len(domains)} domains for user portfolio permissions")
         user_domain_roles = UserDomainRole.objects.select_related(
             "user", "domain", "domain__domain_info", "domain__domain_info__portfolio"
         ).filter(domain__in=domains, domain__domain_info__portfolio__isnull=False, role=UserDomainRole.Roles.MANAGER)
+
+        if not user_domain_roles.exists():
+            logger.info("No domain managers found for the provided domains")
+            return
+
+        logger.info(f"Found {user_domain_roles.count()} domain manager roles to process")
+
         for user_domain_role in user_domain_roles:
-            user = user_domain_role.user
-            permission, created = UserPortfolioPermission.objects.get_or_create(
-                portfolio=user_domain_role.domain.domain_info.portfolio,
-                user=user,
-                defaults={"roles": [UserPortfolioRoleChoices.ORGANIZATION_MEMBER]},
+            self._process_manager_role(user_domain_role)
+
+    def _find_domains_using_fuzzy_matching(self):
+        """Find domains using the same fuzzy matching logic as update_domains() - dry run only."""
+        if self.domain_info_changes.update:
+            domains = []
+            for domain_info in self.domain_info_changes.update:
+                try:
+                    domain = Domain.objects.get(domain_info=domain_info)
+                    domains.append(domain)
+                except Domain.DoesNotExist:
+                    continue
+
+            logger.info(f"Found {len(domains)} domains from domain_info updates for dry run")
+            return domains
+
+        logger.info("No domain info updates found, no domains to process for permissions")
+        return []
+
+    def _process_manager_role(self, user_domain_role):
+        """Process a single domain manager role."""
+        user = user_domain_role.user
+        domain = user_domain_role.domain
+        domain_name = domain.name
+
+        if self.dry_run:
+            portfolio = self._find_new_portfolio_for_domain(domain)
+        else:
+            if domain.domain_info and domain.domain_info.portfolio:
+                portfolio = domain.domain_info.portfolio
+
+        if not portfolio:
+            logger.warning(f"Could not determine portfolio for domain {domain_name}")
+            return
+
+        logger.info(f"Processing manager {user.email} for domain {domain_name} in portfolio '{portfolio}'")
+        self._ensure_manager_portfolio_permission(user, portfolio)
+
+    def _find_new_portfolio_for_domain(self, domain):
+        """Find which portfolio a domain will be assigned to in dry run mode."""
+        for domain_info in self.domain_info_changes.update:
+            if domain_info.domain == domain:
+                return domain_info.portfolio
+
+        return self._find_portfolio_for_domain(domain)
+
+    def _find_portfolio_for_domain(self, domain):
+        """Find which portfolio a domain belongs to using fuzzy matching."""
+        if not domain.domain_info or not domain.domain_info.organization_name:
+            return None
+
+        domain_org_name = domain.domain_info.organization_name
+        portfolios_to_process = list(self.portfolio_changes.create) + list(self.portfolio_changes.skip)
+
+        for portfolio in portfolios_to_process:
+            if portfolio.federal_agency:
+                domain_filter = self._create_fuzzy_organization_filter(
+                    portfolio.federal_agency, [normalize_string(domain_org_name)]
+                )
+
+                if DomainInformation.objects.filter(id=domain.domain_info.id).filter(domain_filter).exists():
+                    return portfolio
+
+        return None
+
+    def _ensure_manager_portfolio_permission(self, user, portfolio):
+        """Ensure a domain manager has the correct portfolio permissions."""
+        defaults = {
+            "roles": [UserPortfolioRoleChoices.ORGANIZATION_MEMBER],
+            "additional_permissions": [UserPortfolioPermissionChoices.VIEW_MANAGED_DOMAINS],
+        }
+
+        if self.dry_run:
+            self._handle_dry_run_permission(user, portfolio, defaults)
+        else:
+            self._handle_live_permission(user, portfolio, defaults)
+
+    def _handle_dry_run_permission(self, user, portfolio, defaults):
+        """Handle permission processing in dry run mode."""
+        try:
+            existing_permission = UserPortfolioPermission.objects.get(portfolio=portfolio, user=user)
+
+            current_roles = existing_permission.roles or []
+            current_perms = existing_permission.additional_permissions or []
+
+            needs_update = (
+                UserPortfolioRoleChoices.ORGANIZATION_MEMBER in current_roles
+                and UserPortfolioPermissionChoices.VIEW_MANAGED_DOMAINS not in current_perms
             )
-            if created:
-                self.user_portfolio_perm_changes.create.append(permission)
+
+            if needs_update:
+                new_perms = current_perms + [UserPortfolioPermissionChoices.VIEW_MANAGED_DOMAINS]
+                changes = [f"additional_permissions: {current_perms} → {new_perms}"]
+                self._log_changes(f"user portfolio permission for {user.email} in portfolio '{portfolio}'", changes)
+                mock_permission = self._create_mock_permission(
+                    user,
+                    portfolio,
+                    current_roles,
+                    current_perms + [UserPortfolioPermissionChoices.VIEW_MANAGED_DOMAINS],
+                )
+                self.user_portfolio_perm_changes.update.append(mock_permission)
             else:
-                self.user_portfolio_perm_changes.skip.append(permission)
+                self._log_action(
+                    "SKIP", f"user portfolio permission for {user.email} in portfolio '{portfolio}' (already correct)"
+                )
+                mock_permission = self._create_mock_permission(user, portfolio, current_roles, current_perms)
+                self.user_portfolio_perm_changes.skip.append(mock_permission)
+
+        except UserPortfolioPermission.DoesNotExist:
+            self._log_action(
+                "CREATE",
+                f"user portfolio permission for {user.email} in portfolio '{portfolio}' with manager permissions",
+            )
+            mock_permission = self._create_mock_permission(
+                user, portfolio, defaults["roles"], defaults["additional_permissions"]
+            )
+            self.user_portfolio_perm_changes.create.append(mock_permission)
+
+    def _handle_live_permission(self, user, portfolio, defaults):
+        """Handle permission processing in live mode."""
+        permission, created = UserPortfolioPermission.objects.get_or_create(
+            portfolio=portfolio, user=user, defaults=defaults
+        )
+
+        if created:
+            self._log_action("CREATE", f"user portfolio permission for {user.email} in portfolio '{portfolio}'")
+            self.user_portfolio_perm_changes.create.append(permission)
+        elif UserPortfolioRoleChoices.ORGANIZATION_MEMBER in (
+            permission.roles or []
+        ) and UserPortfolioPermissionChoices.VIEW_MANAGED_DOMAINS not in (permission.additional_permissions or []):
+
+            additional_perms = (permission.additional_permissions or []).copy()
+            additional_perms.append(UserPortfolioPermissionChoices.VIEW_MANAGED_DOMAINS)
+            permission.additional_permissions = additional_perms
+            permission.save()
+
+            self._log_action(
+                "UPDATE",
+                f"user portfolio permission for {user.email} in portfolio '{portfolio}' - added VIEW_MANAGED_DOMAINS",
+            )
+            self.user_portfolio_perm_changes.update.append(permission)
+        else:
+            self._log_action(
+                "SKIP", f"user portfolio permission for {user.email} in portfolio '{portfolio}' (already correct)"
+            )
+            self.user_portfolio_perm_changes.skip.append(permission)
+
+    def _create_mock_permission(self, user, portfolio, roles, additional_permissions):
+        """Create a mock permission object for dry run tracking."""
+
+        class MockPermission:
+            def __init__(self, user, portfolio, roles, additional_permissions):
+                self.user = user
+                self.portfolio = portfolio
+                self.roles = roles
+                self.additional_permissions = additional_permissions
+
+            def __str__(self):
+                return f"UserPortfolioPermission for {self.user.email} in {self.portfolio}"
+
+        return MockPermission(user, portfolio, roles, additional_permissions)
 
     def create_portfolio_invitations(self, domains):
         domain_invitations = DomainInvitation.objects.select_related(

--- a/src/registrar/signals.py
+++ b/src/registrar/signals.py
@@ -1,0 +1,30 @@
+# registrar/signals.py
+from django.db.models.signals import post_delete
+from django.dispatch import receiver
+import logging
+
+from .models import UserDomainRole, DomainInvitation
+
+logger = logging.getLogger(__name__)
+
+@receiver(post_delete, sender=UserDomainRole)
+def cleanup_retrieved_domain_invitations(sender, instance, **kwargs):
+    """
+    Automatically clean up retrieved domain invitations when a UserDomainRole is deleted.
+    """
+    print(f"🔥 SIGNAL FIRED: UserDomainRole deleted for {instance.user.email} on {instance.domain.name}")
+    
+    matching_invitations = DomainInvitation.objects.filter(
+        email=instance.user.email,
+        domain=instance.domain,
+        status=DomainInvitation.DomainInvitationStatus.RETRIEVED
+    )
+    
+    count = matching_invitations.count()
+    print(f"🧹 Found {count} retrieved invitations to clean up")
+    
+    if count > 0:
+        matching_invitations.delete()
+        print(f"✅ Deleted {count} retrieved invitations")
+    else:
+        print("ℹ️  No retrieved invitations to clean up")

--- a/src/registrar/signals.py
+++ b/src/registrar/signals.py
@@ -1,30 +1,17 @@
 # registrar/signals.py
 from django.db.models.signals import post_delete
 from django.dispatch import receiver
-import logging
 
 from .models import UserDomainRole, DomainInvitation
 
-logger = logging.getLogger(__name__)
 
 @receiver(post_delete, sender=UserDomainRole)
 def cleanup_retrieved_domain_invitations(sender, instance, **kwargs):
     """
     Automatically clean up retrieved domain invitations when a UserDomainRole is deleted.
+    This ensures invitation and permission systems stay synchronized and resolves
+    issues where retrieved invitations block re-adding users to domains.
     """
-    print(f"🔥 SIGNAL FIRED: UserDomainRole deleted for {instance.user.email} on {instance.domain.name}")
-    
-    matching_invitations = DomainInvitation.objects.filter(
-        email=instance.user.email,
-        domain=instance.domain,
-        status=DomainInvitation.DomainInvitationStatus.RETRIEVED
-    )
-    
-    count = matching_invitations.count()
-    print(f"🧹 Found {count} retrieved invitations to clean up")
-    
-    if count > 0:
-        matching_invitations.delete()
-        print(f"✅ Deleted {count} retrieved invitations")
-    else:
-        print("ℹ️  No retrieved invitations to clean up")
+    DomainInvitation.objects.filter(
+        email=instance.user.email, domain=instance.domain, status=DomainInvitation.DomainInvitationStatus.RETRIEVED
+    ).delete()

--- a/src/registrar/tests/test_admin.py
+++ b/src/registrar/tests/test_admin.py
@@ -343,7 +343,7 @@ class TestDomainInvitationAdmin(WebTest):
             # Assert that the filters are added
             self.assertContains(response, "invited", count=5)
             self.assertContains(response, "Invited", count=2)
-            self.assertContains(response, "retrieved", count=3)
+            self.assertContains(response, "retrieved", count=4)
             self.assertContains(response, "Retrieved", count=2)
 
             # Check for the HTML context specificially
@@ -1439,7 +1439,7 @@ class TestPortfolioInvitationAdmin(TestCase):
         # Assert that the filters are added
         self.assertContains(response, "invited", count=5)
         self.assertContains(response, "Invited", count=2)
-        self.assertContains(response, "retrieved", count=3)
+        self.assertContains(response, "retrieved", count=4)
         self.assertContains(response, "Retrieved", count=2)
 
         # Check for the HTML context specificially

--- a/src/registrar/tests/test_email_invitations.py
+++ b/src/registrar/tests/test_email_invitations.py
@@ -26,6 +26,8 @@ from registrar.utility.email_invitations import (
 
 from api.tests.common import less_console_noise_decorator
 from registrar.utility.errors import MissingEmailError
+from django.test import TestCase
+from registrar.models import DomainInvitation
 
 
 class DomainInvitationEmail(unittest.TestCase):
@@ -1331,63 +1333,58 @@ class TestSendPortfolioOrganizationUpdateEmail(unittest.TestCase):
         self.assertTrue(result)
 
 
-from django.test import TestCase
-from registrar.models import Domain, DomainInvitation, UserDomainRole, User
-
 class TestDomainInvitationCleanupSignal(TestCase):
     """Integration tests for the signal that cleans up retrieved invitations when UserDomainRole is deleted."""
 
     def setUp(self):
         """Set up test data."""
-        self.user = User.objects.create_user(
-            email='test@example.com',
-            username='testuser'
-        )
-        self.domain = Domain.objects.create(name='test.gov')
-        
+        self.user = User.objects.create_user(email="test@example.com", username="testuser")
+        self.domain = Domain.objects.create(name="test.gov")
+
     def test_retrieved_invitation_cleaned_up_when_role_deleted(self):
         """Test that retrieved invitations are deleted when UserDomainRole is deleted."""
         # Create and retrieve an invitation
         invitation = DomainInvitation.objects.create(
-            email=self.user.email,
-            domain=self.domain,
-            status=DomainInvitation.DomainInvitationStatus.INVITED
+            email=self.user.email, domain=self.domain, status=DomainInvitation.DomainInvitationStatus.INVITED
         )
         invitation.retrieve()
         invitation.save()
-        
+
         # Verify setup
         self.assertEqual(invitation.status, DomainInvitation.DomainInvitationStatus.RETRIEVED)
         role = UserDomainRole.objects.get(user=self.user, domain=self.domain)
         self.assertTrue(DomainInvitation.objects.filter(id=invitation.id).exists())
-        
+
         # Delete the role (this should trigger the new signal)
         role.delete()
-        
+
         # Verify the invitation was cleaned up
         self.assertFalse(DomainInvitation.objects.filter(id=invitation.id).exists())
 
     def test_bug_fix_can_re_add_user_after_removal(self):
         """Test the complete flow that reproduces and verifies the fix for ticket #3678."""
         invitation = DomainInvitation.objects.create(
-            email=self.user.email,
-            domain=self.domain,
-            status=DomainInvitation.DomainInvitationStatus.INVITED
+            email=self.user.email, domain=self.domain, status=DomainInvitation.DomainInvitationStatus.INVITED
         )
-        invitation.retrieve()  
+        invitation.retrieve()
         invitation.save()
-        
+
         # Remove the user (simulating admin removing domain manager)
         role = UserDomainRole.objects.get(user=self.user, domain=self.domain)
         role.delete()
-        
-        # Re-add the user
-        new_role = UserDomainRole.objects.create(
-            user=self.user,
-            domain=self.domain,
-            role=UserDomainRole.Roles.MANAGER
+
+        self.assertFalse(DomainInvitation.objects.filter(id=invitation.id).exists())
+
+        # Create another invitation
+        invitation = DomainInvitation.objects.create(
+            email=self.user.email, domain=self.domain, status=DomainInvitation.DomainInvitationStatus.INVITED
         )
-        
-        self.assertTrue(
-            UserDomainRole.objects.filter(user=self.user, domain=self.domain).exists()
-        )
+        invitation.retrieve()
+        invitation.save()
+
+        # Verify setup
+        self.assertEqual(invitation.status, DomainInvitation.DomainInvitationStatus.RETRIEVED)
+        role = UserDomainRole.objects.get(user=self.user, domain=self.domain)
+        self.assertTrue(DomainInvitation.objects.filter(id=invitation.id).exists())
+
+        self.assertTrue(UserDomainRole.objects.filter(user=self.user, domain=self.domain).exists())

--- a/src/registrar/views/domain.py
+++ b/src/registrar/views/domain.py
@@ -1258,7 +1258,7 @@ class DomainUsersView(DomainBaseView):
         for domain_invitation in self.object.invitations.filter(
             status__in=[
                 DomainInvitation.DomainInvitationStatus.INVITED,
-                DomainInvitation.DomainInvitationStatus.CANCELED
+                DomainInvitation.DomainInvitationStatus.CANCELED,
             ]
         ):
             # Check if there are any PortfolioInvitations linked to the same portfolio with the ORGANIZATION_ADMIN role

--- a/src/registrar/views/domain.py
+++ b/src/registrar/views/domain.py
@@ -1255,7 +1255,12 @@ class DomainUsersView(DomainBaseView):
         # Prepare a list to store invitations with an admin flag
         invitations = []
 
-        for domain_invitation in self.object.invitations.all():
+        for domain_invitation in self.object.invitations.filter(
+            status__in=[
+                DomainInvitation.DomainInvitationStatus.INVITED,
+                DomainInvitation.DomainInvitationStatus.CANCELED
+            ]
+        ):
             # Check if there are any PortfolioInvitations linked to the same portfolio with the ORGANIZATION_ADMIN role
             has_admin_flag = False
 
@@ -1273,10 +1278,7 @@ class DomainUsersView(DomainBaseView):
                     has_admin_flag = True
                     break  # Once we find one match, no need to check further
 
-            # Add the role along with the computed flag to the list if the domain invitation
-            # if the status is not canceled
-            if domain_invitation.status != "canceled":
-                invitations.append({"domain_invitation": domain_invitation, "has_admin_flag": has_admin_flag})
+            invitations.append({"domain_invitation": domain_invitation, "has_admin_flag": has_admin_flag})
 
         # Pass roles_with_flags to the context
         context["invitations"] = invitations


### PR DESCRIPTION
## Ticket

<!-- PR title format: `#issue_number: Descriptive name ideally matching ticket name - [sandbox]`-->
Resolves #3956 

## Changes

<!-- What was added, updated, or removed in this PR. -->
- Added a dry run option for it
- Added the VIEW_MANAGED_DOMAINS permission for org members being processed.

<!--
    Please add/remove/edit any of the template below to fit the needs
    of this specific PR.
--->

## Context for reviewers

<!--Background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers.  -->

## Setup
I found it most helpful to use both Beekeeper and the Django Admin to setup test data correctly to test this.

1. In Django Admin (or DB), pick a domain that has a manager OR add yourself or someone to the domain you pick e.g. music-or-finally.gov (make a note of the domain, helpful later)
2. Update the suborganization to "Amtrack" (or pick a name that is not already a Portfolio name. I prefer to do this in the database in the suborganization table)
3. Update any other agency org type info in the domain information/request for your domain to Step 2's name. (You will need the domain ID in the DB or do this UI, Django or the App, if the app then you'll have to make yourself the admin. I find the DB easier and recommend that.)
4. Either update an old or create a new Agency named whatever you chose as the suborganization name in Step 2.

Now we are setup to create a portfolio with that suborg / agency name.

If not running locally, open a CLI to Zion and run a dry run to test the changes:
docker compose exec app ./manage.py create_federal_portfolio --agency_name "YOUR_NAME_HERE" --parse_domains --parse_managers --dry_run --debug

If it looks good then run the same thing without this parameter: --dry_run 

Now, go to the DB or the Django Admin and you should see the manager from Step 1 is still a manager for the domain even though it is now in a new portfolio

<!--  Add any steps or code to run in this section to help others run your code.
    
    Example 1:
    ```sh
    echo "Code goes here"
    ``` 
    
    Example 2: If the PR was to add a new link with a redirect, this section could simply be:
    -go to /path/to/start/page
    -click the blue link in the <insert location>
    -notice user is redirected to <proper end location>
-->

## Code Review Verification Steps

### As the original developer, I have

#### Satisfied acceptance criteria and met development standards

- [ ] Met the acceptance criteria, or will meet them in a subsequent PR
- [ ] Created/modified automated tests
- [ ] Update documentation in READMEs and/or onboarding guide

#### Ensured code standards are met (Original Developer)
<!-- Mark "- N/A" and check at the end of each check that is not applicable to your PR -->
- [ ] If any updated dependencies on Pipfile, also update dependencies in requirements.txt.
- [ ] Interactions with external systems are wrapped in try/except
- [ ] Error handling exists for unusual or missing values

#### Validated user-facing changes (if applicable)

- [ ] Tag gov-designers in this PR's Reviewers section for design review. If code is not user-facing, delete design reviewer checklist
- [ ] Verify new pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Checked keyboard navigability
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)

### As a code reviewer, I have

#### Reviewed, tested, and left feedback about the changes

- [ ] Pulled this branch locally and tested it
- [ ] Verified code meets all checks above. Address any checks that are not satisfied
- [ ] Reviewed this code and left comments. Indicate if comments must be addressed before code is merged
- [ ] Checked that all code is adequately covered by tests
- [ ] Verify migrations are valid and do not conflict with existing migrations

#### Validated user-facing changes as a developer
**Note:** Multiple code reviewers can share the checklists above, a second reviewer should not make a duplicate checklist. All checks should be checked before approving, even those labeled N/A. 

- [ ] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Checked keyboard navigability
- [ ] Meets all designs and user flows provided by design/product
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)
- [ ] (Rarely needed) Tested as both an analyst and applicant user

### As a designer reviewer, I have

#### Verified that the changes match the design intention

- [ ] Checked that the design translated visually
- [ ] Checked behavior. Comment any found issues or broken flows.
- [ ] Checked different states (empty, one, some, error)
- [ ] Checked for landmarks, page heading structure, and links

#### Validated user-facing changes as a designer

- [ ] Checked keyboard navigability
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)
- [ ] Tested with multiple browsers (check off which ones were used)
  - [ ] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari
- [ ] (Rarely needed) Tested as both an analyst and applicant user

### References
- [Code review best practices](../docs/dev-practices/code_review.md)

## Screenshots

<!-- If this PR makes visible interface changes, an image of the finished interface can help reviewers
and casual observers understand the context of the changes.
A before image is optional and can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow.
You may want to use [GIPHY Capture](https://giphy.com/apps/giphycapture) for this! 📸

_Please frame images to show useful context but also highlight the affected regions._
--->
