### PR TITLE
4006: Convert DNS prototype to desired service structure

### DIFF
--- a/docs/developer/README.md
+++ b/docs/developer/README.md
@@ -385,16 +385,26 @@ Then, copy the variables under the section labled `s3`.
 The [.gov Domain Request & Domain Status Diagram](https://app.mural.co/t/cisaenterprise3850/m/cisaenterprise3850/1743613581103/eeff220faf8db79d54624cef49d40f66cf85bfd6) visualizes the domain request flow and resulting domain objects.
 
 
-## Testing the prototype add DNS record feature (delete this after we are done testing!)
+## Testing the prototype add DNS record feature (update as testing instructions change)
 We are currently testing using cloudflare to add DNS records. Specifically, an A record. To use this, you will need to enable the
 `prototype_dns_flag` waffle flag and navigate to `igorville.gov`, `dns.gov`, or `domainops.gov`. Click manage, then click DNS. From there, click the `Prototype DNS record creator` button.
 
 Before we can send data to cloudflare, you will need these values in your .env file:
 ```
-REGISTRY_TENANT_KEY = {tenant key}
-REGISTRY_SERVICE_EMAIL = {An email address}
-REGISTRY_TENANT_NAME = {Name of the bucket, i.e. "CISA" }
+DNS_TENANT_KEY = {tenant key}
+DNS_SERVICE_EMAIL = {An email address}
+DNS_TENANT_NAME = {Name of the bucket, i.e. "CISA" }
+DNS_TEST_TENANT_ID = {id of the test tenant (as opposed to the prod tenant)}
 ```
-You can obtain these by following the steps outlined in the [dns hosting discovery doc](https://docs.google.com/document/d/1Yq5d2M3MgM2vPhUBZ0k5wOmCQst4vND9-2qEZ55-h-Y/edit?tab=t.0), BUT it is far easier to just get these from someone else. Reach out to Zander for this information if you do not have it.
-
+You can obtain these by going to cloud.gov and looking at the variables in the getgov-kma application (for now)
 Alternatively, if you are testing on a sandbox, you will need to add those to getgov-credentials.
+
+To manually test locally:
+
+   - Add env't vars to your .env
+   - From localhost:8080 in Enterprise view, go to domains and find one for which you are a domain manager (look for "Manage" under "Action"). Go to that domain's detail page
+   - Add (temporarily) that domain to the list of valid_domains in both the DomainDNSView and PrototypeDomainDNSRecordView. This will allow you to follow a link to a DNS Record page
+   - Click on "DNS" on the left nav menu
+   - Click the link below DNSEC: "Prototype DNS record creator"
+   - You should see a form for adding DNS records
+

--- a/src/docker-compose.yml
+++ b/src/docker-compose.yml
@@ -63,6 +63,7 @@ services:
       - REGISTRY_TENANT_KEY
       - REGISTRY_SERVICE_EMAIL
       - REGISTRY_TENANT_NAME
+      - DOTGOV_TEST_TENANT_ID
     stdin_open: true
     tty: true
     ports:

--- a/src/docker-compose.yml
+++ b/src/docker-compose.yml
@@ -60,10 +60,10 @@ services:
       - AWS_S3_BUCKET_NAME
       # File encryption credentials
       - SECRET_ENCRYPT_METADATA
-      - REGISTRY_TENANT_KEY
-      - REGISTRY_SERVICE_EMAIL
-      - REGISTRY_TENANT_NAME
-      - DOTGOV_TEST_TENANT_ID
+      - DNS_TENANT_KEY
+      - DNS_SERVICE_EMAIL
+      - DNS_TENANT_NAME
+      - DNS_TEST_TENANT_ID
     stdin_open: true
     tty: true
     ports:

--- a/src/registrar/config/settings.py
+++ b/src/registrar/config/settings.py
@@ -95,6 +95,7 @@ secret_registry_hostname = secret("REGISTRY_HOSTNAME")
 secret_registry_tenant_key = secret("REGISTRY_TENANT_KEY", None)
 secret_registry_tenant_name = secret("REGISTRY_TENANT_NAME", None)
 secret_registry_service_email = secret("REGISTRY_SERVICE_EMAIL", None)
+secret_dotgov_tenant_account_id = secret("DOTGOV_TENANT_ID", None)
 
 # region: Basic Django Config-----------------------------------------------###
 

--- a/src/registrar/config/settings.py
+++ b/src/registrar/config/settings.py
@@ -95,7 +95,7 @@ secret_registry_hostname = secret("REGISTRY_HOSTNAME")
 secret_registry_tenant_key = secret("REGISTRY_TENANT_KEY", None)
 secret_registry_tenant_name = secret("REGISTRY_TENANT_NAME", None)
 secret_registry_service_email = secret("REGISTRY_SERVICE_EMAIL", None)
-secret_dotgov_tenant_account_id = secret("DOTGOV_TENANT_ID", None)
+secret_dotgov_tenant_id = secret("DOTGOV_TEST_TENANT_ID", None)
 
 # region: Basic Django Config-----------------------------------------------###
 
@@ -812,6 +812,7 @@ SECRET_REGISTRY_HOSTNAME = secret_registry_hostname
 SECRET_REGISTRY_TENANT_KEY = secret_registry_tenant_key
 SECRET_REGISTRY_TENANT_NAME = secret_registry_tenant_name
 SECRET_REGISTRY_SERVICE_EMAIL = secret_registry_service_email
+SECRET_DOTGOV_TENANT_ID = secret_dotgov_tenant_id
 
 # endregion
 # region: Security and Privacy----------------------------------------------###

--- a/src/registrar/config/settings.py
+++ b/src/registrar/config/settings.py
@@ -92,10 +92,10 @@ secret_registry_key_passphrase = secret("REGISTRY_KEY_PASSPHRASE", "")
 secret_registry_hostname = secret("REGISTRY_HOSTNAME")
 
 # PROTOTYPE: Used for DNS hosting
-secret_registry_tenant_key = secret("REGISTRY_TENANT_KEY", None)
-secret_registry_tenant_name = secret("REGISTRY_TENANT_NAME", None)
-secret_registry_service_email = secret("REGISTRY_SERVICE_EMAIL", None)
-secret_dotgov_tenant_id = secret("DOTGOV_TEST_TENANT_ID", None)
+secret_dns_tenant_key = secret("DNS_TENANT_KEY", None)
+secret_dns_tenant_name = secret("DNS_TENANT_NAME", None)
+secret_registry_service_email = secret("DNS_SERVICE_EMAIL", None)
+secret_dns_tenant_id = secret("DNS_TEST_TENANT_ID", None)
 
 # region: Basic Django Config-----------------------------------------------###
 
@@ -809,10 +809,10 @@ SECRET_REGISTRY_CERT = secret_registry_cert
 SECRET_REGISTRY_KEY = secret_registry_key
 SECRET_REGISTRY_KEY_PASSPHRASE = secret_registry_key_passphrase
 SECRET_REGISTRY_HOSTNAME = secret_registry_hostname
-SECRET_REGISTRY_TENANT_KEY = secret_registry_tenant_key
-SECRET_REGISTRY_TENANT_NAME = secret_registry_tenant_name
-SECRET_REGISTRY_SERVICE_EMAIL = secret_registry_service_email
-SECRET_DOTGOV_TENANT_ID = secret_dotgov_tenant_id
+SECRET_DNS_TENANT_KEY = secret_dns_tenant_key
+SECRET_DNS_TENANT_NAME = secret_dns_tenant_name
+SECRET_DNS_SERVICE_EMAIL = secret_registry_service_email
+SECRET_DNS_TENANT_ID = secret_dns_tenant_id
 
 # endregion
 # region: Security and Privacy----------------------------------------------###

--- a/src/registrar/services/cloudflare_service.py
+++ b/src/registrar/services/cloudflare_service.py
@@ -37,7 +37,7 @@ class CloudflareService:
         response = make_api_request(url=url, method="POST", headers=self.headers, data=data )
 
         if not response['success']:
-            raise APIError(f"Failed to create zone for {account_name}: {response['message']}; errors returned: {errors}")
+            raise APIError(f"Failed to create zone for {account_name}: {response['message']}")
         logger.info(f"Created zone for account {account_name}: {response['data']}")
 
         return response['data']
@@ -53,4 +53,38 @@ class CloudflareService:
 
         return response['data']
     
+    # GET accounts
+    def get_all_accounts(self):
+        '''Gets all accounts under all(?!) tenants'''
+        url = f"{self.base_url}/accounts"
+        response = make_api_request(url=url, method="GET", headers=self.headers )
+
+        if not response['success']:
+            raise APIError(f"Failed to get accounts: {response['message']}")             
+        logger.info(f"Retrieved all accounts: {response['data']}")
+
+        return response['data']
+    
+    # GET zones
+    def get_all_zones(self):
+        '''Gets all zones under all(?!) tenants'''
+        url = f"{self.base_url}/accounts"
+        response = make_api_request(url=url, method="GET", headers=self.headers )
+
+        if not response['success']:
+            raise APIError(f"Failed to get zones: {response['message']}")             
+        logger.info(f"Retrieved all zones: {response['data']}")
+
+        return response['data']
+ 
+    # GET dns record for zone
+    def get_dns_record(self, zone_id, record_id):
+        url = f"{self.base_url}/zones/{zone_id}/dns_records/{record_id}"
+        response = make_api_request(url=url, method="GET", headers=self.headers )
+
+        if not response['success']:
+            raise APIError(f"Failed to get dns record: {response['message']}")             
+        logger.info(f"Retrieved record {record_id} from {zone_id}: {response['data']}")
+
+        return response['data']
     

--- a/src/registrar/services/cloudflare_service.py
+++ b/src/registrar/services/cloudflare_service.py
@@ -66,9 +66,9 @@ class CloudflareService:
 
         return response['data']
     
-    def get_all_zones(self):
-        '''Gets all zones under all(?!) tenants'''
-        url = f"{self.base_url}/zones"
+    def get_account_zones(self, account_id):
+        '''Gets all zones under a particular account'''
+        url = f"{self.base_url}/zones?account.id={account_id}"
         response = make_api_request(url=url, method="GET", headers=self.headers )
 
         if not response['success']:

--- a/src/registrar/services/cloudflare_service.py
+++ b/src/registrar/services/cloudflare_service.py
@@ -40,8 +40,8 @@ class CloudflareService:
         if not response["success"]:
 
             raise APIError(
-                f"Failed to create zone for account {account_id}: errors: {errors} message:" +
-                  f"{response['message']} details: {response['details']}"
+                f"Failed to create zone for account {account_id}: errors: {errors} message: " +
+                f"{response['message']} details: {response['details']}"
             )
         logger.info(f"Created zone {zone_name} for account with id {account_id}: {response['data']}")
 
@@ -70,7 +70,7 @@ class CloudflareService:
 
         if not response["success"]:
             raise APIError(f"Failed to get accounts: message: {response['message']}, details: {response['details']}")
-        logger.info(f"Retrieved all accounts: {response['data']}")
+        logger.info(f"Retrieved all accounts: {response['data']['result']}")
 
         return response["data"]
 

--- a/src/registrar/services/cloudflare_service.py
+++ b/src/registrar/services/cloudflare_service.py
@@ -31,14 +31,14 @@ class CloudflareService:
         return response['data']
 
     # POST zone
-    def create_zone(self, account_name, account_id):     
+    def create_zone(self, zone_name, account_id):     
         url = f"{self.base_url}/zones"
-        data = {"name": account_name, "account": {"id": account_id }}
+        data = {"name": zone_name, "account": {"id": account_id }}
         response = make_api_request(url=url, method="POST", headers=self.headers, data=data )
 
         if not response['success']:
-            raise APIError(f"Failed to create zone for {account_name}: {response['message']}")
-        logger.info(f"Created zone for account {account_name}: {response['data']}")
+            raise APIError(f"Failed to create zone for account {account_id}: {response['message']}")
+        logger.info(f"Created zone {zone_name} for account with id {account_id}: {response['data']}")
 
         return response['data']
 
@@ -68,7 +68,7 @@ class CloudflareService:
     # GET zones
     def get_all_zones(self):
         '''Gets all zones under all(?!) tenants'''
-        url = f"{self.base_url}/accounts"
+        url = f"{self.base_url}/zones"
         response = make_api_request(url=url, method="GET", headers=self.headers )
 
         if not response['success']:

--- a/src/registrar/services/cloudflare_service.py
+++ b/src/registrar/services/cloudflare_service.py
@@ -43,5 +43,14 @@ class CloudflareService:
         return response['data']
 
     # POST dns_record
-   
+    def create_dns_record(self, zone_id, record_data):
+        url = f"{self.base_url}/zones/{zone_id}/dns_record"
+        response = make_api_request(url=url, method="POST", headers=self.headers, data=record_data )
+        if not response['success']:
+            raise APIError(f"Failed to create dns record for zone {zone_id}: {response['message']}")
+               
+        logger.info(f"Created dns_record for zone {zone_id}: {response['data']}")
+
+        return response['data']
+    
     

--- a/src/registrar/services/cloudflare_service.py
+++ b/src/registrar/services/cloudflare_service.py
@@ -61,8 +61,9 @@ class CloudflareService:
 
     def get_all_accounts(self):
         """Gets all accounts under specified tenant. Must include pagination paramenters"""
-        # TODO: adapt fn to check each page until found or doesn't exist
-        url = f"{self.base_url}/tenants/{self.tenant_id}/accounts?page=1&per_page=50"
+        # TODO: adapt fn to check accounts by tenant to check each page until found or doesn't exist
+        # url = f"{self.base_url}/tenants/{self.tenant_id}/accounts?page=1&per_page=50"
+        url = f"{self.base_url}/accounts"
         response = make_api_request(url=url, method="GET", headers=self.headers)
 
         if not response["success"]:

--- a/src/registrar/services/cloudflare_service.py
+++ b/src/registrar/services/cloudflare_service.py
@@ -40,7 +40,8 @@ class CloudflareService:
         if not response["success"]:
 
             raise APIError(
-                f"Failed to create zone for account {account_id}: errors: {errors} message: {response['message']} details: {response['details']}"
+                f"Failed to create zone for account {account_id}: errors: {errors} message:" +
+                  f"{response['message']} details: {response['details']}"
             )
         logger.info(f"Created zone {zone_name} for account with id {account_id}: {response['data']}")
 
@@ -53,7 +54,8 @@ class CloudflareService:
 
         if not response["success"]:
             raise APIError(
-                f"Failed to create dns record for zone {zone_id}: message: {response['message']} details: {response['details']}"
+                f"Failed to create dns record for zone {zone_id}: message: {response['message']} details:" +
+                f" {response['details']}"
             )
         logger.info(f"Created dns_record for zone {zone_id}: {response['data']}")
 

--- a/src/registrar/services/cloudflare_service.py
+++ b/src/registrar/services/cloudflare_service.py
@@ -12,9 +12,9 @@ class CloudflareService:
 
     def __init__(self):
         self.base_url = "https://api.cloudflare.com/client/v4"
-        self.service_email = settings.SECRET_REGISTRY_SERVICE_EMAIL
-        self.tenant_key = settings.SECRET_REGISTRY_TENANT_KEY
-        self.tenant_id = settings.SECRET_DOTGOV_TENANT_ID
+        self.service_email = settings.SECRET_DNS_SERVICE_EMAIL
+        self.tenant_key = settings.SECRET_DNS_TENANT_KEY
+        self.tenant_id = settings.SECRET_DNS_TENANT_ID
         self.headers = {
             "X-Auth-Email": self.service_email,
             "X-Auth-Key": self.tenant_key,

--- a/src/registrar/services/cloudflare_service.py
+++ b/src/registrar/services/cloudflare_service.py
@@ -19,7 +19,7 @@ class CloudflareService:
             "X-Auth-Key": self.tenant_key,
             "Content-Type": "application/json",
         }
-    # POST account
+
     def create_account(self, account_name):
         url = f"{self.base_url}/accounts"
         data = {"name": account_name, "type": "enterprise", "unit": {"id": self.tenant_id}}
@@ -31,7 +31,6 @@ class CloudflareService:
 
         return response['data']
 
-    # POST zone
     def create_zone(self, zone_name, account_id):   
         url = f"{self.base_url}/zones"
         data = {"name": zone_name, "account": {"id": account_id }}
@@ -44,7 +43,6 @@ class CloudflareService:
 
         return response['data']
 
-    # POST dns_record
     def create_dns_record(self, zone_id, record_data):
         url = f"{self.base_url}/zones/{zone_id}/dns_records"
         logger.debug(f'attempting to create record for zone {zone_id} with this data: {json.dumps(record_data)}')
@@ -56,7 +54,6 @@ class CloudflareService:
 
         return response['data']
     
-    # GET accounts
     def get_all_accounts(self):
         '''Gets all accounts under specified tenant. Must include pagination paramenters'''
         # TODO: adapt fn to check each page until found or doesn't exist
@@ -69,7 +66,6 @@ class CloudflareService:
 
         return response['data']
     
-    # GET zones
     def get_all_zones(self):
         '''Gets all zones under all(?!) tenants'''
         url = f"{self.base_url}/zones"
@@ -81,7 +77,6 @@ class CloudflareService:
 
         return response['data']
  
-    # GET dns record for zone
     def get_dns_record(self, zone_id, record_id):
         url = f"{self.base_url}/zones/{zone_id}/dns_records/{record_id}"
         response = make_api_request(url=url, method="GET", headers=self.headers )

--- a/src/registrar/services/cloudflare_service.py
+++ b/src/registrar/services/cloudflare_service.py
@@ -7,6 +7,7 @@ from registrar.utility.api_helpers import make_api_request
 
 logger = logging.getLogger(__name__)
 
+
 class CloudflareService:
 
     def __init__(self):
@@ -23,67 +24,70 @@ class CloudflareService:
     def create_account(self, account_name):
         url = f"{self.base_url}/accounts"
         data = {"name": account_name, "type": "enterprise", "unit": {"id": self.tenant_id}}
-        response = make_api_request(url=url, method="POST", headers=self.headers, data=data )
-        if not response['success']:
+        response = make_api_request(url=url, method="POST", headers=self.headers, data=data)
+        if not response["success"]:
             raise APIError(f"Failed to create account for {account_name}: {response['details']}")
-               
+
         logger.info(f"Created host account: {response['data']}")
 
-        return response['data']
+        return response["data"]
 
-    def create_zone(self, zone_name, account_id):   
+    def create_zone(self, zone_name, account_id):
         url = f"{self.base_url}/zones"
-        data = {"name": zone_name, "account": {"id": account_id }}
-        response = make_api_request(url=url, method="POST", headers=self.headers, data=data )
-        errors = response.get('errors')
-        if not response['success']:
-            
-            raise APIError(f"Failed to create zone for account {account_id}: errors: {errors} message: {response['message']} details: {response['details']}")
+        data = {"name": zone_name, "account": {"id": account_id}}
+        response = make_api_request(url=url, method="POST", headers=self.headers, data=data)
+        errors = response.get("errors")
+        if not response["success"]:
+
+            raise APIError(
+                f"Failed to create zone for account {account_id}: errors: {errors} message: {response['message']} details: {response['details']}"
+            )
         logger.info(f"Created zone {zone_name} for account with id {account_id}: {response['data']}")
 
-        return response['data']
+        return response["data"]
 
     def create_dns_record(self, zone_id, record_data):
         url = f"{self.base_url}/zones/{zone_id}/dns_records"
-        logger.debug(f'attempting to create record for zone {zone_id} with this data: {json.dumps(record_data)}')
-        response = make_api_request(url=url, method="POST", headers=self.headers, data=record_data )
+        logger.debug(f"attempting to create record for zone {zone_id} with this data: {json.dumps(record_data)}")
+        response = make_api_request(url=url, method="POST", headers=self.headers, data=record_data)
 
-        if not response['success']:
-            raise APIError(f"Failed to create dns record for zone {zone_id}: message: {response['message']} details: {response['details']}")             
+        if not response["success"]:
+            raise APIError(
+                f"Failed to create dns record for zone {zone_id}: message: {response['message']} details: {response['details']}"
+            )
         logger.info(f"Created dns_record for zone {zone_id}: {response['data']}")
 
-        return response['data']
-    
+        return response["data"]
+
     def get_all_accounts(self):
-        '''Gets all accounts under specified tenant. Must include pagination paramenters'''
+        """Gets all accounts under specified tenant. Must include pagination paramenters"""
         # TODO: adapt fn to check each page until found or doesn't exist
         url = f"{self.base_url}/tenants/{self.tenant_id}/accounts?page=1&per_page=50"
-        response = make_api_request(url=url, method="GET", headers=self.headers )
+        response = make_api_request(url=url, method="GET", headers=self.headers)
 
-        if not response['success']:
-            raise APIError(f"Failed to get accounts: message: {response['message']}, details: {response['details']}")             
+        if not response["success"]:
+            raise APIError(f"Failed to get accounts: message: {response['message']}, details: {response['details']}")
         logger.info(f"Retrieved all accounts: {response['data']}")
 
-        return response['data']
-    
-    def get_account_zones(self, account_id):
-        '''Gets all zones under a particular account'''
-        url = f"{self.base_url}/zones?account.id={account_id}"
-        response = make_api_request(url=url, method="GET", headers=self.headers )
+        return response["data"]
 
-        if not response['success']:
-            raise APIError(f"Failed to get zones: {response['message']}")             
+    def get_account_zones(self, account_id):
+        """Gets all zones under a particular account"""
+        url = f"{self.base_url}/zones?account.id={account_id}"
+        response = make_api_request(url=url, method="GET", headers=self.headers)
+
+        if not response["success"]:
+            raise APIError(f"Failed to get zones: {response['message']}")
         logger.info(f"Retrieved all zones: {response['data']}")
 
-        return response['data']
- 
+        return response["data"]
+
     def get_dns_record(self, zone_id, record_id):
         url = f"{self.base_url}/zones/{zone_id}/dns_records/{record_id}"
-        response = make_api_request(url=url, method="GET", headers=self.headers )
+        response = make_api_request(url=url, method="GET", headers=self.headers)
 
-        if not response['success']:
-            raise APIError(f"Failed to get dns record: message: {response['message']}, details: {response['details']}")             
+        if not response["success"]:
+            raise APIError(f"Failed to get dns record: message: {response['message']}, details: {response['details']}")
         logger.info(f"Retrieved record {record_id} from {zone_id}: {response['data']}")
 
-        return response['data']
-    
+        return response["data"]

--- a/src/registrar/services/cloudflare_service.py
+++ b/src/registrar/services/cloudflare_service.py
@@ -35,9 +35,9 @@ class CloudflareService:
         url = f"{self.base_url}/zones"
         data = {"name": account_name, "account": {"id": account_id }}
         response = make_api_request(url=url, method="POST", headers=self.headers, data=data )
+
         if not response['success']:
-            raise APIError(f"Failed to create zone for {account_name}: {response['message']}")
-               
+            raise APIError(f"Failed to create zone for {account_name}: {response['message']}; errors returned: {errors}")
         logger.info(f"Created zone for account {account_name}: {response['data']}")
 
         return response['data']
@@ -46,9 +46,9 @@ class CloudflareService:
     def create_dns_record(self, zone_id, record_data):
         url = f"{self.base_url}/zones/{zone_id}/dns_record"
         response = make_api_request(url=url, method="POST", headers=self.headers, data=record_data )
+
         if not response['success']:
-            raise APIError(f"Failed to create dns record for zone {zone_id}: {response['message']}")
-               
+            raise APIError(f"Failed to create dns record for zone {zone_id}: {response['message']}")             
         logger.info(f"Created dns_record for zone {zone_id}: {response['data']}")
 
         return response['data']

--- a/src/registrar/services/cloudflare_service.py
+++ b/src/registrar/services/cloudflare_service.py
@@ -19,7 +19,7 @@ class CloudflareService:
             "Content-Type": "application/json",
         }
     # POST account
-    def create_account(self, account_name)-> str:     
+    def create_account(self, account_name):     
         url = f"{self.base_url}/accounts"
         data = {"name": account_name, "type": "enterprise", "unit": {"id": self.tenant_id}}
         response = make_api_request(url=url, method="POST", headers=self.headers, data=data )
@@ -31,5 +31,17 @@ class CloudflareService:
         return response['data']
 
     # POST zone
+    def create_zone(self, account_name, account_id):     
+        url = f"{self.base_url}/zones"
+        data = {"name": account_name, "account": {"id": account_id }}
+        response = make_api_request(url=url, method="POST", headers=self.headers, data=data )
+        if not response['success']:
+            raise APIError(f"Failed to create zone for {account_name}: {response['message']}")
+               
+        logger.info(f"Created zone for account {account_name}: {response['data']}")
+
+        return response['data']
 
     # POST dns_record
+   
+    

--- a/src/registrar/services/cloudflare_service.py
+++ b/src/registrar/services/cloudflare_service.py
@@ -1,0 +1,41 @@
+import logging
+import requests
+import settings
+
+logger = logging.getLogger(__name__)
+
+class CloudflareService:
+
+    def __init__(self):
+        self.base_url = "https://api.cloudflare.com/client/v4"
+        self.service_email = settings.SECRET_REGISTRY_SERVICE_EMAIL
+        self.tenant_key = settings.SECRET_REGISTRY_TENANT_KEY
+        self.tenant_id = settings.DOTGOV_TEST_TENANT_ACCOUNT_ID
+        self.headers = {
+            "X-Auth-Email": self.service_email,
+            "X-Auth-Key": self.tenant_key,
+            "Content-Type": "application/json",
+        }
+    # POST account
+    def create_account(self, account_name):     
+        try:
+            response = requests.post(
+                    f"{self.base_url}/accounts",
+                    headers=self.headers,
+                    json={"name": account_name, "type": "enterprise", "unit": {"id": self.tenant}},
+                    timeout=5,
+                )
+            response_json = response.json()
+            response.raise_for_status()
+        except requests.exceptions.RequestException as e:
+            logger.debug("Failed to create host account", e)
+        
+        
+        account_id = response.json()["result"]["id"]        
+        logger.info(f"Created host account: {response_json}")
+
+        return account_id
+
+    # POST zone
+
+    # POST dns_record

--- a/src/registrar/services/cloudflare_service.py
+++ b/src/registrar/services/cloudflare_service.py
@@ -40,8 +40,8 @@ class CloudflareService:
         if not response["success"]:
 
             raise APIError(
-                f"Failed to create zone for account {account_id}: errors: {errors} message: " +
-                f"{response['message']} details: {response['details']}"
+                f"Failed to create zone for account {account_id}: errors: {errors} message: "
+                + f"{response['message']} details: {response['details']}"
             )
         logger.info(f"Created zone {zone_name} for account with id {account_id}: {response['data']}")
 
@@ -54,8 +54,8 @@ class CloudflareService:
 
         if not response["success"]:
             raise APIError(
-                f"Failed to create dns record for zone {zone_id}: message: {response['message']} details:" +
-                f" {response['details']}"
+                f"Failed to create dns record for zone {zone_id}: message: {response['message']} details:"
+                + f" {response['details']}"
             )
         logger.info(f"Created dns_record for zone {zone_id}: {response['data']}")
 

--- a/src/registrar/services/cloudflare_service.py
+++ b/src/registrar/services/cloudflare_service.py
@@ -36,9 +36,10 @@ class CloudflareService:
         url = f"{self.base_url}/zones"
         data = {"name": zone_name, "account": {"id": account_id }}
         response = make_api_request(url=url, method="POST", headers=self.headers, data=data )
-
+        errors = response.get('errors')
         if not response['success']:
-            raise APIError(f"Failed to create zone for account {account_id}: {response['details']}")
+            
+            raise APIError(f"Failed to create zone for account {account_id}: errors: {errors} message: {response['message']} details: {response['details']}")
         logger.info(f"Created zone {zone_name} for account with id {account_id}: {response['data']}")
 
         return response['data']
@@ -57,8 +58,9 @@ class CloudflareService:
     
     # GET accounts
     def get_all_accounts(self):
-        '''Gets all accounts under all(?!) tenants'''
-        url = f"{self.base_url}/accounts"
+        '''Gets all accounts under specified tenant. Must include pagination paramenters'''
+        # TODO: adapt fn to check each page until found or doesn't exist
+        url = f"{self.base_url}/tenants/{self.tenant_id}/accounts?page=1&per_page=50"
         response = make_api_request(url=url, method="GET", headers=self.headers )
 
         if not response['success']:

--- a/src/registrar/services/cloudflare_service.py
+++ b/src/registrar/services/cloudflare_service.py
@@ -1,3 +1,4 @@
+import json
 import logging
 from django.conf import settings
 
@@ -19,36 +20,37 @@ class CloudflareService:
             "Content-Type": "application/json",
         }
     # POST account
-    def create_account(self, account_name):     
+    def create_account(self, account_name):
         url = f"{self.base_url}/accounts"
         data = {"name": account_name, "type": "enterprise", "unit": {"id": self.tenant_id}}
         response = make_api_request(url=url, method="POST", headers=self.headers, data=data )
         if not response['success']:
-            raise APIError(f"Failed to create account for {account_name}: {response['message']}")
+            raise APIError(f"Failed to create account for {account_name}: {response['details']}")
                
         logger.info(f"Created host account: {response['data']}")
 
         return response['data']
 
     # POST zone
-    def create_zone(self, zone_name, account_id):     
+    def create_zone(self, zone_name, account_id):   
         url = f"{self.base_url}/zones"
         data = {"name": zone_name, "account": {"id": account_id }}
         response = make_api_request(url=url, method="POST", headers=self.headers, data=data )
 
         if not response['success']:
-            raise APIError(f"Failed to create zone for account {account_id}: {response['message']}")
+            raise APIError(f"Failed to create zone for account {account_id}: {response['details']}")
         logger.info(f"Created zone {zone_name} for account with id {account_id}: {response['data']}")
 
         return response['data']
 
     # POST dns_record
     def create_dns_record(self, zone_id, record_data):
-        url = f"{self.base_url}/zones/{zone_id}/dns_record"
+        url = f"{self.base_url}/zones/{zone_id}/dns_records"
+        logger.debug(f'attempting to create record for zone {zone_id} with this data: {json.dumps(record_data)}')
         response = make_api_request(url=url, method="POST", headers=self.headers, data=record_data )
 
         if not response['success']:
-            raise APIError(f"Failed to create dns record for zone {zone_id}: {response['message']}")             
+            raise APIError(f"Failed to create dns record for zone {zone_id}: message: {response['message']} details: {response['details']}")             
         logger.info(f"Created dns_record for zone {zone_id}: {response['data']}")
 
         return response['data']
@@ -60,7 +62,7 @@ class CloudflareService:
         response = make_api_request(url=url, method="GET", headers=self.headers )
 
         if not response['success']:
-            raise APIError(f"Failed to get accounts: {response['message']}")             
+            raise APIError(f"Failed to get accounts: message: {response['message']}, details: {response['details']}")             
         logger.info(f"Retrieved all accounts: {response['data']}")
 
         return response['data']
@@ -83,7 +85,7 @@ class CloudflareService:
         response = make_api_request(url=url, method="GET", headers=self.headers )
 
         if not response['success']:
-            raise APIError(f"Failed to get dns record: {response['message']}")             
+            raise APIError(f"Failed to get dns record: message: {response['message']}, details: {response['details']}")             
         logger.info(f"Retrieved record {record_id} from {zone_id}: {response['data']}")
 
         return response['data']

--- a/src/registrar/services/cloudflare_service.py
+++ b/src/registrar/services/cloudflare_service.py
@@ -1,6 +1,8 @@
 import logging
-import requests
-import settings
+from django.conf import settings
+
+from registrar.utility.errors import APIError
+from registrar.utility.api_helpers import make_api_request
 
 logger = logging.getLogger(__name__)
 
@@ -10,31 +12,23 @@ class CloudflareService:
         self.base_url = "https://api.cloudflare.com/client/v4"
         self.service_email = settings.SECRET_REGISTRY_SERVICE_EMAIL
         self.tenant_key = settings.SECRET_REGISTRY_TENANT_KEY
-        self.tenant_id = settings.DOTGOV_TEST_TENANT_ACCOUNT_ID
+        self.tenant_id = settings.SECRET_DOTGOV_TENANT_ID
         self.headers = {
             "X-Auth-Email": self.service_email,
             "X-Auth-Key": self.tenant_key,
             "Content-Type": "application/json",
         }
     # POST account
-    def create_account(self, account_name):     
-        try:
-            response = requests.post(
-                    f"{self.base_url}/accounts",
-                    headers=self.headers,
-                    json={"name": account_name, "type": "enterprise", "unit": {"id": self.tenant}},
-                    timeout=5,
-                )
-            response_json = response.json()
-            response.raise_for_status()
-        except requests.exceptions.RequestException as e:
-            logger.debug("Failed to create host account", e)
-        
-        
-        account_id = response.json()["result"]["id"]        
-        logger.info(f"Created host account: {response_json}")
+    def create_account(self, account_name)-> str:     
+        url = f"{self.base_url}/accounts"
+        data = {"name": account_name, "type": "enterprise", "unit": {"id": self.tenant_id}}
+        response = make_api_request(url=url, method="POST", headers=self.headers, data=data )
+        if not response['success']:
+            raise APIError(f"Failed to create account for {account_name}: {response['message']}")
+               
+        logger.info(f"Created host account: {response['data']}")
 
-        return account_id
+        return response['data']
 
     # POST zone
 

--- a/src/registrar/services/dns_host_service.py
+++ b/src/registrar/services/dns_host_service.py
@@ -14,7 +14,7 @@ class DnsHostService:
         """Find an item by name in a list of dictionaries."""
         return next((item.get("id") for item in items if item.get("name") == name), None)
 
-    def dns_setup(self, account_name):
+    def dns_setup(self, account_name, zone_name):
         """Creates an account and zone in the dns host vendor tenant"""
         try:
             account_data = self.dns_vendor_service.create_account(account_name)
@@ -25,7 +25,7 @@ class DnsHostService:
             raise
 
         try:
-            zone_data = self.dns_vendor_service.create_zone(account_name, account_id)
+            zone_data = self.dns_vendor_service.create_zone(zone_name, account_id)
             logger.info("Successfully created zone")
             zone_id = zone_data["result"]["id"]
         except APIError as e:

--- a/src/registrar/services/dns_host_service.py
+++ b/src/registrar/services/dns_host_service.py
@@ -5,7 +5,7 @@ from registrar.utility.errors import APIError
 
 logger = logging.getLogger(__name__)
 
-class DnsHostingService:
+class DnsHostService:
 
     def __init__(self):
         self.dns_vendor_service = CloudflareService()
@@ -21,7 +21,7 @@ class DnsHostingService:
             logger.info("Successfully created account")
             account_id = account_data["result"]["id"]
         except APIError as e:
-            logger.error(f"Error creating account in DnsHostService: {str(e)}")
+            logger.error(f"DNS setup failed to create account: {str(e)}")
             raise
 
         try:
@@ -29,7 +29,7 @@ class DnsHostingService:
             logger.info("Successfully created zone")
             zone_id = zone_data["result"]["id"]
         except APIError as e:
-            logger.error(f"Error creating account in DnsHostService: {str(e)}")
+            logger.error(f"DNS setup failed to create zone: {str(e)}")
             raise
 
         return (account_id, zone_id)
@@ -40,8 +40,9 @@ class DnsHostingService:
             record = self.dns_vendor_service.create_dns_record(zone_id, record_data)
             logger.info(f"Created DNS record of type {record['result'].get('type')}")
         except APIError as e:
-            logger.error(f"Error creating dns record in DnsHostService: {str(e)}")
+            logger.error(f"Error creating DNS record: {str(e)}")
             raise
+        return record
 
     def find_existing_account(self, account_name):
         try:

--- a/src/registrar/services/dns_host_service.py
+++ b/src/registrar/services/dns_host_service.py
@@ -1,9 +1,10 @@
 import logging
 
 from registrar.services.cloudflare_service import CloudflareService
-from registrar.utility.errors import APIError   
+from registrar.utility.errors import APIError
 
 logger = logging.getLogger(__name__)
+
 
 class DnsHostService:
 
@@ -16,7 +17,7 @@ class DnsHostService:
 
     def dns_setup(self, account_name, zone_name):
         """Creates an account and zone in the dns host vendor tenant"""
-        
+
         account_id = self._find_existing_account(account_name)
         has_account = bool(account_id)
 
@@ -67,22 +68,21 @@ class DnsHostService:
     def _find_existing_account(self, account_name):
         try:
             all_accounts_data = self.dns_vendor_service.get_all_accounts()
-            accounts = all_accounts_data['result']
+            accounts = all_accounts_data["result"]
             account_id = self._find_by_name(accounts, account_name)
         except APIError as e:
             logger.error(f"Error fetching accounts: {str(e)}")
             raise
-        
+
         return account_id
-    
+
     def _find_existing_zone(self, zone_name, account_id):
         try:
             all_zones_data = self.dns_vendor_service.get_account_zones(account_id)
-            zones = all_zones_data['result']
+            zones = all_zones_data["result"]
             zone_id = self._find_by_name(zones, zone_name)
         except APIError as e:
             logger.error(f"Error fetching zones: {str(e)}")
             raise
-        
-        return zone_id
 
+        return zone_id

--- a/src/registrar/services/dns_host_service.py
+++ b/src/registrar/services/dns_host_service.py
@@ -32,7 +32,7 @@ class DnsHostService:
             logger.error(f"DNS setup failed to create zone: {str(e)}")
             raise
 
-        return (account_id, zone_id)
+        return account_id, zone_id
 
     def create_record(self, zone_id, record_data):
         """Calls create method of vendor serivce to create a DNS record"""

--- a/src/registrar/services/dns_host_service.py
+++ b/src/registrar/services/dns_host_service.py
@@ -20,7 +20,9 @@ class DnsHostService:
         account_id = self._find_existing_account(account_name)
         has_account = bool(account_id)
 
-        zone_id = self._find_existing_zone(zone_name)
+        zone_id = None
+        if account_id:
+            zone_id = self._find_existing_zone(zone_name, account_id)
         has_zone = bool(zone_id)
 
         if not has_account:
@@ -73,9 +75,9 @@ class DnsHostService:
         
         return account_id
     
-    def _find_existing_zone(self, zone_name):
+    def _find_existing_zone(self, zone_name, account_id):
         try:
-            all_zones_data = self.dns_vendor_service.get_all_zones()
+            all_zones_data = self.dns_vendor_service.get_account_zones(account_id)
             zones = all_zones_data['result']
             zone_id = self._find_by_name(zones, zone_name)
         except APIError as e:

--- a/src/registrar/services/dns_hosting_service.py
+++ b/src/registrar/services/dns_hosting_service.py
@@ -1,0 +1,40 @@
+import logging
+
+from registrar.services.cloudflare_service import CloudflareService
+from registrar.utility.errors import APIError
+
+logger = logging.getLogger(__name__)
+
+class DnsHostingService:
+
+    def __init__(self):
+        self.dns_vendor_service = CloudflareService()
+
+    def dns_setup(self, account_name):
+        """Creates an account and zone in the dns hosting vendor tenant"""
+        try:
+            account_data = self.dns_vendor_service.create_account(account_name)
+            logger.info("Successfully created account")
+            account_id = account_data["result"]["id"]
+        except APIError as e:
+            logger.error(f"Error creating account in hosting service: {str(e)}")
+            raise
+
+        try:
+            zone_data = self.dns_vendor_service.create_zone(account_name, account_id)
+            logger.info("Successfully created zone")
+            zone_id = zone_data["result"]["id"]
+        except APIError as e:
+            logger.error(f"Error creating account in hosting service: {str(e)}")
+            raise
+
+        return (account_id, zone_id)
+
+    def create_record(self, zone_id, record_data):
+        """Creates a DNS record"""
+        try:
+            record = self.dns_vendor_service.create_dns_record(zone_id, record_data)
+            logger.info(f"Created DNS record of type {record["result"].get("type")}")
+        except APIError as e:
+            logger.error(f"Error creating dns record in hosting service: {str(e)}")
+

--- a/src/registrar/services/dns_hosting_service.py
+++ b/src/registrar/services/dns_hosting_service.py
@@ -15,13 +15,13 @@ class DnsHostingService:
         return next((item.get("id") for item in items if item.get("name") == name), None)
 
     def dns_setup(self, account_name):
-        """Creates an account and zone in the dns hosting vendor tenant"""
+        """Creates an account and zone in the dns host vendor tenant"""
         try:
             account_data = self.dns_vendor_service.create_account(account_name)
             logger.info("Successfully created account")
             account_id = account_data["result"]["id"]
         except APIError as e:
-            logger.error(f"Error creating account in hosting service: {str(e)}")
+            logger.error(f"Error creating account in DnsHostService: {str(e)}")
             raise
 
         try:
@@ -29,7 +29,7 @@ class DnsHostingService:
             logger.info("Successfully created zone")
             zone_id = zone_data["result"]["id"]
         except APIError as e:
-            logger.error(f"Error creating account in hosting service: {str(e)}")
+            logger.error(f"Error creating account in DnsHostService: {str(e)}")
             raise
 
         return (account_id, zone_id)
@@ -40,7 +40,8 @@ class DnsHostingService:
             record = self.dns_vendor_service.create_dns_record(zone_id, record_data)
             logger.info(f"Created DNS record of type {record['result'].get('type')}")
         except APIError as e:
-            logger.error(f"Error creating dns record in hosting service: {str(e)}")
+            logger.error(f"Error creating dns record in DnsHostService: {str(e)}")
+            raise
 
     def find_existing_account(self, account_name):
         try:

--- a/src/registrar/services/dns_hosting_service.py
+++ b/src/registrar/services/dns_hosting_service.py
@@ -1,7 +1,7 @@
 import logging
 
 from registrar.services.cloudflare_service import CloudflareService
-from registrar.utility.errors import APIError
+from registrar.utility.errors import APIError   
 
 logger = logging.getLogger(__name__)
 
@@ -9,6 +9,10 @@ class DnsHostingService:
 
     def __init__(self):
         self.dns_vendor_service = CloudflareService()
+
+    def _find_by_name(self, items, name):
+        """Find an item by name in a list of dictionaries."""
+        return next((item.get("id") for item in items if item.get("name") == name), None)
 
     def dns_setup(self, account_name):
         """Creates an account and zone in the dns hosting vendor tenant"""
@@ -31,10 +35,32 @@ class DnsHostingService:
         return (account_id, zone_id)
 
     def create_record(self, zone_id, record_data):
-        """Creates a DNS record"""
+        """Calls create method of vendor serivce to create a DNS record"""
         try:
             record = self.dns_vendor_service.create_dns_record(zone_id, record_data)
             logger.info(f"Created DNS record of type {record["result"].get("type")}")
         except APIError as e:
             logger.error(f"Error creating dns record in hosting service: {str(e)}")
+
+    def find_existing_account(self, account_name):
+        try:
+            all_accounts_data = self.dns_vendor_service.get_all_accounts()
+            accounts = all_accounts_data['result']
+            account_id = self._find_by_name(accounts, account_name)
+        except APIError as e:
+            logger.error(f"Error fetching accounts: {str(e)}")
+            raise
+        
+        return account_id
+    
+    def find_existing_zone(self,zone_name):
+        try:
+            all_zones_data = self.dns_vendor_service.get_all_zones()
+            zones = all_zones_data['result']
+            zone_id = self._find_by_name(zones, zone_name)
+        except APIError as e:
+            logger.error(f"Error fetching zones: {str(e)}")
+            raise
+        
+        return zone_id
 

--- a/src/registrar/services/dns_hosting_service.py
+++ b/src/registrar/services/dns_hosting_service.py
@@ -38,7 +38,7 @@ class DnsHostingService:
         """Calls create method of vendor serivce to create a DNS record"""
         try:
             record = self.dns_vendor_service.create_dns_record(zone_id, record_data)
-            logger.info(f"Created DNS record of type {record["result"].get("type")}")
+            logger.info(f"Created DNS record of type {record['result'].get('type')}")
         except APIError as e:
             logger.error(f"Error creating dns record in hosting service: {str(e)}")
 
@@ -53,7 +53,7 @@ class DnsHostingService:
         
         return account_id
     
-    def find_existing_zone(self,zone_name):
+    def find_existing_zone(self, zone_name):
         try:
             all_zones_data = self.dns_vendor_service.get_all_zones()
             zones = all_zones_data['result']

--- a/src/registrar/templates/prototype_domain_dns.html
+++ b/src/registrar/templates/prototype_domain_dns.html
@@ -31,4 +31,7 @@
             Add record
         </button>
     </form>
+    {% if dns_record %}
+    <p>DNS RECORD: {{ dns_record }} </p>
+    {% endif %}
 {% endblock %}  {# domain_content #}

--- a/src/registrar/tests/services/test_cloudflare_service.py
+++ b/src/registrar/tests/services/test_cloudflare_service.py
@@ -88,7 +88,6 @@ class TestCloudflareService(SimpleTestCase):
             }
         }
         result = self.service.create_dns_record(zone_id, record_data)
-        print(result)
         self.assertEqual(result['result']['name'], "democracy.gov")
         self.assertEqual(result['result']['content'], "198.51.100.4")
         self.assertEqual(result['result'], {

--- a/src/registrar/tests/services/test_cloudflare_service.py
+++ b/src/registrar/tests/services/test_cloudflare_service.py
@@ -64,8 +64,8 @@ class TestCloudflareService(SimpleTestCase):
             self.service.create_zone(account_name, account_id)
 
         self.assertIn(
-            f"Failed to create zone for account {account_id}: errors: ['you failed'] message: invalid details:" 
-            "+ A bit more info!",
+            f"Failed to create zone for account {account_id}: errors: ['you failed'] message: invalid details:" +
+            " A bit more info!",
             str(context.exception),
         )
 

--- a/src/registrar/tests/services/test_cloudflare_service.py
+++ b/src/registrar/tests/services/test_cloudflare_service.py
@@ -4,66 +4,71 @@ from django.test import SimpleTestCase
 from registrar.services.cloudflare_service import CloudflareService
 from registrar.utility.errors import APIError
 
+
 class TestCloudflareService(SimpleTestCase):
     """Test cases for the CloudflareService class"""
+
     def setUp(self):
         self.service = CloudflareService()
 
-    @patch('registrar.services.cloudflare_service.make_api_request')
+    @patch("registrar.services.cloudflare_service.make_api_request")
     def test_create_account_success(self, mock_make_request):
         """Test successful create_account call"""
         account_name = "test.gov test account"
-        mock_make_request.return_value = {
-            'success': True,
-            'data': {"result": {"name": account_name, "id": "12345"}}
-        }
+        mock_make_request.return_value = {"success": True, "data": {"result": {"name": account_name, "id": "12345"}}}
         result = self.service.create_account(account_name)
-        self.assertEqual(result['result']['name'], account_name)   
-        
-    @patch('registrar.services.cloudflare_service.make_api_request')
+        self.assertEqual(result["result"]["name"], account_name)
+
+    @patch("registrar.services.cloudflare_service.make_api_request")
     def test_create_account_failure(self, mock_make_request):
         """Test create_account with API failure"""
-        account_name = ' '
-        mock_make_request.return_value = {
-            'success': False,
-            'details': 'Cannot be empty'
-        }
-        
+        account_name = " "
+        mock_make_request.return_value = {"success": False, "details": "Cannot be empty"}
+
         with self.assertRaises(APIError) as context:
             self.service.create_account(account_name)
-        
+
         self.assertIn(f"Failed to create account for {account_name}: Cannot be empty", str(context.exception))
 
-    @patch('registrar.services.cloudflare_service.make_api_request')
+    @patch("registrar.services.cloudflare_service.make_api_request")
     def test_create_zone_success(self, mock_make_request):
         """Test successful create_zone call"""
         account_name = "test.gov test account"
         account_id = "12345"
         mock_make_request.return_value = {
-            'success': True,
-            'data': {"result": {"name": account_name, "id": "12345", "nameservers": ["hostess1.mostess.gov", "hostess2.mostess.gov"]}}
+            "success": True,
+            "data": {
+                "result": {
+                    "name": account_name,
+                    "id": "12345",
+                    "nameservers": ["hostess1.mostess.gov", "hostess2.mostess.gov"],
+                }
+            },
         }
         result = self.service.create_zone(account_name, account_id)
-        self.assertEqual(result['result']['name'], account_name)   
-        
-    @patch('registrar.services.cloudflare_service.make_api_request')
+        self.assertEqual(result["result"]["name"], account_name)
+
+    @patch("registrar.services.cloudflare_service.make_api_request")
     def test_create_zone_failure(self, mock_make_request):
         """Test create_zone with API failure"""
         account_name = "test.gov test account"
         account_id = "12345"
         mock_make_request.return_value = {
-            'success': False,
-            'message': 'invalid',
-            'errors': ['you failed'],
-            'details': 'A bit more info!'
+            "success": False,
+            "message": "invalid",
+            "errors": ["you failed"],
+            "details": "A bit more info!",
         }
-        
+
         with self.assertRaises(APIError) as context:
             self.service.create_zone(account_name, account_id)
-        
-        self.assertIn(f"Failed to create zone for account {account_id}: errors: ['you failed'] message: invalid details: A bit more info!", str(context.exception))
 
-    @patch('registrar.services.cloudflare_service.make_api_request')
+        self.assertIn(
+            f"Failed to create zone for account {account_id}: errors: ['you failed'] message: invalid details: A bit more info!",
+            str(context.exception),
+        )
+
+    @patch("registrar.services.cloudflare_service.make_api_request")
     def test_create_dns_record_success(self, mock_make_request):
         """Test successful create_dns_record call"""
         zone_id = "54321"
@@ -73,34 +78,37 @@ class TestCloudflareService(SimpleTestCase):
             "proxied": False,
             "type": "A",
             "comment": "Test domain name",
-            "ttl": 3600
+            "ttl": 3600,
         }
         mock_make_request.return_value = {
-            'success': True,
-            'data': {
+            "success": True,
+            "data": {
                 "result": {
                     "content": "198.51.100.4",
                     "name": "democracy.gov",
                     "proxied": False,
                     "type": "A",
                     "comment": "Test domain name",
-                    "ttl": 3600
+                    "ttl": 3600,
                 }
-            }
+            },
         }
         result = self.service.create_dns_record(zone_id, record_data)
-        self.assertEqual(result['result']['name'], "democracy.gov")
-        self.assertEqual(result['result']['content'], "198.51.100.4")
-        self.assertEqual(result['result'], {
-                    "content": "198.51.100.4",
-                    "name": "democracy.gov",
-                    "proxied": False,
-                    "type": "A",
-                    "comment": "Test domain name",
-                    "ttl": 3600
-                })
-        
-    @patch('registrar.services.cloudflare_service.make_api_request')
+        self.assertEqual(result["result"]["name"], "democracy.gov")
+        self.assertEqual(result["result"]["content"], "198.51.100.4")
+        self.assertEqual(
+            result["result"],
+            {
+                "content": "198.51.100.4",
+                "name": "democracy.gov",
+                "proxied": False,
+                "type": "A",
+                "comment": "Test domain name",
+                "ttl": 3600,
+            },
+        )
+
+    @patch("registrar.services.cloudflare_service.make_api_request")
     def test_create_dns_record_failure(self, mock_make_request):
         """Test create_zone with API failure"""
         zone_id = "54321"
@@ -109,120 +117,129 @@ class TestCloudflareService(SimpleTestCase):
             "proxied": False,
             "type": "A",
             "comment": "Test domain name",
-            "ttl": 3600
+            "ttl": 3600,
         }
         mock_make_request.return_value = {
-            'success': False,
-            'message': 'missing content field',
-            'details': 'more detail'
+            "success": False,
+            "message": "missing content field",
+            "details": "more detail",
         }
-        
+
         with self.assertRaises(APIError) as context:
             self.service.create_dns_record(zone_id, record_data_missing_content)
-        
-        self.assertIn(f"Failed to create dns record for zone {zone_id}: message: missing content field details: more detail", str(context.exception))
 
-    @patch('registrar.services.cloudflare_service.make_api_request')
+        self.assertIn(
+            f"Failed to create dns record for zone {zone_id}: message: missing content field details: more detail",
+            str(context.exception),
+        )
+
+    @patch("registrar.services.cloudflare_service.make_api_request")
     def test_get_all_accounts_success(self, mock_make_request):
         """Test successful get_all_accounts call"""
         mock_make_request.return_value = {
-            'success': True,
-            'data': {'result': [
-                {'id': 1, 'name': 'test acct 1'},
-                {'id': 2, 'name': 'test acct 2'},
+            "success": True,
+            "data": {
+                "result": [
+                    {"id": 1, "name": "test acct 1"},
+                    {"id": 2, "name": "test acct 2"},
                 ]
-            }
+            },
         }
-        
+
         result = self.service.get_all_accounts()
-        
-        self.assertEqual(result, {'result': [
-                {'id': 1, 'name': 'test acct 1'},
-                {'id': 2, 'name': 'test acct 2'},
+
+        self.assertEqual(
+            result,
+            {
+                "result": [
+                    {"id": 1, "name": "test acct 1"},
+                    {"id": 2, "name": "test acct 2"},
                 ]
-            })
-    
-    @patch('registrar.services.cloudflare_service.make_api_request')
+            },
+        )
+
+    @patch("registrar.services.cloudflare_service.make_api_request")
     def test_get_all_accounts_failure(self, mock_make_request):
         """Test get_all_accounts with API failure"""
         mock_make_request.return_value = {
-            'success': False,
-            'message': 'Something is wrong',
-            'details': 'More info here'
+            "success": False,
+            "message": "Something is wrong",
+            "details": "More info here",
         }
-        
+
         with self.assertRaises(APIError) as context:
             self.service.get_all_accounts()
-        
-        self.assertIn('Failed to get accounts', str(context.exception))
-        
-    @patch('registrar.services.cloudflare_service.make_api_request')
+
+        self.assertIn("Failed to get accounts", str(context.exception))
+
+    @patch("registrar.services.cloudflare_service.make_api_request")
     def test_get_account_zones_success(self, mock_make_request):
         """Test successful get_account_zones call"""
-        account_id = '55555'
-        
+        account_id = "55555"
+
         mock_make_request.return_value = {
-            'success': True,
-            'data': {'result': [
-                {'id': 1, 'name': 'test zone 1', 'status': 'active'},
-                {'id': 2, 'name': 'test zone 2', 'status': 'active'},
+            "success": True,
+            "data": {
+                "result": [
+                    {"id": 1, "name": "test zone 1", "status": "active"},
+                    {"id": 2, "name": "test zone 2", "status": "active"},
                 ]
-            }
+            },
         }
-        
+
         result = self.service.get_account_zones(account_id)
-        
-        self.assertEqual(result, {'result': [
-                {'id': 1, 'name': 'test zone 1', 'status': 'active'},
-                {'id': 2, 'name': 'test zone 2', 'status': 'active'},
+
+        self.assertEqual(
+            result,
+            {
+                "result": [
+                    {"id": 1, "name": "test zone 1", "status": "active"},
+                    {"id": 2, "name": "test zone 2", "status": "active"},
                 ]
-            })
-    
-    @patch('registrar.services.cloudflare_service.make_api_request')
+            },
+        )
+
+    @patch("registrar.services.cloudflare_service.make_api_request")
     def test_get_account_zones_failure(self, mock_make_request):
         """Test get_account_zones with API failure"""
-        
-        account_id = '44444'
-        mock_make_request.return_value = {
-            'success': False,
-            'message': 'Something is wrong'
-        }
-        
+
+        account_id = "44444"
+        mock_make_request.return_value = {"success": False, "message": "Something is wrong"}
+
         with self.assertRaises(APIError) as context:
             self.service.get_account_zones(account_id)
-        
-        self.assertIn('Failed to get zones', str(context.exception))
-        
-    @patch('registrar.services.cloudflare_service.make_api_request')
+
+        self.assertIn("Failed to get zones", str(context.exception))
+
+    @patch("registrar.services.cloudflare_service.make_api_request")
     def test_get_dns_record_success(self, mock_make_request):
-        '''Test get_dns_record with API success'''
-        zone_id = '1234'
-        record_id = '45454'
+        """Test get_dns_record with API success"""
+        zone_id = "1234"
+        record_id = "45454"
         mock_make_request.return_value = {
-            'success': True,
-            'data': {'result':
-                {'id': 2, 'name': 'A', 'content': '198.22.333.4', 'ttl': 3600}
-            }
+            "success": True,
+            "data": {"result": {"id": 2, "name": "A", "content": "198.22.333.4", "ttl": 3600}},
         }
 
         result = self.service.get_dns_record(zone_id, record_id)
 
-        self.assertEqual( result, {'result':
-            {'id': 2, 'name': 'A', 'content': '198.22.333.4', 'ttl': 3600}
-        })
-        
-    @patch('registrar.services.cloudflare_service.make_api_request')
+        self.assertEqual(result, {"result": {"id": 2, "name": "A", "content": "198.22.333.4", "ttl": 3600}})
+
+    @patch("registrar.services.cloudflare_service.make_api_request")
     def test_get_dns_record_failure(self, mock_make_request):
-        '''Test get_dns_record with API failure'''
-        zone_id = ''
-        record_id = '45454'
+        """Test get_dns_record with API failure"""
+        zone_id = ""
+        record_id = "45454"
         mock_make_request.return_value = {
-            'success': False,
-            'message': 'whomp, whomp',
-            'details': 'That means disappointment'
+            "success": False,
+            "message": "whomp, whomp",
+            "details": "That means disappointment",
         }
 
         with self.assertRaises(APIError) as context:
             self.service.get_dns_record(zone_id, record_id)
 
-        self.assertIn(f"Failed to get dns record: message: whomp, whomp, details: That means disappointment", str(context.exception))
+        self.assertIn(
+            f"Failed to get dns record: message: whomp, whomp, details: That means disappointment",
+            str(context.exception),
+        )

--- a/src/registrar/tests/services/test_cloudflare_service.py
+++ b/src/registrar/tests/services/test_cloudflare_service.py
@@ -44,7 +44,6 @@ class TestCloudflareService(SimpleTestCase):
             'data': {"result": {"name": account_name, "id": "12345", "nameservers": ["hostess1.mostess.gov", "hostess2.mostess.gov"]}}
         }
         result = self.service.create_zone(account_name, account_id)
-        print(result)
         self.assertEqual(result['result']['name'], account_name)   
         
     @patch('registrar.services.cloudflare_service.make_api_request')

--- a/src/registrar/tests/services/test_cloudflare_service.py
+++ b/src/registrar/tests/services/test_cloudflare_service.py
@@ -3,6 +3,7 @@ from django.test import SimpleTestCase
 
 from registrar.services.cloudflare_service import CloudflareService
 from registrar.utility.errors import APIError
+
 class TestCloudflareService(SimpleTestCase):
     """Test cases for the CloudflareService class"""
     def setUp(self):
@@ -76,17 +77,28 @@ class TestCloudflareService(SimpleTestCase):
         mock_make_request.return_value = {
             'success': True,
             'data': {
-                "content": "198.51.100.4",
-                "name": "democracy.gov",
-                "proxied": False,
-                "type": "A",
-                "comment": "Test domain name",
-                "ttl": 3600
+                "result": {
+                    "content": "198.51.100.4",
+                    "name": "democracy.gov",
+                    "proxied": False,
+                    "type": "A",
+                    "comment": "Test domain name",
+                    "ttl": 3600
+                }
             }
         }
         result = self.service.create_dns_record(zone_id, record_data)
         print(result)
-        self.assertEqual(result['result']['name'], )   
+        self.assertEqual(result['result']['name'], "democracy.gov")
+        self.assertEqual(result['result']['content'], "198.51.100.4")
+        self.assertEqual(result['result'], {
+                    "content": "198.51.100.4",
+                    "name": "democracy.gov",
+                    "proxied": False,
+                    "type": "A",
+                    "comment": "Test domain name",
+                    "ttl": 3600
+                })
         
     @patch('registrar.services.cloudflare_service.make_api_request')
     def test_create_dns_record_failure(self, mock_make_request):
@@ -107,5 +119,5 @@ class TestCloudflareService(SimpleTestCase):
         with self.assertRaises(APIError) as context:
             self.service.create_dns_record(zone_id, record_data_missing_content)
         
-        self.assertIn(f"Failed to create record for zone {zone_id}: 'missing content field'", str(context.exception))
+        self.assertIn(f"Failed to create dns record for zone {zone_id}: missing content field", str(context.exception))
         

--- a/src/registrar/tests/services/test_cloudflare_service.py
+++ b/src/registrar/tests/services/test_cloudflare_service.py
@@ -64,8 +64,8 @@ class TestCloudflareService(SimpleTestCase):
             self.service.create_zone(account_name, account_id)
 
         self.assertIn(
-            f"Failed to create zone for account {account_id}: errors: ['you failed'] message: invalid details:" +
-            " A bit more info!",
+            f"Failed to create zone for account {account_id}: errors: ['you failed'] message: invalid details:"
+            + " A bit more info!",
             str(context.exception),
         )
 

--- a/src/registrar/tests/services/test_cloudflare_service.py
+++ b/src/registrar/tests/services/test_cloudflare_service.py
@@ -158,7 +158,7 @@ class TestCloudflareService(SimpleTestCase):
         
     @patch('registrar.services.cloudflare_service.make_api_request')
     def test_get_account_zones_success(self, mock_make_request):
-        """Test successful get_all_zones call"""
+        """Test successful get_account_zones call"""
         account_id = '55555'
         
         mock_make_request.return_value = {
@@ -180,7 +180,7 @@ class TestCloudflareService(SimpleTestCase):
     
     @patch('registrar.services.cloudflare_service.make_api_request')
     def test_get_account_zones_failure(self, mock_make_request):
-        """Test get_all_zones with API failure"""
+        """Test get_account_zones with API failure"""
         
         account_id = '44444'
         mock_make_request.return_value = {

--- a/src/registrar/tests/services/test_cloudflare_service.py
+++ b/src/registrar/tests/services/test_cloudflare_service.py
@@ -64,7 +64,8 @@ class TestCloudflareService(SimpleTestCase):
             self.service.create_zone(account_name, account_id)
 
         self.assertIn(
-            f"Failed to create zone for account {account_id}: errors: ['you failed'] message: invalid details: A bit more info!",
+            f"Failed to create zone for account {account_id}: errors: ['you failed'] message: invalid details:" 
+            "+ A bit more info!",
             str(context.exception),
         )
 
@@ -240,6 +241,6 @@ class TestCloudflareService(SimpleTestCase):
             self.service.get_dns_record(zone_id, record_id)
 
         self.assertIn(
-            f"Failed to get dns record: message: whomp, whomp, details: That means disappointment",
+            "Failed to get dns record: message: whomp, whomp, details: That means disappointment",
             str(context.exception),
         )

--- a/src/registrar/tests/services/test_dns_host_service.py
+++ b/src/registrar/tests/services/test_dns_host_service.py
@@ -24,8 +24,9 @@ class TestDnsHostService(SimpleTestCase):
             "result": {"id": zone_id}
         }
         
-        result = self.service.dns_setup(account_name)
-        self.assertEqual(result, (account_id, zone_id))
+        returned_account_id, returned_zone_id = self.service.dns_setup(account_name)
+        self.assertEqual(returned_account_id, account_id)
+        self.assertEqual(returned_zone_id, zone_id)
 
     @patch('registrar.services.dns_host_service.CloudflareService.create_zone')
     @patch('registrar.services.dns_host_service.CloudflareService.create_account')
@@ -34,9 +35,11 @@ class TestDnsHostService(SimpleTestCase):
         mock_create_account.side_effect = APIError(
             'DNS setup failed to create account'
         )
+    
         with self.assertRaises(APIError) as context:
             self.service.dns_setup(account_name)
         
+        mock_create_account.assert_called_once_with(account_name)
         self.assertEqual(context.exception, APIError('DNS setup failed to create account'))
 
     @patch('registrar.services.dns_host_service.CloudflareService.create_dns_record')

--- a/src/registrar/tests/services/test_dns_host_service.py
+++ b/src/registrar/tests/services/test_dns_host_service.py
@@ -10,11 +10,11 @@ class TestDnsHostService(SimpleTestCase):
     def setUp(self):
         self.service = DnsHostService()
 
-    @patch('registrar.services.dns_host_service.CloudflareService.get_all_zones')
+    @patch('registrar.services.dns_host_service.CloudflareService.get_account_zones')
     @patch('registrar.services.dns_host_service.CloudflareService.get_all_accounts')
     @patch('registrar.services.dns_host_service.CloudflareService.create_zone')
     @patch('registrar.services.dns_host_service.CloudflareService.create_account')
-    def test_dns_setup_success(self, mock_create_account, mock_create_zone, mock_get_all_accounts, mock_get_all_zones):
+    def test_dns_setup_success(self, mock_create_account, mock_create_zone, mock_get_all_accounts, mock_get_account_zones):
         test_cases = [
             {
                 "test_name": "no account, no zone",
@@ -59,7 +59,7 @@ class TestDnsHostService(SimpleTestCase):
                     "result": [{"id": case.get("found_account_id")}]
                 }
 
-                mock_get_all_zones.return_value = {
+                mock_get_account_zones.return_value = {
                     "result": [{"id": case.get("found_zone_id")}]
                 }
             
@@ -67,11 +67,11 @@ class TestDnsHostService(SimpleTestCase):
                 self.assertEqual(returned_account_id, case["account_id"])
                 self.assertEqual(returned_zone_id, case["zone_id"])
 
-    @patch('registrar.services.dns_host_service.CloudflareService.get_all_zones')
+    @patch('registrar.services.dns_host_service.CloudflareService.get_account_zones')
     @patch('registrar.services.dns_host_service.CloudflareService.get_all_accounts')
     @patch('registrar.services.dns_host_service.CloudflareService.create_zone')
     @patch('registrar.services.dns_host_service.CloudflareService.create_account')
-    def test_dns_setup_failure_from_create_account(self, mock_create_account, mock_create_zone, mock_get_all_accounts, mock_get_all_zones):
+    def test_dns_setup_failure_from_create_account(self, mock_create_account, mock_create_zone, mock_get_all_accounts, mock_get_account_zones):
         account_name = " "
         zone_name = "test.gov"
         mock_create_account.side_effect = APIError(
@@ -84,11 +84,11 @@ class TestDnsHostService(SimpleTestCase):
         mock_create_account.assert_called_once_with(account_name)
         self.assertIn('DNS setup failed to create account', str(context.exception))
     
-    @patch('registrar.services.dns_host_service.CloudflareService.get_all_zones')
+    @patch('registrar.services.dns_host_service.CloudflareService.get_account_zones')
     @patch('registrar.services.dns_host_service.CloudflareService.get_all_accounts')
     @patch('registrar.services.dns_host_service.CloudflareService.create_zone')
     @patch('registrar.services.dns_host_service.CloudflareService.create_account')
-    def test_dns_setup_failure_from_create_zone(self, mock_create_account, mock_create_zone, mock_get_all_accounts, mock_get_all_zones):
+    def test_dns_setup_failure_from_create_zone(self, mock_create_account, mock_create_zone, mock_get_all_accounts, mock_get_account_zones):
         account_name = "Account for test.gov"
         zone_name = "test.gov"
         account_id = "12345"

--- a/src/registrar/tests/services/test_dns_host_service.py
+++ b/src/registrar/tests/services/test_dns_host_service.py
@@ -1,0 +1,81 @@
+from unittest.mock import patch
+from django.test import SimpleTestCase
+
+from registrar.services.cloudflare_service import CloudflareService
+from registrar.services.dns_host_service import DnsHostService
+from registrar.utility.errors import APIError
+
+class TestDnsHostService(SimpleTestCase):
+    
+    def setUp(self):
+        self.service = DnsHostService()
+
+    @patch('registrar.services.dns_host_service.CloudflareService.create_zone')
+    @patch('registrar.services.dns_host_service.CloudflareService.create_account')
+    def test_dns_setup_success(self, mock_create_account, mock_create_zone):
+        account_name = "Account for test.gov"
+        account_id = "12345"
+        mock_create_account.return_value = {
+            "result": {"id": account_id }
+        }
+        
+        zone_id = "9876"
+        mock_create_zone.return_value = {
+            "result": {"id": zone_id}
+        }
+        
+        result = self.service.dns_setup(account_name)
+        self.assertEqual(result, (account_id, zone_id))
+
+    @patch('registrar.services.dns_host_service.CloudflareService.create_zone')
+    @patch('registrar.services.dns_host_service.CloudflareService.create_account')
+    def test_dns_setup_failure(self, mock_create_account, mock_create_zone):
+        account_name = " "
+        mock_create_account.side_effect = APIError(
+            'DNS setup failed to create account'
+        )
+        with self.assertRaises(APIError) as context:
+            self.service.dns_setup(account_name)
+        
+        self.assertEqual(context.exception, APIError('DNS setup failed to create account'))
+
+    @patch('registrar.services.dns_host_service.CloudflareService.create_dns_record')
+    def test_create_record_success(self, mock_create_dns_record):
+    
+        zone_id = '1234'
+        record_data = {
+            "type": "A",
+            "name": "test.gov", # record name
+            "content": "1.1.1.1", # IPv4
+            "ttl": 1,
+            "comment": "Test record"
+        }
+
+        mock_create_dns_record.return_value = {
+            "result": {"id": zone_id, 
+            **record_data
+            }
+        }
+
+        response = self.service.create_record(zone_id, record_data)
+        self.assertEqual(response["result"]["id"], zone_id)
+        self.assertEqual(response["result"]["name"], "test.gov")
+
+    @patch('registrar.services.dns_host_service.CloudflareService.create_dns_record')
+    def test_create_record_failure(self, mock_create_dns_record):
+    
+        zone_id = '1234'
+        record_data = {
+            "type": "A",
+            "content": "1.1.1.1", # IPv4
+            "ttl": 1,
+            "comment": "Test record"
+        }
+
+        mock_create_dns_record.side_effect = APIError("Bad request: missing name")
+
+        with self.assertRaises(APIError) as context:
+            self.service.create_record(zone_id, record_data)
+        
+        self.assertEqual(context.exception, APIError("Bad request: missing name"))
+

--- a/src/registrar/tests/services/test_dns_host_service.py
+++ b/src/registrar/tests/services/test_dns_host_service.py
@@ -5,16 +5,19 @@ from registrar.services.cloudflare_service import CloudflareService
 from registrar.services.dns_host_service import DnsHostService
 from registrar.utility.errors import APIError
 
+
 class TestDnsHostService(SimpleTestCase):
-    
+
     def setUp(self):
         self.service = DnsHostService()
 
-    @patch('registrar.services.dns_host_service.CloudflareService.get_account_zones')
-    @patch('registrar.services.dns_host_service.CloudflareService.get_all_accounts')
-    @patch('registrar.services.dns_host_service.CloudflareService.create_zone')
-    @patch('registrar.services.dns_host_service.CloudflareService.create_account')
-    def test_dns_setup_success(self, mock_create_account, mock_create_zone, mock_get_all_accounts, mock_get_account_zones):
+    @patch("registrar.services.dns_host_service.CloudflareService.get_account_zones")
+    @patch("registrar.services.dns_host_service.CloudflareService.get_all_accounts")
+    @patch("registrar.services.dns_host_service.CloudflareService.create_zone")
+    @patch("registrar.services.dns_host_service.CloudflareService.create_account")
+    def test_dns_setup_success(
+        self, mock_create_account, mock_create_zone, mock_get_all_accounts, mock_get_account_zones
+    ):
         test_cases = [
             {
                 "test_name": "no account, no zone",
@@ -42,107 +45,87 @@ class TestDnsHostService(SimpleTestCase):
                 "zone_id": "8765",
                 "found_account_id": "12345",
                 "found_zone_id": None,
-            }
+            },
         ]
-        
+
         for case in test_cases:
             with self.subTest(msg=case["test_name"], **case):
-                mock_create_account.return_value = {
-                    "result": {"id": case["account_id"] }
-                }
-                
-                mock_create_zone.return_value = {
-                    "result": {"id": case["zone_id"], "name": case["zone_name"]}
-                }
+                mock_create_account.return_value = {"result": {"id": case["account_id"]}}
 
-                mock_get_all_accounts.return_value = {
-                    "result": [{"id": case.get("found_account_id")}]
-                }
+                mock_create_zone.return_value = {"result": {"id": case["zone_id"], "name": case["zone_name"]}}
 
-                mock_get_account_zones.return_value = {
-                    "result": [{"id": case.get("found_zone_id")}]
-                }
-            
+                mock_get_all_accounts.return_value = {"result": [{"id": case.get("found_account_id")}]}
+
+                mock_get_account_zones.return_value = {"result": [{"id": case.get("found_zone_id")}]}
+
                 returned_account_id, returned_zone_id = self.service.dns_setup(case["account_name"], case["zone_name"])
                 self.assertEqual(returned_account_id, case["account_id"])
                 self.assertEqual(returned_zone_id, case["zone_id"])
 
-    @patch('registrar.services.dns_host_service.CloudflareService.get_account_zones')
-    @patch('registrar.services.dns_host_service.CloudflareService.get_all_accounts')
-    @patch('registrar.services.dns_host_service.CloudflareService.create_zone')
-    @patch('registrar.services.dns_host_service.CloudflareService.create_account')
-    def test_dns_setup_failure_from_create_account(self, mock_create_account, mock_create_zone, mock_get_all_accounts, mock_get_account_zones):
+    @patch("registrar.services.dns_host_service.CloudflareService.get_account_zones")
+    @patch("registrar.services.dns_host_service.CloudflareService.get_all_accounts")
+    @patch("registrar.services.dns_host_service.CloudflareService.create_zone")
+    @patch("registrar.services.dns_host_service.CloudflareService.create_account")
+    def test_dns_setup_failure_from_create_account(
+        self, mock_create_account, mock_create_zone, mock_get_all_accounts, mock_get_account_zones
+    ):
         account_name = " "
         zone_name = "test.gov"
-        mock_create_account.side_effect = APIError(
-            'DNS setup failed to create account'
-        )
-    
+        mock_create_account.side_effect = APIError("DNS setup failed to create account")
+
         with self.assertRaises(APIError) as context:
             self.service.dns_setup(account_name, zone_name)
-        
+
         mock_create_account.assert_called_once_with(account_name)
-        self.assertIn('DNS setup failed to create account', str(context.exception))
-    
-    @patch('registrar.services.dns_host_service.CloudflareService.get_account_zones')
-    @patch('registrar.services.dns_host_service.CloudflareService.get_all_accounts')
-    @patch('registrar.services.dns_host_service.CloudflareService.create_zone')
-    @patch('registrar.services.dns_host_service.CloudflareService.create_account')
-    def test_dns_setup_failure_from_create_zone(self, mock_create_account, mock_create_zone, mock_get_all_accounts, mock_get_account_zones):
+        self.assertIn("DNS setup failed to create account", str(context.exception))
+
+    @patch("registrar.services.dns_host_service.CloudflareService.get_account_zones")
+    @patch("registrar.services.dns_host_service.CloudflareService.get_all_accounts")
+    @patch("registrar.services.dns_host_service.CloudflareService.create_zone")
+    @patch("registrar.services.dns_host_service.CloudflareService.create_account")
+    def test_dns_setup_failure_from_create_zone(
+        self, mock_create_account, mock_create_zone, mock_get_all_accounts, mock_get_account_zones
+    ):
         account_name = "Account for test.gov"
         zone_name = "test.gov"
         account_id = "12345"
-        mock_create_account.return_value = {
-            "result": {"id": account_id }
-        }
+        mock_create_account.return_value = {"result": {"id": account_id}}
 
-        mock_create_account.side_effect = APIError(
-            'DNS setup failed to create zone'
-        )
-    
+        mock_create_account.side_effect = APIError("DNS setup failed to create zone")
+
         with self.assertRaises(APIError) as context:
             self.service.dns_setup(account_name, zone_name)
-        
+
         mock_create_account.assert_called_once_with(account_name)
         # mock_create_zone.assert_called_once_with(zone_name, account_id) not sure why this fails: 0 calls
-        self.assertIn('DNS setup failed to create zone', str(context.exception))
+        self.assertIn("DNS setup failed to create zone", str(context.exception))
 
-    @patch('registrar.services.dns_host_service.CloudflareService.create_dns_record')
+    @patch("registrar.services.dns_host_service.CloudflareService.create_dns_record")
     def test_create_record_success(self, mock_create_dns_record):
-    
-        zone_id = '1234'
+
+        zone_id = "1234"
         record_data = {
             "type": "A",
-            "name": "test.gov", # record name
-            "content": "1.1.1.1", # IPv4
+            "name": "test.gov",  # record name
+            "content": "1.1.1.1",  # IPv4
             "ttl": 1,
-            "comment": "Test record"
+            "comment": "Test record",
         }
 
-        mock_create_dns_record.return_value = {
-            "result": {"id": zone_id, 
-            **record_data
-            }
-        }
+        mock_create_dns_record.return_value = {"result": {"id": zone_id, **record_data}}
 
         response = self.service.create_record(zone_id, record_data)
         self.assertEqual(response["result"]["id"], zone_id)
         self.assertEqual(response["result"]["name"], "test.gov")
 
-    @patch('registrar.services.dns_host_service.CloudflareService.create_dns_record')
+    @patch("registrar.services.dns_host_service.CloudflareService.create_dns_record")
     def test_create_record_failure(self, mock_create_dns_record):
-    
-        zone_id = '1234'
-        record_data = {
-            "type": "A",
-            "content": "1.1.1.1", # IPv4
-            "ttl": 1,
-            "comment": "Test record"
-        }
+
+        zone_id = "1234"
+        record_data = {"type": "A", "content": "1.1.1.1", "ttl": 1, "comment": "Test record"}  # IPv4
 
         mock_create_dns_record.side_effect = APIError("Bad request: missing name")
 
         with self.assertRaises(APIError) as context:
             self.service.create_record(zone_id, record_data)
-        self.assertIn('Bad request: missing name', str(context.exception))
-
+        self.assertIn("Bad request: missing name", str(context.exception))

--- a/src/registrar/tests/services/test_dns_host_service.py
+++ b/src/registrar/tests/services/test_dns_host_service.py
@@ -1,7 +1,6 @@
 from unittest.mock import patch
 from django.test import SimpleTestCase
 
-from registrar.services.cloudflare_service import CloudflareService
 from registrar.services.dns_host_service import DnsHostService
 from registrar.utility.errors import APIError
 

--- a/src/registrar/tests/test_api_helpers.py
+++ b/src/registrar/tests/test_api_helpers.py
@@ -1,0 +1,168 @@
+
+from unittest.mock import patch, Mock
+from django.test import SimpleTestCase
+from requests.exceptions import ConnectionError, Timeout, HTTPError, RequestException
+from registrar.utility.api_helpers import make_api_request
+
+class TestMakeAPIRequest(SimpleTestCase):
+    """Test cases for the make_api_request function"""
+    
+    @patch('registrar.utility.api_helpers.requests.request')
+    def test_successful_json_response(self, mock_request):
+        """Test successful API request with JSON response"""
+        # Mock successful response
+        mock_response = Mock()
+        mock_response.json.return_value = {'id': 1, 'name': 'Jalaya Doe'}
+        mock_response.status_code = 200
+        mock_response.raise_for_status.return_value = None
+        mock_request.return_value = mock_response
+        
+        result = make_api_request('https://api.example.com/users/1')
+        
+        self.assertTrue(result['success'])
+        self.assertEqual(result['data'], {'id': 1, 'name': 'Jalaya Doe'})
+        self.assertEqual(result['status_code'], 200)
+        
+        # Verify request was called correctly
+        mock_request.assert_called_once_with(
+            method='GET',
+            url='https://api.example.com/users/1',
+            json=None,
+            headers=None,
+            timeout=30,
+            verify=True
+        )
+    
+    @patch('registrar.utility.api_helpers.requests.request')
+    def test_successful_text_response(self, mock_request):
+        """Test successful API request with non-JSON response"""
+        mock_response = Mock()
+        mock_response.json.side_effect = ValueError("No JSON object could be decoded")
+        mock_response.text = "Plain text response"
+        mock_response.status_code = 200
+        mock_response.raise_for_status.return_value = None
+        mock_request.return_value = mock_response
+        
+        result = make_api_request('https://api.example.com/health')
+        
+        self.assertTrue(result['success'])
+        self.assertEqual(result['data'], "Plain text response")
+        self.assertEqual(result['status_code'], 200)
+    
+    @patch('registrar.utility.api_helpers.requests.request')
+    def test_post_request_with_data(self, mock_request):
+        """Test POST request with JSON data"""
+        mock_response = Mock()
+        mock_response.json.return_value = {'id': 2, 'created': True}
+        mock_response.status_code = 201
+        mock_response.raise_for_status.return_value = None
+        mock_request.return_value = mock_response
+        
+        test_data = {'name': 'Justice Doe', 'email': 'Justice@example.com'}
+        result = make_api_request(
+            'https://api.example.com/users',
+            method='POST',
+            headers={
+                    'Content-Type': 'application/json'
+                },
+            data=test_data
+        )
+        
+        self.assertTrue(result['success'])
+        self.assertEqual(result['data'], {'id': 2, 'created': True})
+        
+        # Verify POST data was passed correctly
+        mock_request.assert_called_once_with(
+            method='POST',
+            url='https://api.example.com/users',
+            json=test_data,
+            headers={
+                'Content-Type': 'application/json'
+            },
+            timeout=30,
+            verify=True
+        )
+    
+    @patch('registrar.utility.api_helpers.requests.request')
+    def test_connection_error(self, mock_request):
+        """Test handling of connection errors"""
+        mock_request.side_effect = ConnectionError("Connection failed")
+        
+        result = make_api_request('https://api.example.com/users/1')
+        
+        self.assertFalse(result['success'])
+        self.assertEqual(result['error'], 'connection_error')
+        self.assertEqual(result['message'], 'Unable to connect to the server')
+        self.assertIn('Connection failed', result['details'])
+    
+    @patch('registrar.utility.api_helpers.requests.request')
+    def test_timeout_error(self, mock_request):
+        """Test handling of timeout errors"""
+        mock_request.side_effect = Timeout("Request timed out")
+        
+        result = make_api_request('https://api.example.com/users/1', timeout=10)
+        
+        self.assertFalse(result['success'])
+        self.assertEqual(result['error'], 'timeout')
+        self.assertEqual(result['message'], 'Request timed out after 10 seconds')
+        self.assertIn('Request timed out', result['details'])
+    
+    @patch('registrar.utility.api_helpers.requests.request')
+    def test_http_error_404(self, mock_request):
+        """Test handling of HTTP 404 error"""
+        mock_response = Mock()
+        mock_response.status_code = 404
+        http_error = HTTPError("404 Client Error")
+        http_error.response = mock_response
+        mock_request.return_value = mock_response
+        mock_response.raise_for_status.side_effect = http_error
+        
+        result = make_api_request('https://api.example.com/users/999')
+        
+        self.assertFalse(result['success'])
+        self.assertEqual(result['error'], 'http_error')
+        self.assertEqual(result['status_code'], 404)
+        self.assertEqual(result['message'], 'Not found - resource does not exist')
+    
+    @patch('registrar.utility.api_helpers.requests.request')
+    def test_http_error_500(self, mock_request):
+        """Test handling of HTTP 500 error"""
+        mock_response = Mock()
+        mock_response.status_code = 500
+        http_error = HTTPError("500 Server Error")
+        http_error.response = mock_response
+        mock_request.return_value = mock_response
+        mock_response.raise_for_status.side_effect = http_error
+        
+        result = make_api_request('https://api.example.com/users/1')
+        
+        self.assertFalse(result['success'])
+        self.assertEqual(result['error'], 'http_error')
+        self.assertEqual(result['status_code'], 500)
+        self.assertEqual(result['message'], 'Internal server error')
+    
+    @patch('registrar.utility.api_helpers.requests.request')
+    def test_custom_headers(self, mock_request):
+        """Test request with custom headers"""
+        mock_response = Mock()
+        mock_response.json.return_value = {'data': 'test'}
+        mock_response.status_code = 200
+        mock_response.raise_for_status.return_value = None
+        mock_request.return_value = mock_response
+        
+        custom_headers = {'Authorization': 'Bearer token123', 'Content-Type': 'application/json'}
+        result = make_api_request(
+            'https://api.example.com/users/1',
+            headers=custom_headers
+        )
+        
+        self.assertTrue(result['success'])
+        
+        # Verify headers were merged correctly
+        expected_headers = {
+            'Content-Type': 'application/json',
+            'Authorization': 'Bearer token123'
+        }
+        mock_request.assert_called_once()
+        call_args = mock_request.call_args
+        self.assertEqual(call_args[1]['headers'], expected_headers)

--- a/src/registrar/tests/test_api_helpers.py
+++ b/src/registrar/tests/test_api_helpers.py
@@ -1,39 +1,34 @@
-
 from unittest.mock import patch, Mock
 from django.test import SimpleTestCase
 from requests.exceptions import ConnectionError, Timeout, HTTPError, RequestException
 from registrar.utility.api_helpers import make_api_request
 
+
 class TestMakeAPIRequest(SimpleTestCase):
     """Test cases for the make_api_request function"""
-    
-    @patch('registrar.utility.api_helpers.requests.request')
+
+    @patch("registrar.utility.api_helpers.requests.request")
     def test_successful_json_response(self, mock_request):
         """Test successful API request with JSON response"""
         # Mock successful response
         mock_response = Mock()
-        mock_response.json.return_value = {'id': 1, 'name': 'Jalaya Doe'}
+        mock_response.json.return_value = {"id": 1, "name": "Jalaya Doe"}
         mock_response.status_code = 200
         mock_response.raise_for_status.return_value = None
         mock_request.return_value = mock_response
-        
-        result = make_api_request('https://api.example.com/users/1')
-        
-        self.assertTrue(result['success'])
-        self.assertEqual(result['data'], {'id': 1, 'name': 'Jalaya Doe'})
-        self.assertEqual(result['status_code'], 200)
-        
+
+        result = make_api_request("https://api.example.com/users/1")
+
+        self.assertTrue(result["success"])
+        self.assertEqual(result["data"], {"id": 1, "name": "Jalaya Doe"})
+        self.assertEqual(result["status_code"], 200)
+
         # Verify request was called correctly
         mock_request.assert_called_once_with(
-            method='GET',
-            url='https://api.example.com/users/1',
-            json=None,
-            headers=None,
-            timeout=30,
-            verify=True
+            method="GET", url="https://api.example.com/users/1", json=None, headers=None, timeout=30, verify=True
         )
-    
-    @patch('registrar.utility.api_helpers.requests.request')
+
+    @patch("registrar.utility.api_helpers.requests.request")
     def test_successful_text_response(self, mock_request):
         """Test successful API request with non-JSON response"""
         mock_response = Mock()
@@ -42,72 +37,65 @@ class TestMakeAPIRequest(SimpleTestCase):
         mock_response.status_code = 200
         mock_response.raise_for_status.return_value = None
         mock_request.return_value = mock_response
-        
-        result = make_api_request('https://api.example.com/health')
-        
-        self.assertTrue(result['success'])
-        self.assertEqual(result['data'], "Plain text response")
-        self.assertEqual(result['status_code'], 200)
-    
-    @patch('registrar.utility.api_helpers.requests.request')
+
+        result = make_api_request("https://api.example.com/health")
+
+        self.assertTrue(result["success"])
+        self.assertEqual(result["data"], "Plain text response")
+        self.assertEqual(result["status_code"], 200)
+
+    @patch("registrar.utility.api_helpers.requests.request")
     def test_post_request_with_data(self, mock_request):
         """Test POST request with JSON data"""
         mock_response = Mock()
-        mock_response.json.return_value = {'id': 2, 'created': True}
+        mock_response.json.return_value = {"id": 2, "created": True}
         mock_response.status_code = 201
         mock_response.raise_for_status.return_value = None
         mock_request.return_value = mock_response
-        
-        test_data = {'name': 'Justice Doe', 'email': 'Justice@example.com'}
+
+        test_data = {"name": "Justice Doe", "email": "Justice@example.com"}
         result = make_api_request(
-            'https://api.example.com/users',
-            method='POST',
-            headers={
-                    'Content-Type': 'application/json'
-                },
-            data=test_data
+            "https://api.example.com/users", method="POST", headers={"Content-Type": "application/json"}, data=test_data
         )
-        
-        self.assertTrue(result['success'])
-        self.assertEqual(result['data'], {'id': 2, 'created': True})
-        
+
+        self.assertTrue(result["success"])
+        self.assertEqual(result["data"], {"id": 2, "created": True})
+
         # Verify POST data was passed correctly
         mock_request.assert_called_once_with(
-            method='POST',
-            url='https://api.example.com/users',
+            method="POST",
+            url="https://api.example.com/users",
             json=test_data,
-            headers={
-                'Content-Type': 'application/json'
-            },
+            headers={"Content-Type": "application/json"},
             timeout=30,
-            verify=True
+            verify=True,
         )
-    
-    @patch('registrar.utility.api_helpers.requests.request')
+
+    @patch("registrar.utility.api_helpers.requests.request")
     def test_connection_error(self, mock_request):
         """Test handling of connection errors"""
         mock_request.side_effect = ConnectionError("Connection failed")
-        
-        result = make_api_request('https://api.example.com/users/1')
-        
-        self.assertFalse(result['success'])
-        self.assertEqual(result['error'], 'connection_error')
-        self.assertEqual(result['message'], 'Unable to connect to the server')
-        self.assertIn('Connection failed', result['details'])
-    
-    @patch('registrar.utility.api_helpers.requests.request')
+
+        result = make_api_request("https://api.example.com/users/1")
+
+        self.assertFalse(result["success"])
+        self.assertEqual(result["error"], "connection_error")
+        self.assertEqual(result["message"], "Unable to connect to the server")
+        self.assertIn("Connection failed", result["details"])
+
+    @patch("registrar.utility.api_helpers.requests.request")
     def test_timeout_error(self, mock_request):
         """Test handling of timeout errors"""
         mock_request.side_effect = Timeout("Request timed out")
-        
-        result = make_api_request('https://api.example.com/users/1', timeout=10)
-        
-        self.assertFalse(result['success'])
-        self.assertEqual(result['error'], 'timeout')
-        self.assertEqual(result['message'], 'Request timed out after 10 seconds')
-        self.assertIn('Request timed out', result['details'])
-    
-    @patch('registrar.utility.api_helpers.requests.request')
+
+        result = make_api_request("https://api.example.com/users/1", timeout=10)
+
+        self.assertFalse(result["success"])
+        self.assertEqual(result["error"], "timeout")
+        self.assertEqual(result["message"], "Request timed out after 10 seconds")
+        self.assertIn("Request timed out", result["details"])
+
+    @patch("registrar.utility.api_helpers.requests.request")
     def test_http_error_404(self, mock_request):
         """Test handling of HTTP 404 error"""
         mock_response = Mock()
@@ -116,15 +104,15 @@ class TestMakeAPIRequest(SimpleTestCase):
         http_error.response = mock_response
         mock_request.return_value = mock_response
         mock_response.raise_for_status.side_effect = http_error
-        
-        result = make_api_request('https://api.example.com/users/999')
-        
-        self.assertFalse(result['success'])
-        self.assertEqual(result['error'], 'http_error')
-        self.assertEqual(result['status_code'], 404)
-        self.assertEqual(result['message'], 'Not found - resource does not exist')
-    
-    @patch('registrar.utility.api_helpers.requests.request')
+
+        result = make_api_request("https://api.example.com/users/999")
+
+        self.assertFalse(result["success"])
+        self.assertEqual(result["error"], "http_error")
+        self.assertEqual(result["status_code"], 404)
+        self.assertEqual(result["message"], "Not found - resource does not exist")
+
+    @patch("registrar.utility.api_helpers.requests.request")
     def test_http_error_500(self, mock_request):
         """Test handling of HTTP 500 error"""
         mock_response = Mock()
@@ -133,36 +121,30 @@ class TestMakeAPIRequest(SimpleTestCase):
         http_error.response = mock_response
         mock_request.return_value = mock_response
         mock_response.raise_for_status.side_effect = http_error
-        
-        result = make_api_request('https://api.example.com/users/1')
-        
-        self.assertFalse(result['success'])
-        self.assertEqual(result['error'], 'http_error')
-        self.assertEqual(result['status_code'], 500)
-        self.assertEqual(result['message'], 'Internal server error')
-    
-    @patch('registrar.utility.api_helpers.requests.request')
+
+        result = make_api_request("https://api.example.com/users/1")
+
+        self.assertFalse(result["success"])
+        self.assertEqual(result["error"], "http_error")
+        self.assertEqual(result["status_code"], 500)
+        self.assertEqual(result["message"], "Internal server error")
+
+    @patch("registrar.utility.api_helpers.requests.request")
     def test_custom_headers(self, mock_request):
         """Test request with custom headers"""
         mock_response = Mock()
-        mock_response.json.return_value = {'data': 'test'}
+        mock_response.json.return_value = {"data": "test"}
         mock_response.status_code = 200
         mock_response.raise_for_status.return_value = None
         mock_request.return_value = mock_response
-        
-        custom_headers = {'Authorization': 'Bearer token123', 'Content-Type': 'application/json'}
-        result = make_api_request(
-            'https://api.example.com/users/1',
-            headers=custom_headers
-        )
-        
-        self.assertTrue(result['success'])
-        
+
+        custom_headers = {"Authorization": "Bearer token123", "Content-Type": "application/json"}
+        result = make_api_request("https://api.example.com/users/1", headers=custom_headers)
+
+        self.assertTrue(result["success"])
+
         # Verify headers were merged correctly
-        expected_headers = {
-            'Content-Type': 'application/json',
-            'Authorization': 'Bearer token123'
-        }
+        expected_headers = {"Content-Type": "application/json", "Authorization": "Bearer token123"}
         mock_request.assert_called_once()
         call_args = mock_request.call_args
-        self.assertEqual(call_args[1]['headers'], expected_headers)
+        self.assertEqual(call_args[1]["headers"], expected_headers)

--- a/src/registrar/tests/test_api_helpers.py
+++ b/src/registrar/tests/test_api_helpers.py
@@ -1,6 +1,6 @@
 from unittest.mock import patch, Mock
 from django.test import SimpleTestCase
-from requests.exceptions import ConnectionError, Timeout, HTTPError, RequestException
+from requests.exceptions import ConnectionError, Timeout, HTTPError
 from registrar.utility.api_helpers import make_api_request
 
 

--- a/src/registrar/tests/test_services_cloudflare.py
+++ b/src/registrar/tests/test_services_cloudflare.py
@@ -1,0 +1,22 @@
+from unittest.mock import patch, Mock, MagicMock
+from django.test import TestCase
+
+from registrar.services.cloudflare_service import CloudflareService
+
+class TestCloudflareService(TestCase):
+    """Test cases for the CloudflareService class"""
+    def setUp(self):
+        self.service = CloudflareService()
+
+    @patch('registrar.services.cloudflare_service.make_api_request')
+    def test_create_account_success(self, mock_make_request):
+        """Test successful create_account call"""
+        account_name = "test.gov test account"
+        mock_make_request.return_value = {
+            'success': True,
+            'data': {"result": {"name": account_name, "id": "12345"}}
+        }
+        result = self.service.create_account(account_name)
+        print(result)
+        self.assertEqual(result['result']['name'], account_name)
+        

--- a/src/registrar/tests/test_services_cloudflare.py
+++ b/src/registrar/tests/test_services_cloudflare.py
@@ -17,7 +17,6 @@ class TestCloudflareService(SimpleTestCase):
             'data': {"result": {"name": account_name, "id": "12345"}}
         }
         result = self.service.create_account(account_name)
-        print(result)
         self.assertEqual(result['result']['name'], account_name)   
         
     @patch('registrar.services.cloudflare_service.make_api_request')
@@ -33,3 +32,31 @@ class TestCloudflareService(SimpleTestCase):
             self.service.create_account(account_name)
         
         self.assertIn(f"Failed to create account for {account_name}: Cannot be empty", str(context.exception))
+
+    @patch('registrar.services.cloudflare_service.make_api_request')
+    def test_create_zone_success(self, mock_make_request):
+        """Test successful create_zone call"""
+        account_name = "test.gov test account"
+        account_id = "12345"
+        mock_make_request.return_value = {
+            'success': True,
+            'data': {"result": {"name": account_name, "id": "12345", "nameservers": ["hostess1.mostess.gov", "hostess2.mostess.gov"]}}
+        }
+        result = self.service.create_zone(account_name, account_id)
+        print(result)
+        self.assertEqual(result['result']['name'], account_name)   
+        
+    @patch('registrar.services.cloudflare_service.make_api_request')
+    def test_create_zone_failure(self, mock_make_request):
+        """Test create_zone with API failure"""
+        account_name = "test.gov test account"
+        account_id = "12345"
+        mock_make_request.return_value = {
+            'success': False,
+            'message': 'invalid'
+        }
+        
+        with self.assertRaises(APIError) as context:
+            self.service.create_zone(account_name, account_id)
+        
+        self.assertIn(f"Failed to create zone for {account_name}: invalid", str(context.exception))

--- a/src/registrar/tests/test_services_cloudflare.py
+++ b/src/registrar/tests/test_services_cloudflare.py
@@ -2,7 +2,7 @@ from unittest.mock import patch
 from django.test import SimpleTestCase
 
 from registrar.services.cloudflare_service import CloudflareService
-
+from registrar.utility.errors import APIError
 class TestCloudflareService(SimpleTestCase):
     """Test cases for the CloudflareService class"""
     def setUp(self):
@@ -18,5 +18,18 @@ class TestCloudflareService(SimpleTestCase):
         }
         result = self.service.create_account(account_name)
         print(result)
-        self.assertEqual(result['result']['name'], account_name)
+        self.assertEqual(result['result']['name'], account_name)   
         
+    @patch('registrar.services.cloudflare_service.make_api_request')
+    def test_create_account_failure(self, mock_make_request):
+        """Test create_account with API failure"""
+        account_name = ' '
+        mock_make_request.return_value = {
+            'success': False,
+            'message': 'Cannot be empty'
+        }
+        
+        with self.assertRaises(APIError) as context:
+            self.service.create_account(account_name)
+        
+        self.assertIn(f"Failed to create account for {account_name}: Cannot be empty", str(context.exception))

--- a/src/registrar/tests/test_services_cloudflare.py
+++ b/src/registrar/tests/test_services_cloudflare.py
@@ -60,3 +60,52 @@ class TestCloudflareService(SimpleTestCase):
             self.service.create_zone(account_name, account_id)
         
         self.assertIn(f"Failed to create zone for {account_name}: invalid", str(context.exception))
+
+    @patch('registrar.services.cloudflare_service.make_api_request')
+    def test_create_dns_record_success(self, mock_make_request):
+        """Test successful create_dns_record call"""
+        zone_id = "54321"
+        record_data = {
+            "content": "198.51.100.4",
+            "name": "democracy.gov",
+            "proxied": False,
+            "type": "A",
+            "comment": "Test domain name",
+            "ttl": 3600
+        }
+        mock_make_request.return_value = {
+            'success': True,
+            'data': {
+                "content": "198.51.100.4",
+                "name": "democracy.gov",
+                "proxied": False,
+                "type": "A",
+                "comment": "Test domain name",
+                "ttl": 3600
+            }
+        }
+        result = self.service.create_dns_record(zone_id, record_data)
+        print(result)
+        self.assertEqual(result['result']['name'], )   
+        
+    @patch('registrar.services.cloudflare_service.make_api_request')
+    def test_create_dns_record_failure(self, mock_make_request):
+        """Test create_zone with API failure"""
+        zone_id = "54321"
+        record_data_missing_content = {
+            "name": "democracy.gov",
+            "proxied": False,
+            "type": "A",
+            "comment": "Test domain name",
+            "ttl": 3600
+        }
+        mock_make_request.return_value = {
+            'success': False,
+            'message': 'missing content field'
+        }
+        
+        with self.assertRaises(APIError) as context:
+            self.service.create_dns_record(zone_id, record_data_missing_content)
+        
+        self.assertIn(f"Failed to create record for zone {zone_id}: 'missing content field'", str(context.exception))
+        

--- a/src/registrar/tests/test_services_cloudflare.py
+++ b/src/registrar/tests/test_services_cloudflare.py
@@ -1,9 +1,9 @@
-from unittest.mock import patch, Mock, MagicMock
-from django.test import TestCase
+from unittest.mock import patch
+from django.test import SimpleTestCase
 
 from registrar.services.cloudflare_service import CloudflareService
 
-class TestCloudflareService(TestCase):
+class TestCloudflareService(SimpleTestCase):
     """Test cases for the CloudflareService class"""
     def setUp(self):
         self.service = CloudflareService()

--- a/src/registrar/utility/api_helpers.py
+++ b/src/registrar/utility/api_helpers.py
@@ -1,0 +1,128 @@
+
+import logging
+import requests
+from requests.exceptions import (
+    RequestException, 
+    ConnectionError, 
+    HTTPError, 
+    Timeout, 
+    TooManyRedirects
+)
+
+logger = logging.getLogger(__name__)
+
+def make_api_request(url, method='GET', data=None, headers=None, params=None, timeout=30):
+    """
+    Make an HTTP request with comprehensive error handling
+    
+    Args:
+        url (str): The URL to make the request to
+        method (str): HTTP method (GET, POST, PUT, DELETE)
+        data (dict): Request payload for POST/PUT requests
+        headers (dict): Custom headers
+        timeout (int): Request timeout in seconds
+    
+    Returns:
+        dict: Response data or error information
+    """
+    
+    try:
+        # Make the request
+        response = requests.request(
+            method=method.upper(),
+            url=url,
+            json=data if data else None,
+            headers=headers,
+            timeout=timeout,
+            verify=True  # SSL verification
+        )
+        
+        # Raise an exception for bad status codes (4xx, 5xx)
+        response.raise_for_status()
+        
+        # Try to parse JSON response
+        try:
+            return {
+                'success': True,
+                'data': response.json(),
+                'status_code': response.status_code
+            }
+        except ValueError:
+            # Response is not JSON
+            return {
+                'success': True,
+                'data': response.text,
+                'status_code': response.status_code
+            }
+            
+    except ConnectionError as e:
+        logger.error(f"Connection error for {url}: {str(e)}")
+        return {
+            'success': False,
+            'error': 'connection_error',
+            'message': 'Unable to connect to the server',
+            'details': str(e)
+        }
+        
+    except Timeout as e:
+        logger.error(f"Timeout error for {url}: {str(e)}")
+        return {
+            'success': False,
+            'error': 'timeout',
+            'message': f'Request timed out after {timeout} seconds',
+            'details': str(e)
+        }
+        
+    except HTTPError as e:
+        logger.error(f"HTTP error for {url}: {str(e)}")
+        status_code = e.response.status_code if e.response else None
+        
+        # Handle different HTTP error codes
+        error_messages = {
+            400: 'Bad request - invalid parameters',
+            401: 'Unauthorized - invalid credentials',
+            403: 'Forbidden - access denied',
+            404: 'Not found - resource does not exist',
+            429: 'Too many requests - rate limit exceeded',
+            500: 'Internal server error',
+            502: 'Bad gateway',
+            503: 'Service unavailable',
+            504: 'Gateway timeout'
+        }
+        
+        return {
+            'success': False,
+            'error': 'http_error',
+            'status_code': status_code,
+            'message': error_messages.get(status_code, f'HTTP error {status_code}'),
+            'details': str(e)
+        }
+        
+    except TooManyRedirects as e:
+        logger.error(f"Too many redirects for {url}: {str(e)}")
+        return {
+            'success': False,
+            'error': 'too_many_redirects',
+            'message': 'Too many redirects',
+            'details': str(e)
+        }
+        
+    except RequestException as e:
+        # Catch-all for other requests exceptions
+        logger.error(f"Request exception for {url}: {str(e)}")
+        return {
+            'success': False,
+            'error': 'request_error',
+            'message': 'An error occurred while making the request',
+            'details': str(e)
+        }
+        
+    except Exception as e:
+        # Catch any other unexpected errors
+        logger.error(f"Unexpected error for {url}: {str(e)}")
+        return {
+            'success': False,
+            'error': 'unexpected_error',
+            'message': 'An unexpected error occurred',
+            'details': str(e)
+        }

--- a/src/registrar/utility/api_helpers.py
+++ b/src/registrar/utility/api_helpers.py
@@ -1,31 +1,25 @@
-
 import logging
 import requests
-from requests.exceptions import (
-    RequestException, 
-    ConnectionError, 
-    HTTPError, 
-    Timeout, 
-    TooManyRedirects
-)
+from requests.exceptions import RequestException, ConnectionError, HTTPError, Timeout, TooManyRedirects
 
 logger = logging.getLogger(__name__)
 
-def make_api_request(url, method='GET', data=None, headers=None, params=None, timeout=30):
+
+def make_api_request(url, method="GET", data=None, headers=None, params=None, timeout=30):
     """
     Make an HTTP request with comprehensive error handling
-    
+
     Args:
         url (str): The URL to make the request to
         method (str): HTTP method (GET, POST, PUT, DELETE)
         data (dict): Request payload for POST/PUT requests
         headers (dict): Custom headers
         timeout (int): Request timeout in seconds
-    
+
     Returns:
         dict: Response data or error information
     """
-    
+
     try:
         # Make the request
         response = requests.request(
@@ -34,95 +28,82 @@ def make_api_request(url, method='GET', data=None, headers=None, params=None, ti
             json=data if data else None,
             headers=headers,
             timeout=timeout,
-            verify=True  # SSL verification
+            verify=True,  # SSL verification
         )
-        
+
         # Raise an exception for bad status codes (4xx, 5xx)
         response.raise_for_status()
-        
+
         # Try to parse JSON response
         try:
-            return {
-                'success': True,
-                'data': response.json(),
-                'status_code': response.status_code
-            }
+            return {"success": True, "data": response.json(), "status_code": response.status_code}
         except ValueError:
             # Response is not JSON
-            return {
-                'success': True,
-                'data': response.text,
-                'status_code': response.status_code
-            }
-            
+            return {"success": True, "data": response.text, "status_code": response.status_code}
+
     except ConnectionError as e:
         logger.error(f"Connection error for {url}: {str(e)}")
         return {
-            'success': False,
-            'error': 'connection_error',
-            'message': 'Unable to connect to the server',
-            'details': str(e)
+            "success": False,
+            "error": "connection_error",
+            "message": "Unable to connect to the server",
+            "details": str(e),
         }
-        
+
     except Timeout as e:
         logger.error(f"Timeout error for {url}: {str(e)}")
         return {
-            'success': False,
-            'error': 'timeout',
-            'message': f'Request timed out after {timeout} seconds',
-            'details': str(e)
+            "success": False,
+            "error": "timeout",
+            "message": f"Request timed out after {timeout} seconds",
+            "details": str(e),
         }
-        
+
     except HTTPError as e:
         logger.error(f"HTTP error for {url}: {str(e)}")
         status_code = e.response.status_code if e.response else None
-        
+
         # Handle different HTTP error codes
         error_messages = {
-            400: 'Bad request - invalid parameters',
-            401: 'Unauthorized - invalid credentials',
-            403: 'Forbidden - access denied',
-            404: 'Not found - resource does not exist',
-            429: 'Too many requests - rate limit exceeded',
-            500: 'Internal server error',
-            502: 'Bad gateway',
-            503: 'Service unavailable',
-            504: 'Gateway timeout'
+            400: "Bad request - invalid parameters",
+            401: "Unauthorized - invalid credentials",
+            403: "Forbidden - access denied",
+            404: "Not found - resource does not exist",
+            429: "Too many requests - rate limit exceeded",
+            500: "Internal server error",
+            502: "Bad gateway",
+            503: "Service unavailable",
+            504: "Gateway timeout",
         }
-        
+
         return {
-            'success': False,
-            'error': 'http_error',
-            'status_code': status_code,
-            'message': error_messages.get(status_code, f'HTTP error {status_code}'),
-            'details': str(e)
+            "success": False,
+            "error": "http_error",
+            "status_code": status_code,
+            "message": error_messages.get(status_code, f"HTTP error {status_code}"),
+            "details": str(e),
         }
-        
+
     except TooManyRedirects as e:
         logger.error(f"Too many redirects for {url}: {str(e)}")
-        return {
-            'success': False,
-            'error': 'too_many_redirects',
-            'message': 'Too many redirects',
-            'details': str(e)
-        }
-        
+        return {"success": False, "error": "too_many_redirects", "message": "Too many redirects", "details": str(e)}
+
     except RequestException as e:
         # Catch-all for other requests exceptions
         logger.error(f"Request exception for {url}: {str(e)}")
         return {
-            'success': False,
-            'error': 'request_error',
-            'message': 'An error occurred while making the request',
-            'details': str(e)
+            "success": False,
+            "error": "request_error",
+            "message": "An error occurred while making the request",
+            "details": str(e),
         }
-        
+
     except Exception as e:
         # Catch any other unexpected errors
         logger.error(f"Unexpected error for {url}: {str(e)}")
         return {
-            'success': False,
-            'error': 'unexpected_error',
-            'message': 'An unexpected error occurred',
-            'details': str(e)
+            "success": False,
+            "error": "unexpected_error",
+            "message": "An unexpected error occurred",
+            "details": str(e),
         }

--- a/src/registrar/utility/errors.py
+++ b/src/registrar/utility/errors.py
@@ -1,5 +1,16 @@
+import requests
+import logging
+from requests.exceptions import (
+    RequestException, 
+    ConnectionError, 
+    HTTPError, 
+    Timeout, 
+    TooManyRedirects
+)
+
 from enum import IntEnum
 
+logger = logging.getLogger(__name__)
 
 class BlankValueError(ValueError):
     pass
@@ -307,3 +318,7 @@ class SecurityEmailError(Exception):
 
     def __str__(self):
         return f"{self.message}"
+
+class APIError(Exception):
+    """Custom exception for API-related errors"""
+    pass

--- a/src/registrar/utility/errors.py
+++ b/src/registrar/utility/errors.py
@@ -1,6 +1,4 @@
-import requests
 import logging
-from requests.exceptions import RequestException, ConnectionError, HTTPError, Timeout, TooManyRedirects
 
 from enum import IntEnum
 

--- a/src/registrar/utility/errors.py
+++ b/src/registrar/utility/errors.py
@@ -1,16 +1,11 @@
 import requests
 import logging
-from requests.exceptions import (
-    RequestException, 
-    ConnectionError, 
-    HTTPError, 
-    Timeout, 
-    TooManyRedirects
-)
+from requests.exceptions import RequestException, ConnectionError, HTTPError, Timeout, TooManyRedirects
 
 from enum import IntEnum
 
 logger = logging.getLogger(__name__)
+
 
 class BlankValueError(ValueError):
     pass
@@ -319,6 +314,8 @@ class SecurityEmailError(Exception):
     def __str__(self):
         return f"{self.message}"
 
+
 class APIError(Exception):
     """Custom exception for API-related errors"""
+
     pass

--- a/src/registrar/views/domain.py
+++ b/src/registrar/views/domain.py
@@ -806,8 +806,6 @@ class PrototypeDomainDNSRecordView(DomainFormBaseView):
                      errors = zone_data.get("errors", [])
                      logger.error(f"API error in view: {str(e)}, {errors}")
                     
-                    zone_response.raise_for_status()
-
                 # # 5. Create DNS record
                 # # Format the DNS record according to Cloudflare's API requirements
                 dns_response = requests.post(

--- a/src/registrar/views/domain.py
+++ b/src/registrar/views/domain.py
@@ -761,28 +761,27 @@ class PrototypeDomainDNSRecordView(DomainFormBaseView):
                         f"Can only create DNS records for: {self.valid_domains}."
                         " Create one in a test environment if it doesn't already exist."
                     )
-
+                
                 record_data = {
                                 "type": "A",
                                 "name": form.cleaned_data["name"], # record name
                                 "content": form.cleaned_data["content"], # IPv4
                                 "ttl": int(form.cleaned_data["ttl"]),
-                                "comment": "Test record (will need clean up)",
+                                "comment": "Test record",
                             }
 
-                # Check (by name) to see if the account already exists
                 account_name = f"account-{self.object.name}"
-                zone_name = self.object.name # domain name
-                account_id = self.dns_host_service.find_existing_account(account_name)
-                # if the account doesn't exist, CREATE account and zone and create a record on that zone
-                if not account_id:
-                    try:
-                        _, created_zone_id = self.dns_host_service.dns_setup(account_name, zone_name)
-                    except APIError as e:
-                     logger.error(f"API error in view: {str(e)}")
+                zone_name = f"{self.object.name}" # must be a domain name
+                zone_id = ""
+            
+                try:
+                 _, zone_id = self.dns_host_service.dns_setup(account_name, zone_name)
+                except APIError as e:
+                    logger.error(f"API error in view: {str(e)}")
                 
+                if zone_id:
                     try:
-                        record_response = self.dns_host_service.create_record(created_zone_id, record_data)
+                        record_response = self.dns_host_service.create_record(zone_id, record_data)
                         logger.info(f"Created DNS record: {record_response['result']}")
                         self.dns_record = record_response["result"]
                         dns_name = record_response["result"]["name"]
@@ -790,32 +789,12 @@ class PrototypeDomainDNSRecordView(DomainFormBaseView):
                     except APIError as e:
                         logger.error(f"API error in view: {str(e)}")
 
-                # if an account already exists but the zone does not, create a zone.
-                if account_id:
-                    zone_id = self.dns_host_service.find_existing_zone(zone_name)
-
-                    if not zone_id:
-                        try:
-                            zone_data = self.dns_vendor_service.create_zone(zone_name, account_id) # TODO: make a create_zone on dns_host_service
-                            zone_id = zone_data["result"]["id"]
-                        except APIError as e:
-                            logger.error(f"API error in view: {str(e)}")
-
-                    if zone_id:
-                        # Create a dns record for the zone
-                        try:
-                            record_response = self.dns_host_service.create_record(zone_id, record_data)
-                            logger.info(f"Created DNS record: {record_response['result']}")
-                            self.dns_record = record_response["result"]
-                            dns_name = record_response["result"]["name"]
-                            messages.success(request, f"DNS A record '{dns_name}' created successfully.")
-                        except APIError as e:
-                            logger.error(f"API error in view: {str(e)}")
                 context_dns_record.set(self.dns_record)
             finally:
                 if errors:
                     messages.error(request, f"Request errors: {errors}")
         return super().post(request)
+
 @grant_access(IS_DOMAIN_MANAGER, IS_STAFF_MANAGING_DOMAIN)
 class DomainNameserversView(DomainFormBaseView):
     """Domain nameserver editing view."""

--- a/src/registrar/views/domain.py
+++ b/src/registrar/views/domain.py
@@ -83,6 +83,8 @@ from django import forms
 logger = logging.getLogger(__name__)
 
 context_dns_record = ContextVar("context_dns_record", default=None)
+
+
 class DomainBaseView(PermissionRequiredMixin, DetailView):
     """
     Base View for the Domain. Handles getting and setting the domain
@@ -761,24 +763,24 @@ class PrototypeDomainDNSRecordView(DomainFormBaseView):
                         f"Can only create DNS records for: {self.valid_domains}."
                         " Create one in a test environment if it doesn't already exist."
                     )
-                
+
                 record_data = {
-                                "type": "A",
-                                "name": form.cleaned_data["name"], # record name
-                                "content": form.cleaned_data["content"], # IPv4
-                                "ttl": int(form.cleaned_data["ttl"]),
-                                "comment": "Test record",
-                            }
+                    "type": "A",
+                    "name": form.cleaned_data["name"],  # record name
+                    "content": form.cleaned_data["content"],  # IPv4
+                    "ttl": int(form.cleaned_data["ttl"]),
+                    "comment": "Test record",
+                }
 
                 account_name = f"account-{self.object.name}"
-                zone_name = f"{self.object.name}" # must be a domain name
+                zone_name = f"{self.object.name}"  # must be a domain name
                 zone_id = ""
-            
+
                 try:
-                 _, zone_id = self.dns_host_service.dns_setup(account_name, zone_name)
+                    _, zone_id = self.dns_host_service.dns_setup(account_name, zone_name)
                 except APIError as e:
                     logger.error(f"API error in view: {str(e)}")
-                
+
                 if zone_id:
                     try:
                         record_response = self.dns_host_service.create_record(zone_id, record_data)
@@ -794,6 +796,7 @@ class PrototypeDomainDNSRecordView(DomainFormBaseView):
                 if errors:
                     messages.error(request, f"Request errors: {errors}")
         return super().post(request)
+
 
 @grant_access(IS_DOMAIN_MANAGER, IS_STAFF_MANAGING_DOMAIN)
 class DomainNameserversView(DomainFormBaseView):

--- a/src/registrar/views/domain.py
+++ b/src/registrar/views/domain.py
@@ -52,7 +52,7 @@ from registrar.views.utility.invitation_helper import (
 )
 
 from registrar.services.cloudflare_service import CloudflareService
-from registrar.services.dns_hosting_service import DnsHostingService
+from registrar.services.dns_host_service import DnsHostService
 
 from ..forms import (
     SeniorOfficialContactForm,
@@ -712,7 +712,7 @@ class PrototypeDomainDNSRecordView(DomainFormBaseView):
     form_class = PrototypeDomainDNSRecordForm
     valid_domains = ["igorville.gov", "domainops.gov", "dns.gov", "dns1.gov", "dns2.gov", "dns3.gov"]
     dns_vendor_service = CloudflareService()
-    dns_hosting_service = DnsHostingService()
+    dns_hosting_service = DnsHostService()
 
     def has_permission(self):
         has_permission = super().has_permission()

--- a/src/registrar/views/domain.py
+++ b/src/registrar/views/domain.py
@@ -669,7 +669,7 @@ class DomainDNSView(DomainBaseView):
     """DNS Information View."""
 
     template_name = "domain_dns.html"
-    valid_domains = ["igorville.gov", "domainops.gov", "dns.gov", "dns1.gov", "dns2.gov", "dns3.gov", "address-argue-any.gov", "actually-among-role.gov"]
+    valid_domains = ["igorville.gov", "domainops.gov", "dns.gov", "dns1.gov", "dns2.gov"]
 
     def get_context_data(self, **kwargs):
         """Adds custom context."""
@@ -711,7 +711,7 @@ class PrototypeDomainDNSRecordForm(forms.Form):
 class PrototypeDomainDNSRecordView(DomainFormBaseView):
     template_name = "prototype_domain_dns.html"
     form_class = PrototypeDomainDNSRecordForm
-    valid_domains = ["igorville.gov", "domainops.gov", "dns.gov", "dns1.gov", "dns2.gov", "dns3.gov", "address-argue-any.gov", "actually-among-role.gov"]
+    valid_domains = ["igorville.gov", "domainops.gov", "dns.gov", "dns1.gov", "dns2.gov"]
     dns_vendor_service = CloudflareService()
     dns_host_service = DnsHostService()
 

--- a/src/registrar/views/domain.py
+++ b/src/registrar/views/domain.py
@@ -763,11 +763,12 @@ class PrototypeDomainDNSRecordView(DomainFormBaseView):
 
                 # Check (by name) to see if the account already exists
                 account_name = f"account-{self.object.name}"
+                zone_name = self.object.name # domain name
                 account_id = self.dns_host_service.find_existing_account(account_name)
                 # if the account doesn't exist, CREATE account and zone and create a record on that zone
                 if not account_id:
                     try:
-                        _, created_zone_id = self.dns_host_service.dns_setup(account_name)
+                        _, created_zone_id = self.dns_host_service.dns_setup(account_name, zone_name)
                     except APIError as e:
                      logger.error(f"API error in view: {str(e)}")
                 
@@ -782,7 +783,6 @@ class PrototypeDomainDNSRecordView(DomainFormBaseView):
 
                 # if an account already exists but the zone does not, create a zone.
                 if account_id:
-                    zone_name = self.object.name # domain name
                     zone_id = self.dns_host_service.find_existing_zone(zone_name)
 
                     if not zone_id:

--- a/src/registrar/views/domain.py
+++ b/src/registrar/views/domain.py
@@ -669,7 +669,7 @@ class DomainDNSView(DomainBaseView):
     """DNS Information View."""
 
     template_name = "domain_dns.html"
-    valid_domains = ["igorville.gov", "domainops.gov", "dns.gov", "dns1.gov", "dns2.gov"]
+    valid_domains = ["igorville.gov", "domainops.gov"]
 
     def get_context_data(self, **kwargs):
         """Adds custom context."""
@@ -711,7 +711,7 @@ class PrototypeDomainDNSRecordForm(forms.Form):
 class PrototypeDomainDNSRecordView(DomainFormBaseView):
     template_name = "prototype_domain_dns.html"
     form_class = PrototypeDomainDNSRecordForm
-    valid_domains = ["igorville.gov", "domainops.gov", "dns.gov", "dns1.gov", "dns2.gov"]
+    valid_domains = ["igorville.gov", "domainops.gov", "dns.gov"]
     dns_host_service = DnsHostService()
 
     def __init__(self):

--- a/src/registrar/views/domain.py
+++ b/src/registrar/views/domain.py
@@ -1,7 +1,6 @@
 from datetime import date
 import logging
 from contextvars import ContextVar
-import requests
 from django.contrib import messages
 from django.contrib.auth.mixins import PermissionRequiredMixin
 from django.contrib.messages.views import SuccessMessageMixin
@@ -52,7 +51,6 @@ from registrar.views.utility.invitation_helper import (
     handle_invitation_exceptions,
 )
 
-from registrar.services.cloudflare_service import CloudflareService
 from registrar.services.dns_host_service import DnsHostService
 
 from ..forms import (
@@ -714,7 +712,6 @@ class PrototypeDomainDNSRecordView(DomainFormBaseView):
     template_name = "prototype_domain_dns.html"
     form_class = PrototypeDomainDNSRecordForm
     valid_domains = ["igorville.gov", "domainops.gov", "dns.gov", "dns1.gov", "dns2.gov"]
-    dns_vendor_service = CloudflareService()
     dns_host_service = DnsHostService()
 
     def __init__(self):


### PR DESCRIPTION
## Ticket

<!-- PR title format: `#issue_number: Descriptive name ideally matching ticket name - [sandbox]`-->
Resolves #4006

## Changes

<!-- What was added, updated, or removed in this PR. -->
- Creates an external api `make_api_request` function and handling of errors
- Creates a CloudflareService that interacts with the cloudflare apis
- Creates a DnsHostService that calls the CloudflareService
- Updates `PrototypeDomainDNSRecordView` post method to call `DnsHostService` methods to create a Dns Record
- displays Dns Record response data to screen after success
- Establishes a new way to organize tests by nesting in a directory (`tests.service.test_dns_host_service`)

<!--
    Please add/remove/edit any of the template below to fit the needs
    of this specific PR.
--->

## Context for reviewers

<!--Background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers.  -->
- [PR](https://github.com/cisagov/manage.get.gov/pull/3189) with original prototype
- The main goal of this PR is to move business logic from the existing prototype into the two services. Much will evolve as we build, including security of the APIs. For now we are using a global key and email, which have to be established in Cloudflare. For this PR, I am using my email and associated key. Ask me for the required env't vars.
- Testing requires actually creating accounts, zones, and records in Cloudflare, so it will require some cleanup. TODO: create a cleanup function to remove created accounts after testing
- Error handling is very rough, and we'll need to establish a pattern and structure for what we return, as well as log. I'm also not sure if we want to be returning account ids in logs etc.
- tests organization- new pattern starting with service level. The intention is to later refactor the other tests to fall under `models`,`views` and `admin` directories respectively

## Setup

To manually test locally:

1. Add env't vars to your .env (REGISTRY_TENANT_KEY, REGISTRY_TEST_TENANT_NAME, REGISTRY_SERVICE_EMAIL, DOTGOV_TEST_TENANT_ID) talk to Kim
2. In Enterprise view, go to domains and find one for which you are a domain manager (look for "Manage" under "Action"). Go to that domain's detail page
3. Add (temporarily) that domain to the list of `valid_domains` in both the `DomainDNSView` and `PrototypeDomainDNSRecordView`. This will allow you to follow a link to a DNS Record page
4. Click on  "DNS" on the left nav menu
5. Click the link below DNSEC: "Prototype DNS record creator"
    
<img width="628" height="350" alt="image" src="https://github.com/user-attachments/assets/34fdd954-3284-4860-92c4-353ec8623989" />

6. At the form 'Add DNS records', add a domain name as "DNS record name", a valid IPv4 address (4 sets of numbers separated by `.` between 0-255)
7. Click "Add record"
<img width="618" height="603" alt="image" src="https://github.com/user-attachments/assets/f23f8fd5-d32f-4153-9622-2e08a7907ef0" />

8. You should see a success message. You will have created a new account and zone (check the logs)

10. Add another record. This time you should be using the same account/zone to which to add a record (check logs)

It's also possible to test in sandbox, but requires adding a new allowed domain each time one wants to test a new domain. Since this PR doesn't need a design review, I recommend engineers just test locally.

## Code Review Verification Steps

### As the original developer, I have

#### Satisfied acceptance criteria and met development standards

- [ ] Met the acceptance criteria, or will meet them in a subsequent PR
- [ ] Created/modified automated tests
- [ ] Update documentation in READMEs and/or onboarding guide

#### Ensured code standards are met (Original Developer)
<!-- Mark "- N/A" and check at the end of each check that is not applicable to your PR -->
- [ ] If any updated dependencies on Pipfile, also update dependencies in requirements.txt.
- [ ] Interactions with external systems are wrapped in try/except
- [ ] Error handling exists for unusual or missing values

#### Validated user-facing changes (if applicable)

- [ ] [Follow the process for requesting a design review](https://dhscisa.enterprise.slack.com/docs/T02QH7E1MHA/F06CZ6MRUKA). If code is not user-facing, delete design reviewer checklist
- [ ] Verify new pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Checked keyboard navigability
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)

### As a code reviewer, I have

#### Reviewed, tested, and left feedback about the changes

- [ ] Pulled this branch locally and tested it
- [ ] Verified code meets all checks above. Address any checks that are not satisfied
- [ ] Reviewed this code and left comments. Indicate if comments must be addressed before code is merged
- [ ] Checked that all code is adequately covered by tests
- [ ] Verify migrations are valid and do not conflict with existing migrations

#### Validated user-facing changes as a developer
**Note:** Multiple code reviewers can share the checklists above, a second reviewer should not make a duplicate checklist. All checks should be checked before approving, even those labeled N/A. 

- [ ] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Checked keyboard navigability
- [ ] Meets all designs and user flows provided by design/product
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)
- [ ] (Rarely needed) Tested as both an analyst and applicant user

### As a designer reviewer, I have

#### Verified that the changes match the design intention

- [ ] Checked that the design translated visually
- [ ] Checked behavior. Comment any found issues or broken flows.
- [ ] Checked different states (empty, one, some, error)
- [ ] Checked for landmarks, page heading structure, and links

#### Validated user-facing changes as a designer

- [ ] Checked keyboard navigability
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)
- [ ] Tested with multiple browsers (check off which ones were used)
  - [ ] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari
- [ ] (Rarely needed) Tested as both an analyst and applicant user

### References
- [Code review best practices](../docs/dev-practices/code_review.md)

## Screenshots

<img width="795" height="800" alt="image" src="https://github.com/user-attachments/assets/f4d28180-007b-4134-ab01-e292c0a9c946" />
