### PR TITLE
#5028: Hide DNSSEC and DS data page for DNS-enrolled domains [none]

### DIFF
--- a/src/registrar/templates/domain_detail.html
+++ b/src/registrar/templates/domain_detail.html
@@ -96,13 +96,13 @@
           {% include "includes/summary_item.html" with title='DNS name servers' domains='true' value='' edit_link=url editable=is_editable %}
         {% endif %}
       {% endif %}
-    {% endif %}
 
-    {% url 'domain-dns-dnssec' domain_pk=domain.id as url %}
-    {% if domain.dnssecdata is not None %}
-      {% include "includes/summary_item.html" with title='DNSSEC' value='Enabled' edit_link=url editable=is_editable %}
-    {% else %}
-      {% include "includes/summary_item.html" with title='DNSSEC' value='Not enabled' edit_link=url editable=is_editable %}
+      {% url 'domain-dns-dnssec' domain_pk=domain.id as url %}
+      {% if domain.dnssecdata is not None %}
+        {% include "includes/summary_item.html" with title='DNSSEC' value='Enabled' edit_link=url editable=is_editable %}
+      {% else %}
+        {% include "includes/summary_item.html" with title='DNSSEC' value='Not enabled' edit_link=url editable=is_editable %}
+      {% endif %}
     {% endif %}
 
     {% if portfolio %}

--- a/src/registrar/templates/domain_dns.html
+++ b/src/registrar/templates/domain_dns.html
@@ -47,7 +47,6 @@
       </h2>
       <p class="margin-top-0 margin-bottom-0">Review, add, and edit DNS nameservers.</p>
     </li>
-    {% endif %}
 
     <li>
       {% url 'domain-dns-dnssec' domain_pk=domain.id as url %}
@@ -63,6 +62,7 @@
       </h2>
       <p class="margin-top-0 margin-bottom-0">Enable digital signatures to DNS records.</p>
     </li>
+    {% endif %}
   </ul>
 
 {% endblock %}  {# domain_content #}

--- a/src/registrar/templates/domain_sidebar.html
+++ b/src/registrar/templates/domain_sidebar.html
@@ -45,7 +45,7 @@
           </li>
           {% endif %}
 
-
+          {% if not dns_hosting or not domain.is_enrolled_in_dns_hosting %}
           <li class="usa-sidenav__item">
             {% url 'domain-dns-dnssec' domain_pk=domain.id as url %}
             <a href="{{ url }}"
@@ -68,6 +68,8 @@
               {% endif %}
             {% endif %}
           </li>
+          {% endif %}
+
         </ul>
         {% endif %}
       </li>

--- a/src/registrar/tests/test_views_domain.py
+++ b/src/registrar/tests/test_views_domain.py
@@ -1750,15 +1750,19 @@ class TestDomainNameservers(TestDomainOverview, MockEppLib):
             self.assertContains(page, "DNS name servers")
 
     @override_flag("dns_hosting", active=False)
-    def test_domain_nameservers_found_when_dns_hosting_flag_disabled_and_domain_enrolled_in_dns_hosting(self):
+    def test_domain_nameservers_dnssec_found_when_dns_hosting_flag_disabled_and_domain_enrolled_in_dns_hosting(self):
         """Can load domain's nameservers, DNSSEC, and DS data page when dns hosting flag is disabled
         and domain is enrolled in dns hosting.
         """
         with override_flag("dns_hosting", active=False):
-            page = self.client.get(
-                reverse("domain-dns-nameservers", kwargs={"domain_pk": self.domain_enrolled_in_dns_hosting.id})
-            )
-            self.assertContains(page, "DNS name servers")
+            for view_page, page_title in [
+                ("domain-dns-nameservers", "DNS name servers"),
+                ("domain-dns-dnssec", "DNSSEC"),
+            ]:
+                page = self.client.get(
+                    reverse(view_page, kwargs={"domain_pk": self.domain_enrolled_in_dns_hosting.id})
+                )
+                self.assertContains(page, page_title)
 
     @less_console_noise_decorator
     def test_domain_nameservers_form_submit_one_nameserver(self):

--- a/src/registrar/tests/test_views_domain.py
+++ b/src/registrar/tests/test_views_domain.py
@@ -428,9 +428,10 @@ class TestDomainDetail(TestDomainOverview):
     @override_flag("dns_hosting", active=True)
     def test_domain_detail_no_nameserver_info_when_enrolled_in_dns_hosting(self):
         with less_console_noise():
-            # Views DNS record and does not view nameserver on Domain Overview page
+            # Views DNS record and does not view nameservers or DNSSEC on Domain Overview page
             detail_page = self.app.get(reverse("domain", kwargs={"domain_pk": self.domain_enrolled_in_dns_hosting.id}))
             self.assertNotContains(detail_page, "DNS name servers")
+            self.assertNotContains(detail_page, "DNSSEC")
 
     def test_domain_detail_show_nameserver_info_when_enrolled_in_dns_hosting_but_feature_flag_disabled(self):
         with less_console_noise() and override_flag("dns_hosting", active=False):
@@ -438,6 +439,7 @@ class TestDomainDetail(TestDomainOverview):
             detail_page = self.app.get(reverse("domain", kwargs={"domain_pk": self.domain_enrolled_in_dns_hosting.id}))
 
             self.assertContains(detail_page, "DNS name servers")
+            self.assertContains(detail_page, "DNSSEC")
 
     def test_domain_detail_with_no_information_or_domain_request(self):
         """Test that domain management page returns 200 and displays error

--- a/src/registrar/tests/test_views_domain.py
+++ b/src/registrar/tests/test_views_domain.py
@@ -1708,16 +1708,21 @@ class TestDomainNameservers(TestDomainOverview, MockEppLib):
         page = self.client.get(reverse("domain-dns-nameservers", kwargs={"domain_pk": self.domain.id}))
         self.assertContains(page, "DNS name servers")
 
-    def test_domain_nameservers_redirects_when_dns_hosting_flag_enabled_and_enrolled(self):
+    def test_domain_nameservers_dnssec_dsdata_redirects_when_dns_hosting_flag_enabled_and_enrolled(self):
         """Cannot load domain's nameservers page. Redirects to dns records page instead."""
         with override_flag("dns_hosting", active=True):
-            response = self.client.get(
-                reverse("domain-dns-nameservers", kwargs={"domain_pk": self.domain_enrolled_in_dns_hosting.id})
-            )
-            self.assertRedirects(
-                response,
-                reverse("domain-dns-records", kwargs={"domain_pk": self.domain_enrolled_in_dns_hosting.id}),
-            )
+            for view_name in [
+                "domain-dns-nameservers",
+                "domain-dns-dnssec",
+                "domain-dns-dnssec-dsdata",
+            ]:
+                response = self.client.get(
+                    reverse(view_name, kwargs={"domain_pk": self.domain_enrolled_in_dns_hosting.id})
+                )
+                self.assertRedirects(
+                    response,
+                    reverse("domain-dns-records", kwargs={"domain_pk": self.domain_enrolled_in_dns_hosting.id}),
+                )
 
     def test_domain_nameservers_when_dns_hosting_flag_enabled_and_not_enrolled(self):
         """Cannot load domain's nameservers page."""
@@ -1727,7 +1732,7 @@ class TestDomainNameservers(TestDomainOverview, MockEppLib):
 
     @override_flag("dns_hosting", active=False)
     def test_domain_nameservers_found_when_dns_hosting_flag_disabled_and_domain_enrolled_in_dns_hosting(self):
-        """Can load domain's nameservers page when dns hosting flag is disabled
+        """Can load domain's nameservers, DNSSEC, and DS data page when dns hosting flag is disabled
         and domain is enrolled in dns hosting.
         """
         with override_flag("dns_hosting", active=False):
@@ -3758,6 +3763,7 @@ class TestDomainDns(TestWithSharedDomainPermissions, WebTest):
         page = self.client.get(reverse("domain-dns", kwargs={"domain_pk": self.domain_enrolled_in_dns_hosting.id}))
         self.assertNotContains(page, "Name servers")
         self.assertContains(page, "DNS Records")
+        self.assertNotComtains(page, "DNSSEC")
 
     @override_flag("dns_hosting", active=False)
     def test_domain_dns_when_dns_hosting_flag_is_disabled_and_enrolled_in_dns_hosting(self):
@@ -3772,6 +3778,7 @@ class TestDomainDns(TestWithSharedDomainPermissions, WebTest):
         page = self.client.get(reverse("domain-dns", kwargs={"domain_pk": self.domain_enrolled_in_dns_hosting.id}))
         self.assertContains(page, "Name servers")
         self.assertNotContains(page, "DNS Records")
+        self.assertContains(page, "DNSSEC")
 
 
 class TestDomainDnsRecords(TestWithSharedDomainPermissions, WebTest):

--- a/src/registrar/tests/test_views_domain.py
+++ b/src/registrar/tests/test_views_domain.py
@@ -2194,7 +2194,7 @@ class TestDomainNameservers(TestDomainOverview, MockEppLib):
 class TestDomainDNSPagesNonenrolledDomains(TestDomainOverview):
     def test_domain_dns_redirects_when_dns_hosting_flag_enabled_and_enrolled(self):
         """
-        When DNS hosting flag is off, cannot load domain's nameservers, DNSSEC, or DS data page. 
+        When DNS hosting flag is off, cannot load domain's nameservers, DNSSEC, or DS data page.
         Redirects to dns records page instead."""
         with override_flag("dns_hosting", active=True):
             for view_name in [
@@ -2209,7 +2209,7 @@ class TestDomainDNSPagesNonenrolledDomains(TestDomainOverview):
                     response,
                     reverse("domain-dns-records", kwargs={"domain_pk": self.domain_enrolled_in_dns_hosting.id}),
                 )
-    
+
     @override_flag("dns_hosting", active=False)
     def test_domain_nameservers_dnssec_found_when_dns_hosting_flag_disabled_and_domain_enrolled_in_dns_hosting(self):
         """Can load domain's nameservers, DNSSEC, and DS data pages when dns hosting flag is disabled
@@ -2221,9 +2221,7 @@ class TestDomainDNSPagesNonenrolledDomains(TestDomainOverview):
                 ("domain-dns-dnssec", "DNSSEC"),
                 ("domain-dns-dnssec-dsdata", "DS data"),
             ]:
-                page = self.client.get(
-                    reverse(view_page, kwargs={"domain_pk": self.domain_enrolled_in_dns_hosting.id})
-                )
+                page = self.client.get(reverse(view_page, kwargs={"domain_pk": self.domain_enrolled_in_dns_hosting.id}))
                 self.assertContains(page, page_title)
 
 

--- a/src/registrar/tests/test_views_domain.py
+++ b/src/registrar/tests/test_views_domain.py
@@ -426,16 +426,16 @@ class TestDomainDetail(TestDomainOverview):
             self.assertContains(detail_page, "2.3.4.5)")
 
     @override_flag("dns_hosting", active=True)
-    def test_domain_detail_no_nameserver_info_when_enrolled_in_dns_hosting(self):
+    def test_domain_detail_no_external_dns_info_when_enrolled_in_dns_hosting(self):
         with less_console_noise():
             # Views DNS record and does not view nameservers or DNSSEC on Domain Overview page
             detail_page = self.app.get(reverse("domain", kwargs={"domain_pk": self.domain_enrolled_in_dns_hosting.id}))
             self.assertNotContains(detail_page, "DNS name servers")
             self.assertNotContains(detail_page, "DNSSEC")
 
-    def test_domain_detail_show_nameserver_info_when_enrolled_in_dns_hosting_but_feature_flag_disabled(self):
+    def test_domain_detail_show_external_dns_info_when_enrolled_in_dns_hosting_but_feature_flag_disabled(self):
         with less_console_noise() and override_flag("dns_hosting", active=False):
-            # Does not view dns record and not nameserver on Domain Overview page
+            # Displays dns nameservers and DNSSEC pages on Domain Overview page
             detail_page = self.app.get(reverse("domain", kwargs={"domain_pk": self.domain_enrolled_in_dns_hosting.id}))
 
             self.assertContains(detail_page, "DNS name servers")
@@ -2192,7 +2192,7 @@ class TestDomainNameservers(TestDomainOverview, MockEppLib):
 
 
 class TestDomainDNSPagesNonenrolledDomains(TestDomainOverview):
-    def test_domain_dns_redirects_when_dns_hosting_flag_enabled_and_enrolled(self):
+    def test_domain_external_dns_pages_redirect_when_dns_hosting_flag_enabled_and_enrolled(self):
         """
         When DNS hosting flag is off, cannot load domain's nameservers, DNSSEC, or DS data page.
         Redirects to dns records page instead."""
@@ -2211,7 +2211,7 @@ class TestDomainDNSPagesNonenrolledDomains(TestDomainOverview):
                 )
 
     @override_flag("dns_hosting", active=False)
-    def test_domain_nameservers_dnssec_found_when_dns_hosting_flag_disabled_and_domain_enrolled_in_dns_hosting(self):
+    def test_domain_loads_external_dns_pages_when_dns_hosting_flag_disabled_and_domain_enrolled_in_dns_hosting(self):
         """Can load domain's nameservers, DNSSEC, and DS data pages when dns hosting flag is disabled
         and domain is enrolled in dns hosting.
         """

--- a/src/registrar/tests/test_views_domain.py
+++ b/src/registrar/tests/test_views_domain.py
@@ -1727,42 +1727,11 @@ class TestDomainNameservers(TestDomainOverview, MockEppLib):
         page = self.client.get(reverse("domain-dns-nameservers", kwargs={"domain_pk": self.domain.id}))
         self.assertContains(page, "DNS name servers")
 
-    def test_domain_nameservers_dnssec_dsdata_redirects_when_dns_hosting_flag_enabled_and_enrolled(self):
-        """Cannot load domain's nameservers page. Redirects to dns records page instead."""
-        with override_flag("dns_hosting", active=True):
-            for view_name in [
-                "domain-dns-nameservers",
-                "domain-dns-dnssec",
-                "domain-dns-dnssec-dsdata",
-            ]:
-                response = self.client.get(
-                    reverse(view_name, kwargs={"domain_pk": self.domain_enrolled_in_dns_hosting.id})
-                )
-                self.assertRedirects(
-                    response,
-                    reverse("domain-dns-records", kwargs={"domain_pk": self.domain_enrolled_in_dns_hosting.id}),
-                )
-
     def test_domain_nameservers_when_dns_hosting_flag_enabled_and_not_enrolled(self):
         """Cannot load domain's nameservers page."""
         with override_flag("dns_hosting", active=True):
             page = self.client.get(reverse("domain-dns-nameservers", kwargs={"domain_pk": self.domain.id}))
             self.assertContains(page, "DNS name servers")
-
-    @override_flag("dns_hosting", active=False)
-    def test_domain_nameservers_dnssec_found_when_dns_hosting_flag_disabled_and_domain_enrolled_in_dns_hosting(self):
-        """Can load domain's nameservers, DNSSEC, and DS data page when dns hosting flag is disabled
-        and domain is enrolled in dns hosting.
-        """
-        with override_flag("dns_hosting", active=False):
-            for view_page, page_title in [
-                ("domain-dns-nameservers", "DNS name servers"),
-                ("domain-dns-dnssec", "DNSSEC"),
-            ]:
-                page = self.client.get(
-                    reverse(view_page, kwargs={"domain_pk": self.domain_enrolled_in_dns_hosting.id})
-                )
-                self.assertContains(page, page_title)
 
     @less_console_noise_decorator
     def test_domain_nameservers_form_submit_one_nameserver(self):
@@ -2220,6 +2189,42 @@ class TestDomainNameservers(TestDomainOverview, MockEppLib):
             count=2,
             status_code=200,
         )
+
+
+class TestDomainDNSPagesNonenrolledDomains(TestDomainOverview):
+    def test_domain_dns_redirects_when_dns_hosting_flag_enabled_and_enrolled(self):
+        """
+        When DNS hosting flag is off, cannot load domain's nameservers, DNSSEC, or DS data page. 
+        Redirects to dns records page instead."""
+        with override_flag("dns_hosting", active=True):
+            for view_name in [
+                "domain-dns-nameservers",
+                "domain-dns-dnssec",
+                "domain-dns-dnssec-dsdata",
+            ]:
+                response = self.client.get(
+                    reverse(view_name, kwargs={"domain_pk": self.domain_enrolled_in_dns_hosting.id})
+                )
+                self.assertRedirects(
+                    response,
+                    reverse("domain-dns-records", kwargs={"domain_pk": self.domain_enrolled_in_dns_hosting.id}),
+                )
+    
+    @override_flag("dns_hosting", active=False)
+    def test_domain_nameservers_dnssec_found_when_dns_hosting_flag_disabled_and_domain_enrolled_in_dns_hosting(self):
+        """Can load domain's nameservers, DNSSEC, and DS data pages when dns hosting flag is disabled
+        and domain is enrolled in dns hosting.
+        """
+        with override_flag("dns_hosting", active=False):
+            for view_page, page_title in [
+                ("domain-dns-nameservers", "DNS name servers"),
+                ("domain-dns-dnssec", "DNSSEC"),
+                ("domain-dns-dnssec-dsdata", "DS data"),
+            ]:
+                page = self.client.get(
+                    reverse(view_page, kwargs={"domain_pk": self.domain_enrolled_in_dns_hosting.id})
+                )
+                self.assertContains(page, page_title)
 
 
 class TestDomainSeniorOfficial(TestDomainOverview):

--- a/src/registrar/tests/test_views_domain.py
+++ b/src/registrar/tests/test_views_domain.py
@@ -3789,7 +3789,7 @@ class TestDomainDns(TestWithSharedDomainPermissions, WebTest):
         page = self.client.get(reverse("domain-dns", kwargs={"domain_pk": self.domain_enrolled_in_dns_hosting.id}))
         self.assertNotContains(page, "Name servers")
         self.assertContains(page, "DNS Records")
-        self.assertNotComtains(page, "DNSSEC")
+        self.assertNotContains(page, "DNSSEC")
 
     @override_flag("dns_hosting", active=False)
     def test_domain_dns_when_dns_hosting_flag_is_disabled_and_enrolled_in_dns_hosting(self):

--- a/src/registrar/views/domain.py
+++ b/src/registrar/views/domain.py
@@ -140,6 +140,15 @@ class DomainBaseView(PermissionRequiredMixin, DetailView):
             self.object = self.get_object()
         self._update_session_with_domain()
 
+    def _get_domain_force_reset_cache(self, request):
+        """
+        Get domain and always reset the cache for the domain object.
+        Used to get domain and reset cache in Nameservers, DNSSEC, and DS Data views.
+        """
+        self.session = request.session
+        self.object = self.get_object()
+        self._update_session_with_domain()
+
     def _update_session_with_domain(self):
         """
         update domain in the session cache
@@ -1160,17 +1169,8 @@ class DomainNameserversView(DomainFormBaseView):
     form_class = NameserverFormset
     model = Domain
 
-    def _get_domain(self, request):
-        """
-        override get_domain for this view so that domain overview
-        always resets the cache for the domain object
-        """
-        self.session = request.session
-        self.object = self.get_object()
-        self._update_session_with_domain()
-
     def dispatch(self, request, *args, **kwargs):
-        self._get_domain(
+        self._get_domain_force_reset_cache(
             request
         )  # Ensure the domain is reset in the session cache. Sets self.object to the domain object.
 
@@ -1308,6 +1308,19 @@ class DomainDNSSECView(DomainFormBaseView):
 
     template_name = "domain_dnssec.html"
     form_class = DomainDnssecForm
+    model = Domain
+
+    def dispatch(self, request, *args, **kwargs):
+        self._get_domain_force_reset_cache(
+            request
+        )  # Ensure the domain is reset in the session cache. Sets self.object to the domain object.
+
+        if flag_is_active(request, "dns_hosting") and self.object.is_enrolled_in_dns_hosting:
+            logger.info("Domain is enrolled in DNS hosting. DNSSEC cannot be edited in this case.")
+            redirect_url = reverse("domain-dns-records", kwargs={"domain_pk": self.object.pk})
+            return redirect(redirect_url)
+
+        return super().dispatch(request, *args, **kwargs)
 
     def get_breadcrumb_items(self):
         return [{"label": "DNS", "url": reverse("domain-dns", kwargs={"domain_pk": self.object.id})}]
@@ -1360,6 +1373,19 @@ class DomainDsDataView(DomainFormBaseView):
     template_name = "domain_dsdata.html"
     form_class = DomainDsdataFormset
     form = DomainDsdataForm
+    model = Domain
+
+    def dispatch(self, request, *args, **kwargs):
+        self._get_domain_force_reset_cache(
+            request
+        )  # Ensure the domain is reset in the session cache. Sets self.object to the domain object.
+
+        if flag_is_active(request, "dns_hosting") and self.object.is_enrolled_in_dns_hosting:
+            logger.info("Domain is enrolled in DNS hosting. DNSSEC cannot be edited in this case.")
+            redirect_url = reverse("domain-dns-records", kwargs={"domain_pk": self.object.pk})
+            return redirect(redirect_url)
+
+        return super().dispatch(request, *args, **kwargs)
 
     def get_breadcrumb_items(self):
         return [


### PR DESCRIPTION
## Ticket

<!-- PR title format: `#issue_number: Descriptive name ideally matching ticket name - [sandbox]`-->
Resolves #5028

## Changes

<!-- What was added, updated, or removed in this PR. -->
- Removes DNSSEC from domain sidemenu, domain overview page, and domain DNS page when (1) dns_hosting flag is on and (2) domain is enrolled in DNS hosting
- When the dns_hosting flag is on and the domain is enrolled in DNS hosting, when a user tries to navigate to that domain's DNSSEC (`/domain/<id>/dns/dnssec`) or DS data page (`/domain/<id>/dns/dnssec/dsdata`), they are redirected to the domain's DNS records page

<!--
    Please add/remove/edit any of the template below to fit the needs
    of this specific PR.
--->

## Context for reviewers

<!--Background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers.  -->

## Setup

<!--  Add any steps or code to run in this section to help others run your code.

    Example 1:
    ```sh
    echo "Code goes here"
    ```

    Example 2: If the PR was to add a new link with a redirect, this section could simply be:
    -go to /path/to/start/page
    -click the blue link in the <insert location>
    -notice user is redirected to <proper end location>
-->
Prereq: Deploy this branch to a sandbox with test tenant access (`glacier`, `es`)

### 1. A domain's DNSSEC page and DS data page are not accessible when (1) dns_hosting flag is on and (2) domain is enrolled in DNS hosting.
1. Preconditions: Turn on the dns_hosting flag and manage a domain enrolled in DNS hosting. 
2. On the domain's Domain overview page, verify there is no DNSSEC section on the page. 
<img width="683" height="565" alt="image" src="https://github.com/user-attachments/assets/14dfc038-d0f5-454f-9fa7-6f55dbe63481" />
3. On the domain's DNS page, verify that there is no DNSSEC section on the DNS sidemenu navigation. Also verify there is no DNSSEC section on the domain's DNS page. 
<img width="979" height="419" alt="image" src="https://github.com/user-attachments/assets/43f55251-7c6a-46a0-8faf-d277b5e1b843" />
4. Manually navigate to a URL to try accessing the domain's DNSSEC page (`domain/<id>/dns/dnssec`) and DS data page (`domain/<id>/dns/dnssec/dsdata`). You should be redirected to the domain's DNS records page instead (`domain/<id>/dns/records`)

### 2. A domain's DNSSEC page and DS data page are not accessible when the two above conditions are not met.
Verify the following happens when:

- [ ] A domain is enrolled in DNS hosting BUT the dns_hosting flag is off.
- [ ] dns_hosting flag is on BUT a domain is not enrolled in DNS hosting.
- [ ] A domain is not enrolled in DNS hosting and the dns_hosting flag is off

1. On the domain's Domain overview page, verify the nameservers and DNSSEC sections display on the page
<img width="687" height="704" alt="image" src="https://github.com/user-attachments/assets/49d0b09a-5a45-47e1-9dc0-c0b7561f340f" />
2. On the domain's DNS page, verify that the Name servers and DNSSEC sections appear on the DNS sidemenu nav. Also verify they appear on the domain's DNS page.
<img width="898" height="479" alt="image" src="https://github.com/user-attachments/assets/33a13be1-31fd-427b-b85c-5296a47eac76" />
3. Navigate to the domain's DNSSEC page (`domain/<id>/dns/dnssec`) and DS data page (`domain/<id>/dns/dnssec/dsdata`). You should be directed to the the domain's DNSSEC and DS data pages respectively.



## Code Review Verification Steps

### As the original developer, I have

#### Satisfied acceptance criteria and met development standards

- [x] Met the acceptance criteria, or will meet them in a subsequent PR
- [x] Created/modified automated tests
- [ ] Update documentation in READMEs and/or onboarding guide

#### Ensured code standards are met (Original Developer)
<!-- Mark "- N/A" and check at the end of each check that is not applicable to your PR -->
- [ ] If any updated dependencies on Pipfile, also update dependencies in requirements.txt.
- [ ] Interactions with external systems are wrapped in try/except
- [ ] Error handling exists for unusual or missing values

#### Validated user-facing changes (if applicable)

- [ ] [Follow the process for requesting a design review](https://dhscisa.enterprise.slack.com/docs/T02QH7E1MHA/F06CZ6MRUKA). If code is not user-facing, delete design reviewer checklist
- [ ] Verify new pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Checked keyboard navigability
- [ ] Reviewed [accessibility checklist](https://github.com/cisagov/manage.get.gov/blob/main/docs/dev-practices/code_review.md#accessibility-checklist) using screen reader (such as NVDA with Chrome or Voiceover with Safari), ANDI, or WAVE:
  - [ ] Tested general usability
  - [ ] Page header structure
  - [ ] Landmarks
  - [ ] Links and buttons
- [ ] Checked for errors or warnings with an a11y browser tool (such as ANDI or WAVE)

### As a code reviewer, I have

#### Reviewed, tested, and left feedback about the changes

- [ ] Pulled this branch locally and tested it
- [ ] Verified code meets all checks above. Address any checks that are not satisfied
- [ ] Reviewed this code and left comments. Indicate if comments must be addressed before code is merged
- [ ] Checked that all code is adequately covered by tests
- [ ] Verify migrations are valid and do not conflict with existing migrations

#### Validated user-facing changes as a developer
**Note:** Multiple code reviewers can share the checklists above, a second reviewer should not make a duplicate checklist. All checks should be checked before approving, even those labeled N/A.

- [ ] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Meets all designs and user flows provided by design/product
- [ ] Checked keyboard navigability
- [ ] Reviewed [accessibility checklist](https://github.com/cisagov/manage.get.gov/blob/main/docs/dev-practices/code_review.md#accessibility-checklist) using screen reader (such as NVDA with Chrome or Voiceover with Safari), ANDI, or WAVE:
  - [ ] Tested general usability
  - [ ] Page header structure
  - [ ] Landmarks
  - [ ] Links and buttons
- [ ] Checked for errors or warnings with an a11y browser tool (such as ANDI or WAVE)
- [ ] (Rarely needed) Tested as both an analyst and applicant user

### As a designer reviewer, I have

#### Verified that the changes match the design intention

- [ ] Checked that the design translated visually
- [ ] Checked behavior. Comment any found issues or broken flows.
- [ ] Checked different states (empty, one, some, error)
- [ ] Checked for landmarks, page heading structure, and links

#### Validated user-facing changes as a designer

- [ ] Checked keyboard navigability
- [ ] Reviewed [accessibility checklist](https://github.com/cisagov/manage.get.gov/blob/main/docs/dev-practices/code_review.md#accessibility-checklist) using screen reader (such as NVDA with Chrome or Voiceover with Safari), ANDI, or WAVE:
  - [ ] Tested general usability
  - [ ] Page header structure
  - [ ] Landmarks
  - [ ] Links and buttons
- [ ] Checked for errors or warnings with an a11y browser tool (such as ANDI or WAVE)
- [ ] Tested with multiple browsers (check off which ones were used)
  - [ ] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari
- [ ] (Rarely needed) Tested as both an analyst and applicant user

### References
- [Code review best practices](../docs/dev-practices/code_review.md)

## Screenshots

<!-- If this PR makes visible interface changes, an image of the finished interface can help reviewers
and casual observers understand the context of the changes.
A before image is optional and can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow.
You may want to use [GIPHY Capture](https://giphy.com/apps/giphycapture) for this! 📸

_Please frame images to show useful context but also highlight the affected regions._
--->
