### PR TITLE
#3870:  add helper text to legacy request form fed agency drop down

### DIFF
--- a/src/registrar/assets/src/sass/_theme/_register-form.scss
+++ b/src/registrar/assets/src/sass/_theme/_register-form.scss
@@ -41,6 +41,11 @@
   margin-top: units(1);
 }
 
+.register-form-step #id_organization_contact-federal_agency__sublabel.text-base {
+  font-size: 14.88px;
+  color: #3D4551;  
+}
+
 .ao_example p {
   margin-top: units(1);
 }
@@ -66,3 +71,5 @@
   margin-top: 0;
   margin-bottom: units(0.5);
 }
+
+

--- a/src/registrar/forms/domain_request_wizard.py
+++ b/src/registrar/forms/domain_request_wizard.py
@@ -20,7 +20,6 @@ from registrar.templatetags.url_helpers import public_site_url
 from registrar.utility.enums import ValidationReturnType
 from registrar.utility.constants import BranchChoices
 from django.core.exceptions import ValidationError
-from django.utils.safestring import mark_safe
 
 logger = logging.getLogger(__name__)
 
@@ -330,12 +329,6 @@ class OrganizationContactForm(RegistrarForm):
         # We populate this queryset in init.
         queryset=FederalAgency.objects.none(),
         widget=ComboboxWidget,
-        help_text=mark_safe(
-            "Don't see your agency listed? Its domains may be managed through enterprise mode, "
-            "which limits who can submit domain requests. "
-            f'<a href="{public_site_url("contact")}" class="usa-link" target="_blank">Contact us</a> '
-            "for assistance."
-        ),
     )
     organization_name = forms.CharField(
         label="Organization name",

--- a/src/registrar/forms/domain_request_wizard.py
+++ b/src/registrar/forms/domain_request_wizard.py
@@ -20,6 +20,7 @@ from registrar.templatetags.url_helpers import public_site_url
 from registrar.utility.enums import ValidationReturnType
 from registrar.utility.constants import BranchChoices
 from django.core.exceptions import ValidationError
+from django.utils.safestring import mark_safe
 
 logger = logging.getLogger(__name__)
 
@@ -329,6 +330,12 @@ class OrganizationContactForm(RegistrarForm):
         # We populate this queryset in init.
         queryset=FederalAgency.objects.none(),
         widget=ComboboxWidget,
+        help_text=mark_safe(
+            "Don't see your agency listed? Its domains may be managed through enterprise mode, "
+            "which limits who can submit domain requests. "
+            f'<a href="{public_site_url("contact")}" class="usa-link" target="_blank">Contact us</a> '
+            "for assistance."
+        ),
     )
     organization_name = forms.CharField(
         label="Organization name",

--- a/src/registrar/templates/domain_request_org_contact.html
+++ b/src/registrar/templates/domain_request_org_contact.html
@@ -18,9 +18,12 @@
     </legend>
 
     {% if is_federal %}
-      {% with attr_required=True sublabel_text=forms.0.federal_agency.help_text %}
+      {% with attr_required=True %}
         {% input_with_errors forms.0.federal_agency %}
       {% endwith %}
+      <p id="id_organization_contact-federal_agency__sublabel" class="text-base margin-top-2px margin-bottom-1">
+        Don't see your agency listed? Its domains may be managed through enterprise mode, which limits who can submit domain requests. <a href="{% public_site_url 'contact' %}" class="usa-link" target="_blank">Contact us</a> for assistance.
+      </p>
     {% endif %}
 
     {% input_with_errors forms.0.organization_name %}

--- a/src/registrar/templates/domain_request_org_contact.html
+++ b/src/registrar/templates/domain_request_org_contact.html
@@ -18,7 +18,7 @@
     </legend>
 
     {% if is_federal %}
-      {% with attr_required=True %}
+      {% with attr_required=True sublabel_text=forms.0.federal_agency.help_text %}
         {% input_with_errors forms.0.federal_agency %}
       {% endwith %}
     {% endif %}


### PR DESCRIPTION
## Ticket

<!-- PR title format: `#issue_number: Descriptive name ideally matching ticket name - [sandbox]`-->
Resolves #3870

## Changes

<!-- What was added, updated, or removed in this PR. -->
- new styling for the helper text

<!--
    Please add/remove/edit any of the template below to fit the needs
    of this specific PR.
--->

## Context for reviewers

<!--Background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers.  -->

In Zion: https://getgov-zion.app.cloud.gov/request/start/

## Setup

1. Go here: https://getgov-zion.app.cloud.gov/request/start/ 
2. Click Continue
3. Select Federal and click Save & Continue
4. Pick one and click Save & Continue 
5. In the Organization Contact page / form you should see the text under the dropdown for federal agency.

<!--  Add any steps or code to run in this section to help others run your code.
    
    Example 1:
    ```sh
    echo "Code goes here"
    ``` 
    
    Example 2: If the PR was to add a new link with a redirect, this section could simply be:
    -go to /path/to/start/page
    -click the blue link in the <insert location>
    -notice user is redirected to <proper end location>
-->

## Code Review Verification Steps

### As the original developer, I have

#### Satisfied acceptance criteria and met development standards

- [ ] Met the acceptance criteria, or will meet them in a subsequent PR
- [ ] Created/modified automated tests
- [ ] Update documentation in READMEs and/or onboarding guide

#### Ensured code standards are met (Original Developer)
<!-- Mark "- N/A" and check at the end of each check that is not applicable to your PR -->
- [ ] If any updated dependencies on Pipfile, also update dependencies in requirements.txt.
- [ ] Interactions with external systems are wrapped in try/except
- [ ] Error handling exists for unusual or missing values

#### Validated user-facing changes (if applicable)

- [ ] [Follow the process for requesting a design review](https://dhscisa.enterprise.slack.com/docs/T02QH7E1MHA/F06CZ6MRUKA). If code is not user-facing, delete design reviewer checklist
- [ ] Verify new pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Checked keyboard navigability
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)

### As a code reviewer, I have

#### Reviewed, tested, and left feedback about the changes

- [ ] Pulled this branch locally and tested it
- [ ] Verified code meets all checks above. Address any checks that are not satisfied
- [ ] Reviewed this code and left comments. Indicate if comments must be addressed before code is merged
- [ ] Checked that all code is adequately covered by tests
- [ ] Verify migrations are valid and do not conflict with existing migrations

#### Validated user-facing changes as a developer
**Note:** Multiple code reviewers can share the checklists above, a second reviewer should not make a duplicate checklist. All checks should be checked before approving, even those labeled N/A. 

- [ ] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Checked keyboard navigability
- [ ] Meets all designs and user flows provided by design/product
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)
- [ ] (Rarely needed) Tested as both an analyst and applicant user

### As a designer reviewer, I have

#### Verified that the changes match the design intention

- [ ] Checked that the design translated visually
- [ ] Checked behavior. Comment any found issues or broken flows.
- [ ] Checked different states (empty, one, some, error)
- [ ] Checked for landmarks, page heading structure, and links

#### Validated user-facing changes as a designer

- [ ] Checked keyboard navigability
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)
- [ ] Tested with multiple browsers (check off which ones were used)
  - [ ] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari
- [ ] (Rarely needed) Tested as both an analyst and applicant user

### References
- [Code review best practices](../docs/dev-practices/code_review.md)

## Screenshots

<!-- If this PR makes visible interface changes, an image of the finished interface can help reviewers
and casual observers understand the context of the changes.
A before image is optional and can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow.
You may want to use [GIPHY Capture](https://giphy.com/apps/giphycapture) for this! 📸

_Please frame images to show useful context but also highlight the affected regions._
--->
