### PR TITLE
Make subheadings/h4s sentence case instead of title case on org overview page [PRODUCT]

### DIFF
--- a/src/registrar/templates/includes/summary_item.html
+++ b/src/registrar/templates/includes/summary_item.html
@@ -26,7 +26,7 @@
     {# To display default styling for sub-header text and organization information in organization overview #}
     {% if sub_header_text %}
       <h4 class="margin-bottom-0">{{ sub_header_text }}</h4>  
-      {% if sub_header_text == "Organization Admins" %}  
+      {% if sub_header_text == "Organization admins" %}  
         <ul class="usa-list">
           {% for admin in portfolio_admins %}
             <li>{{ admin.get_full_name|default:admin.username }}</li>
@@ -34,7 +34,7 @@
             <li>No admins assigned.</li>
           {% endfor %}
         </ul>
-        <h4 class="margin-bottom-2">Organization Name and Address</h4>
+        <h4 class="margin-bottom-2">Organization name and address</h4>
       {% endif %}
     {% endif %}
     

--- a/src/registrar/templates/portfolio_organization.html
+++ b/src/registrar/templates/portfolio_organization.html
@@ -20,7 +20,7 @@
             <div class="margin-top-2 tablet:grid-col-10">
                 <h2 class="string-wrap margin-top-2">{{ portfolio }}</h2>
                     {% url 'organization-info' as url %}
-                    {% include "includes/summary_item.html" with title='Organization' value=portfolio address='true' sub_header_text='Organization Admins' edit_link=url editable=has_edit_portfolio_permission view_button='true' portfolio_first_section='true' %}
+                    {% include "includes/summary_item.html" with title='Organization' value=portfolio address='true' sub_header_text='Organization admins' edit_link=url editable=has_edit_portfolio_permission view_button='true' portfolio_first_section='true' %}
 
                     {% url 'organization-senior-official' as url %}
                     {% include "includes/summary_item.html" with title='Senior official' value=portfolio.senior_official contact='true' edit_link=url view_button='true' %}


### PR DESCRIPTION
## Ticket

<!-- PR title format: `#issue_number: Descriptive name ideally matching ticket name - [sandbox]`-->
Resolves #4020 

## Changes

<!-- What was added, updated, or removed in this PR. -->
- Updated headings on org overview page to be sentence case
- Updated subhead variable conditional to also be sentence case for consistency

## Context for reviewers

## Setup

This is deployed on the Product sandbox for review.

## Code Review Verification Steps

### As the original developer, I have

#### Satisfied acceptance criteria and met development standards

- [ ] Met the acceptance criteria, or will meet them in a subsequent PR
- [ ] Created/modified automated tests (N/A)
- [ ] Update documentation in READMEs and/or onboarding guide (N/A)

#### Ensured code standards are met (Original Developer)
<!-- Mark "- N/A" and check at the end of each check that is not applicable to your PR -->
- [ ] If any updated dependencies on Pipfile, also update dependencies in requirements.txt. (N/A)
- [ ] Interactions with external systems are wrapped in try/except (N/A)
- [ ] Error handling exists for unusual or missing values (N/A)

#### Validated user-facing changes (if applicable)

- [ ] Tag gov-designers in this PR's Reviewers section for design review. If code is not user-facing, delete design reviewer checklist

### As a code reviewer, I have

#### Reviewed, tested, and left feedback about the changes

- [ ] Pulled this branch locally and tested it
- [ ] Verified code meets all checks above. Address any checks that are not satisfied
- [ ] Reviewed this code and left comments. Indicate if comments must be addressed before code is merged
- [ ] Checked that all code is adequately covered by tests
- [ ] Verify migrations are valid and do not conflict with existing migrations

#### Validated user-facing changes as a developer
**Note:** Multiple code reviewers can share the checklists above, a second reviewer should not make a duplicate checklist. All checks should be checked before approving, even those labeled N/A. 

- [ ] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing  (N/A)
- [ ] Checked keyboard navigability
- [ ] Meets all designs and user flows provided by design/product
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)
- [ ] (Rarely needed) Tested as both an analyst and applicant user

### As a designer reviewer, I have

#### Verified that the changes match the design intention

- [ ] Checked that the design translated visually
- [ ] Checked behavior. Comment any found issues or broken flows.
- [ ] Checked different states (empty, one, some, error)
- [ ] Checked for landmarks, page heading structure, and links

#### Validated user-facing changes as a designer

- [ ] Checked keyboard navigability
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)
- [ ] Tested with multiple browsers (check off which ones were used)
  - [ ] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari
- [ ] (Rarely needed) Tested as both an analyst and applicant user

### References
- [Code review best practices](../docs/dev-practices/code_review.md)

## Screenshots

<!-- If this PR makes visible interface changes, an image of the finished interface can help reviewers
and casual observers understand the context of the changes.
A before image is optional and can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow.
You may want to use [GIPHY Capture](https://giphy.com/apps/giphycapture) for this! 📸

_Please frame images to show useful context but also highlight the affected regions._
--->
