### PR TITLE
#5286 - Display members tab when in a managed domain in subpages

### DIFF
--- a/src/registrar/templates/domain_detail.html
+++ b/src/registrar/templates/domain_detail.html
@@ -48,9 +48,9 @@
                 This domain will expire soon.
                 {% url 'domain-renewal' domain_pk=domain.id as url %}
                 <a href="{{ url }}" class="usa-link">Renew to maintain access.</a>
-              {% elif domain.is_expiring and is_portfolio_user %}
+              {% elif domain.is_expiring and can_access_domain_via_portfolio %}
                 This domain will expire soon. Contact one of the listed domain managers to renew the domain.
-              {% elif domain.is_expired and is_portfolio_user %}
+              {% elif domain.is_expired and can_access_domain_via_portfolio %}
                 This domain has expired, but it is still online. Contact one of the listed domain managers to renew the domain.
               {% else %}
                 {{ domain.get_state_help_text }}
@@ -64,7 +64,7 @@
     {% include "includes/domain_dates.html" %}
 
     {% if analyst_action != 'edit' or analyst_action_location != domain.pk %}
-      {% if is_portfolio_user and not is_domain_manager %}
+      {% if can_access_domain_via_portfolio and not is_domain_manager %}
       <div class="usa-alert usa-alert--info usa-alert--slim">
         <div class="usa-alert__body">
           {% if not is_portfolio_admin %}

--- a/src/registrar/templates/domain_renewal.html
+++ b/src/registrar/templates/domain_renewal.html
@@ -44,7 +44,7 @@
     {% include "includes/summary_item.html" with title='Your contact information' value=request.user edit_link=url editable=is_editable  contact='true' %}
   
     {% if analyst_action != 'edit' or analyst_action_location != domain.pk %}
-      {% if is_portfolio_user and not is_domain_manager %}
+      {% if can_access_domain_via_portfolio and not is_domain_manager %}
       <div class="usa-alert usa-alert--info usa-alert--slim">
         <div class="usa-alert__body">
           <p class="usa-alert__text ">

--- a/src/registrar/views/domain.py
+++ b/src/registrar/views/domain.py
@@ -156,7 +156,7 @@ class DomainBaseView(PermissionRequiredMixin, DetailView):
             "registrar.full_access_permission"
         )
         context["is_domain_manager"] = UserDomainRole.objects.filter(user=user, domain=self.object).exists()
-        context["is_portfolio_user"] = self.can_access_domain_via_portfolio(self.object.pk)
+        context["can_access_domain_via_portfolio"] = self.can_access_domain_via_portfolio(self.object.pk)
         context["is_editable"] = self.is_editable()
         context["domain_deletion_flag"] = flag_is_active_for_user(user, "domain_deletion")
         context["domain_is_expiring_or_expired"] = domain.is_expiring() or domain.is_expired()


### PR DESCRIPTION
## Ticket

<!-- PR title format: `#issue_number: Descriptive name ideally matching ticket name - [sandbox]`-->
Resolves #5286 

## Changes + Context for reviewers

Previously, when you went to "Manage" a domain, and click on any of the subpages (everything except for "Domain overview", the "Members" option in the top nav disappeared.

What had happened was that two variables had the same name by accident (`is_portfolio_user`). 

In `context_processors.py` which is global, `is_portfolio_user` meant that "is the user a portfolio user at all", and was used to show the Members tab in nav

In `domain.py` this one is supposed to be domain specific, as in "can this user access this domain via their portfolio". I've now renamed it to be `can_access_domain_via_portfolio`

One was silently overwriting the other, since it ran after and shared the same name. Ask me how much hair I lost to discover this 🤣 

## Setup

1. In a portfolio, go to any domain you manage
2. Click into any of the subpages (DNS, Security email, etc) and you should now see the "Members" option in the top nav.

## Code Review Verification Steps

### As the original developer, I have

#### Satisfied acceptance criteria and met development standards

- [ ] Met the acceptance criteria, or will meet them in a subsequent PR
- [ ] Created/modified automated tests
- [ ] Update documentation in READMEs and/or onboarding guide

#### Ensured code standards are met (Original Developer)
<!-- Mark "- N/A" and check at the end of each check that is not applicable to your PR -->
- [ ] If any updated dependencies on Pipfile, also update dependencies in requirements.txt.
- [ ] Interactions with external systems are wrapped in try/except
- [ ] Error handling exists for unusual or missing values

#### Validated user-facing changes (if applicable)

- [ ] [Follow the process for requesting a design review](https://dhscisa.enterprise.slack.com/docs/T02QH7E1MHA/F06CZ6MRUKA). If code is not user-facing, delete design reviewer checklist
- [ ] Verify new pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Checked keyboard navigability
- [ ] Reviewed [accessibility checklist](https://github.com/cisagov/manage.get.gov/blob/main/docs/dev-practices/code_review.md#accessibility-checklist) using screen reader (such as NVDA with Chrome or Voiceover with Safari), ANDI, or WAVE:
  - [ ] Tested general usability
  - [ ] Page header structure
  - [ ] Landmarks
  - [ ] Links and buttons
- [ ] Checked for errors or warnings with an a11y browser tool (such as ANDI or WAVE)

### As a code reviewer, I have

#### Reviewed, tested, and left feedback about the changes

- [ ] Pulled this branch locally and tested it
- [ ] Verified code meets all checks above. Address any checks that are not satisfied
- [ ] Reviewed this code and left comments. Indicate if comments must be addressed before code is merged
- [ ] Checked that all code is adequately covered by tests
- [ ] Verify migrations are valid and do not conflict with existing migrations

#### Validated user-facing changes as a developer
**Note:** Multiple code reviewers can share the checklists above, a second reviewer should not make a duplicate checklist. All checks should be checked before approving, even those labeled N/A.

- [ ] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Meets all designs and user flows provided by design/product
- [ ] Checked keyboard navigability
- [ ] Reviewed [accessibility checklist](https://github.com/cisagov/manage.get.gov/blob/main/docs/dev-practices/code_review.md#accessibility-checklist) using screen reader (such as NVDA with Chrome or Voiceover with Safari), ANDI, or WAVE:
  - [ ] Tested general usability
  - [ ] Page header structure
  - [ ] Landmarks
  - [ ] Links and buttons
- [ ] Checked for errors or warnings with an a11y browser tool (such as ANDI or WAVE)
- [ ] (Rarely needed) Tested as both an analyst and applicant user

### As a designer reviewer, I have

#### Verified that the changes match the design intention

- [ ] Checked that the design translated visually
- [ ] Checked behavior. Comment any found issues or broken flows.
- [ ] Checked different states (empty, one, some, error)
- [ ] Checked for landmarks, page heading structure, and links

#### Validated user-facing changes as a designer

- [ ] Checked keyboard navigability
- [ ] Reviewed [accessibility checklist](https://github.com/cisagov/manage.get.gov/blob/main/docs/dev-practices/code_review.md#accessibility-checklist) using screen reader (such as NVDA with Chrome or Voiceover with Safari), ANDI, or WAVE:
  - [ ] Tested general usability
  - [ ] Page header structure
  - [ ] Landmarks
  - [ ] Links and buttons
- [ ] Checked for errors or warnings with an a11y browser tool (such as ANDI or WAVE)
- [ ] Tested with multiple browsers (check off which ones were used)
  - [ ] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari
- [ ] (Rarely needed) Tested as both an analyst and applicant user

### References
- [Code review best practices](../docs/dev-practices/code_review.md)

## Screenshots

<!-- If this PR makes visible interface changes, an image of the finished interface can help reviewers
and casual observers understand the context of the changes.
A before image is optional and can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow.
You may want to use [GIPHY Capture](https://giphy.com/apps/giphycapture) for this! 📸

_Please frame images to show useful context but also highlight the affected regions._
--->
