### PR TITLE
#5314: Ensure portfolio invite is sent from userdomainrole if necessary [cw]

### DIFF
--- a/src/registrar/admin.py
+++ b/src/registrar/admin.py
@@ -2547,7 +2547,7 @@ class UserDomainRoleAdmin(ListHeaderAdmin, ImportExportRegistrarModelAdmin):
 
         try:
             requested_user = get_requested_user(requested_email) if requested_email else None
-            member_of_a_different_org = self._save_portfolio_membership_invitation(
+            member_of_a_different_org = self._save_portfolio_membership(
                 request,
                 obj.domain,
                 requested_email,
@@ -2569,7 +2569,7 @@ class UserDomainRoleAdmin(ListHeaderAdmin, ImportExportRegistrarModelAdmin):
 
         return None
 
-    def _save_portfolio_membership_invitation(self, request, domain, requested_email, requested_user, form):
+    def _save_portfolio_membership(self, request, domain, requested_email, requested_user, form):
         try:
             domain_org = getattr(domain.domain_info, "portfolio", None)
         except ObjectDoesNotExist:
@@ -2584,31 +2584,31 @@ class UserDomainRoleAdmin(ListHeaderAdmin, ImportExportRegistrarModelAdmin):
                 requested_user,
             )
 
-        if not self._should_send_portfolio_membership_email(
+        if not self._should_create_portfolio_membership(
             request,
             domain_org,
             member_of_a_different_org,
             member_of_this_org,
-            form,
-            requested_user,
         ):
             return member_of_a_different_org
 
+        send_email = self._will_send_invitation_email(form, requested_user)
         if self._use_portfolio_permission_invitation_admin(request):
             create_portfolio_permission_or_invitation(
                 email=requested_email,
                 portfolio=domain_org,
                 requestor=request.user,
                 roles=[UserPortfolioRoleChoices.ORGANIZATION_MEMBER],
-                send_email=True,
+                send_email=send_email,
             )
         else:
-            send_portfolio_invitation_email(
-                email=requested_email,
-                requestor=request.user,
-                portfolio=domain_org,
-                is_admin_invitation=False,
-            )
+            if send_email:
+                send_portfolio_invitation_email(
+                    email=requested_email,
+                    requestor=request.user,
+                    portfolio=domain_org,
+                    is_admin_invitation=False,
+                )
             portfolio_invitation, _ = PortfolioInvitation.objects.get_or_create(
                 email=requested_email,
                 portfolio=domain_org,
@@ -2624,31 +2624,20 @@ class UserDomainRoleAdmin(ListHeaderAdmin, ImportExportRegistrarModelAdmin):
     def _use_portfolio_permission_invitation_admin(self, request):
         return flag_is_active(request, "user_portfolio_permission_invitations")
 
-    def _should_send_portfolio_membership_email(
+    def _should_create_portfolio_membership(
         self,
         request,
         domain_org,
         member_of_a_different_org,
         member_of_this_org,
-        form,
-        requested_user,
     ):
-        if not self._will_send_invitation_email(form, requested_user):
-            return False
-
-        if not request.user.is_org_user(request):
-            return False
-
-        if flag_is_active(request, "multiple_portfolios"):
-            return False
-
         if domain_org is None:
             return False
 
         if member_of_this_org:
             return False
 
-        if member_of_a_different_org:
+        if member_of_a_different_org and not flag_is_active(request, "multiple_portfolios"):
             return False
 
         return True
@@ -2951,11 +2940,9 @@ class DomainInvitationAdmin(BaseInvitationAdmin):
                 )
 
                 if (
-                    request.user.is_org_user(request)
-                    and not flag_is_active(request, "multiple_portfolios")
+                    (flag_is_active(request, "multiple_portfolios") or not member_of_a_different_org)
                     and domain_org is not None
                     and not member_of_this_org
-                    and not member_of_a_different_org
                 ):
                     send_portfolio_invitation_email(
                         email=requested_email, requestor=requestor, portfolio=domain_org, is_admin_invitation=False

--- a/src/registrar/tests/test_admin.py
+++ b/src/registrar/tests/test_admin.py
@@ -1660,6 +1660,65 @@ class TestUserDomainRoleInvitationAdmin(TestCase):
         mock_send_domain_email.assert_not_called()
         mock_send_portfolio_email.assert_not_called()
 
+    @less_console_noise_decorator
+    @override_flag("multiple_portfolios", active=True)
+    @override_flag("user_domain_role_invitations", active=True)
+    @override_flag("user_portfolio_permission_invitations", active=True)
+    @patch("registrar.services.invitation_service.send_domain_invitation_email")
+    @patch("registrar.services.invitation_service.send_portfolio_invitation_email")
+    @patch("django.contrib.messages.success")
+    def test_analyst_save_existing_portfolio_member_with_email_sends_only_domain_email(
+        self,
+        mock_messages_success,
+        mock_send_portfolio_email,
+        mock_send_domain_email,
+    ):
+        admin_instance = UserDomainRoleAdmin(UserDomainRole, admin_site=AdminSite())
+        analyst = create_omb_analyst_user()
+        models.AllowedEmail.objects.create(email=self.testuser.email)
+        UserPortfolioPermission.objects.create(
+            user=self.testuser,
+            portfolio=self.portfolio,
+            roles=[UserPortfolioRoleChoices.ORGANIZATION_MEMBER],
+            status=UserPortfolioPermission.Status.ACCEPTED,
+        )
+        form = UserDomainRoleForm(
+            data={
+                "user": self.testuser.email,
+                "domain": self.domain.id,
+                "send_email": "on",
+            }
+        )
+        self.assertTrue(form.is_valid(), form.errors)
+        role = form.save(commit=False)
+        request = self.factory.post("/admin/registrar/userdomainrole/add/")
+        request.user = analyst
+        request.session = SessionStore()
+
+        admin_instance.save_model(request, role, form, False)
+
+        role.refresh_from_db()
+        self.assertEqual(role.user, self.testuser)
+        self.assertEqual(role.status, UserDomainRole.Status.ACCEPTED)
+        self.assertEqual(role.invited_by, analyst)
+        self.assertEqual(
+            UserPortfolioPermission.objects.filter(user=self.testuser, portfolio=self.portfolio).count(),
+            1,
+        )
+        mock_send_domain_email.assert_called_once_with(
+            email=self.testuser.email,
+            requestor=analyst,
+            domains=self.domain,
+            is_member_of_different_org=None,
+            requested_user=self.testuser,
+            skip_existing_invitation_check=True,
+        )
+        mock_send_portfolio_email.assert_not_called()
+        mock_messages_success.assert_called_once_with(
+            request,
+            f"{self.testuser.email} has been added to the domain: {self.domain}",
+        )
+
     @override_flag("user_domain_role_invitations", active=False)
     @patch("registrar.admin.create_domain_role_or_invitation")
     def test_save_with_invitation_flag_off_uses_direct_model_save(self, mock_create_role):

--- a/src/registrar/tests/test_admin.py
+++ b/src/registrar/tests/test_admin.py
@@ -1518,9 +1518,16 @@ class TestUserDomainRoleInvitationAdmin(TestCase):
 
     @less_console_noise_decorator
     @override_flag("user_domain_role_invitations", active=True)
+    @override_flag("user_portfolio_permission_invitations", active=True)
     @patch("registrar.services.invitation_service.send_domain_invitation_email")
+    @patch("registrar.services.invitation_service.send_portfolio_invitation_email")
     @patch("django.contrib.messages.success")
-    def test_save_unknown_email_forces_invitation_email(self, mock_messages_success, mock_send_email):
+    def test_save_unknown_email_forces_invitation_email(
+        self,
+        mock_messages_success,
+        mock_send_portfolio_email,
+        mock_send_domain_email,
+    ):
         admin_instance = UserDomainRoleAdmin(UserDomainRole, admin_site=AdminSite())
         models.AllowedEmail.objects.create(email="new.person@example.gov")
         form = UserDomainRoleForm(
@@ -1544,10 +1551,81 @@ class TestUserDomainRoleInvitationAdmin(TestCase):
         self.assertEqual(role.role, UserDomainRole.Roles.MANAGER)
         self.assertEqual(role.status, UserDomainRole.Status.INVITED)
         self.assertEqual(role.invited_by, self.superuser)
-        mock_send_email.assert_called_once()
-        mock_messages_success.assert_called_once_with(
-            request, "new.person@example.gov has been invited to the domain: test.gov"
+        mock_send_domain_email.assert_called_once_with(
+            email="new.person@example.gov",
+            requestor=self.superuser,
+            domains=self.domain,
+            is_member_of_different_org=None,
+            requested_user=None,
+            skip_existing_invitation_check=True,
         )
+        mock_send_portfolio_email.assert_called_once_with(
+            email="new.person@example.gov",
+            requestor=self.superuser,
+            portfolio=self.portfolio,
+            is_admin_invitation=False,
+        )
+        mock_messages_success.assert_has_calls(
+            [
+                call(
+                    request,
+                    f"new.person@example.gov has been invited to become a member of {self.portfolio}",
+                ),
+                call(request, "new.person@example.gov has been invited to the domain: test.gov"),
+            ]
+        )
+
+    @less_console_noise_decorator
+    @override_flag("multiple_portfolios", active=True)
+    @override_flag("user_domain_role_invitations", active=True)
+    @override_flag("user_portfolio_permission_invitations", active=True)
+    @patch("registrar.services.invitation_service.send_domain_invitation_email")
+    @patch("registrar.services.invitation_service.send_portfolio_invitation_email")
+    @patch("django.contrib.messages.success")
+    def test_analyst_save_existing_user_email_adds_user_to_domain_portfolio_without_email(
+        self,
+        mock_messages_success,
+        mock_send_portfolio_email,
+        mock_send_domain_email,
+    ):
+        admin_instance = UserDomainRoleAdmin(UserDomainRole, admin_site=AdminSite())
+        analyst = create_omb_analyst_user()
+        other_portfolio = Portfolio.objects.create(
+            organization_name="Other Portfolio",
+            requester=self.superuser,
+        )
+        UserPortfolioPermission.objects.create(
+            user=self.testuser,
+            portfolio=other_portfolio,
+            roles=[UserPortfolioRoleChoices.ORGANIZATION_MEMBER],
+            status=UserPortfolioPermission.Status.ACCEPTED,
+        )
+        form = UserDomainRoleForm(
+            data={
+                "user": self.testuser.email,
+                "domain": self.domain.id,
+                "send_email": "",
+            }
+        )
+        self.assertTrue(form.is_valid(), form.errors)
+        role = form.save(commit=False)
+        request = self.factory.post("/admin/registrar/userdomainrole/add/")
+        request.user = analyst
+        request.session = SessionStore()
+
+        admin_instance.save_model(request, role, form, False)
+
+        role.refresh_from_db()
+        portfolio_permission = UserPortfolioPermission.objects.get(
+            user=self.testuser,
+            portfolio=self.portfolio,
+        )
+        self.assertEqual(role.user, self.testuser)
+        self.assertEqual(role.status, UserDomainRole.Status.ACCEPTED)
+        self.assertEqual(portfolio_permission.roles, [UserPortfolioRoleChoices.ORGANIZATION_MEMBER])
+        self.assertEqual(portfolio_permission.status, UserPortfolioPermission.Status.ACCEPTED)
+        mock_send_domain_email.assert_not_called()
+        mock_send_portfolio_email.assert_not_called()
 
     @override_flag("user_domain_role_invitations", active=False)
     @patch("registrar.admin.create_domain_role_or_invitation")

--- a/src/registrar/views/utility/invitation_helper.py
+++ b/src/registrar/views/utility/invitation_helper.py
@@ -1,5 +1,6 @@
 from django.contrib import messages
 from django.db import IntegrityError
+from django.db.models import Q
 from registrar.models import PortfolioInvitation, UserPortfolioPermission
 from registrar.utility.email import EmailSendingError
 import logging
@@ -29,27 +30,27 @@ def get_org_membership(org, email, user):
     - member_of_a_different_org: True if the user/email is associated with an organization other than the given org.
     - member_of_this_org: True if the user/email is associated with the given org.
 
-    Note: This implementation assumes single portfolio ownership for a user.
-    If the "multiple portfolios" feature is enabled, this logic may not account for
-    situations where a user or email belongs to multiple organizations.
+    Rejected and expired permissions do not count as portfolio membership.
     """
 
-    # Check for existing permissions or invitations for the user
-    existing_org_permission = None
+    permission_identity = Q(email__iexact=email)
     if user is not None:
-        existing_org_permission = UserPortfolioPermission.objects.filter(user=user).first()
-    if existing_org_permission is None:
-        existing_org_permission = UserPortfolioPermission.objects.filter(email__iexact=email).first()
-    existing_org_invitation = PortfolioInvitation.objects.filter(email__iexact=email).first()
+        permission_identity |= Q(user=user)
 
-    # Determine membership in a different organization
-    member_of_a_different_org = (existing_org_permission and existing_org_permission.portfolio != org) or (
-        existing_org_invitation and existing_org_invitation.portfolio != org
+    active_permissions = UserPortfolioPermission.objects.filter(permission_identity).filter(
+        Q(status__in=[UserPortfolioPermission.Status.INVITED, UserPortfolioPermission.Status.ACCEPTED])
+        | Q(status__isnull=True)
+    )
+    active_invitations = PortfolioInvitation.objects.filter(
+        email__iexact=email,
+        status=PortfolioInvitation.PortfolioInvitationStatus.INVITED,
     )
 
-    # Determine membership in the same organization
-    member_of_this_org = (existing_org_permission and existing_org_permission.portfolio == org) or (
-        existing_org_invitation and existing_org_invitation.portfolio == org
+    member_of_a_different_org = (
+        active_permissions.exclude(portfolio=org).exists() or active_invitations.exclude(portfolio=org).exists() or None
+    )
+    member_of_this_org = (
+        active_permissions.filter(portfolio=org).exists() or active_invitations.filter(portfolio=org).exists() or None
     )
 
     return member_of_a_different_org, member_of_this_org


### PR DESCRIPTION
## Ticket

<!-- PR title format: `#issue_number: Descriptive name ideally matching ticket name - [sandbox]`-->
Resolves #5314 

Users of the analyst group that tried to send a domain invitation via the admin user domain role page which needed a corresponding portfolio-level invitation would not have the portfolio invitation sent if multiple_porfolios flag was on

## Changes

<!-- What was added, updated, or removed in this PR. -->
- Analysts who send invites from UserDomainRole will have appropriate portfolio-level invitations created if nescessary, respecting multi-portfolio, current invitee portfolio membership(s) if any. Respects waffle flags.
- Additionally discovered this condition would also not send portfolio level invitation if the optional send email was unchecked.
- Modified to separate email sending from actual portfolio/domain membership requirements

<!--
    Please add/remove/edit any of the template below to fit the needs
    of this specific PR.
--->

## Context for reviewers

<!--Background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers.  -->
Discovered when testing in stable by Kaitlin and Kristina.

## Setup
Waffle flags for user_domain_role and user_portfolio_permission turned on.  Multiple_portfolios turned on and set to Everyone.  User you are testing with should be an analyst (they were affected).  Superusers and front end users were not affected by this (but regression testing as them couldn't hurt)

<!--  Add any steps or code to run in this section to help others run your code.

    Example 1:
    ```sh
    echo "Code goes here"
    ```

    Example 2: If the PR was to add a new link with a redirect, this section could simply be:
    -go to /path/to/start/page
    -click the blue link in the <insert location>
    -notice user is redirected to <proper end location>
-->

## Code Review Verification Steps

### As the original developer, I have

#### Satisfied acceptance criteria and met development standards

- [ ] Met the acceptance criteria, or will meet them in a subsequent PR
- [ ] Created/modified automated tests
- [ ] Update documentation in READMEs and/or onboarding guide

#### Ensured code standards are met (Original Developer)
<!-- Mark "- N/A" and check at the end of each check that is not applicable to your PR -->
- [ ] If any updated dependencies on Pipfile, also update dependencies in requirements.txt.
- [ ] Interactions with external systems are wrapped in try/except
- [ ] Error handling exists for unusual or missing values

#### Validated user-facing changes (if applicable)

- [ ] [Follow the process for requesting a design review](https://dhscisa.enterprise.slack.com/docs/T02QH7E1MHA/F06CZ6MRUKA). If code is not user-facing, delete design reviewer checklist
- [ ] Verify new pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Checked keyboard navigability
- [ ] Reviewed [accessibility checklist](https://github.com/cisagov/manage.get.gov/blob/main/docs/dev-practices/code_review.md#accessibility-checklist) using screen reader (such as NVDA with Chrome or Voiceover with Safari), ANDI, or WAVE:
  - [ ] Tested general usability
  - [ ] Page header structure
  - [ ] Landmarks
  - [ ] Links and buttons
- [ ] Checked for errors or warnings with an a11y browser tool (such as ANDI or WAVE)

### As a code reviewer, I have

#### Reviewed, tested, and left feedback about the changes

- [x] Pulled this branch locally and tested it
- [x] Verified code meets all checks above. Address any checks that are not satisfied
- [x] Reviewed this code and left comments. Indicate if comments must be addressed before code is merged
- [x] Checked that all code is adequately covered by tests
- [ ] Verify migrations are valid and do not conflict with existing migrations

#### Validated user-facing changes as a developer
**Note:** Multiple code reviewers can share the checklists above, a second reviewer should not make a duplicate checklist. All checks should be checked before approving, even those labeled N/A.

- [ ] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Meets all designs and user flows provided by design/product
- [ ] Checked keyboard navigability
- [ ] Reviewed [accessibility checklist](https://github.com/cisagov/manage.get.gov/blob/main/docs/dev-practices/code_review.md#accessibility-checklist) using screen reader (such as NVDA with Chrome or Voiceover with Safari), ANDI, or WAVE:
  - [ ] Tested general usability
  - [ ] Page header structure
  - [ ] Landmarks
  - [ ] Links and buttons
- [ ] Checked for errors or warnings with an a11y browser tool (such as ANDI or WAVE)
- [ ] (Rarely needed) Tested as both an analyst and applicant user

### As a designer reviewer, I have

#### Verified that the changes match the design intention

- [ ] Checked that the design translated visually
- [ ] Checked behavior. Comment any found issues or broken flows.
- [ ] Checked different states (empty, one, some, error)
- [ ] Checked for landmarks, page heading structure, and links

#### Validated user-facing changes as a designer

- [ ] Checked keyboard navigability
- [ ] Reviewed [accessibility checklist](https://github.com/cisagov/manage.get.gov/blob/main/docs/dev-practices/code_review.md#accessibility-checklist) using screen reader (such as NVDA with Chrome or Voiceover with Safari), ANDI, or WAVE:
  - [ ] Tested general usability
  - [ ] Page header structure
  - [ ] Landmarks
  - [ ] Links and buttons
- [ ] Checked for errors or warnings with an a11y browser tool (such as ANDI or WAVE)
- [ ] Tested with multiple browsers (check off which ones were used)
  - [ ] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari
- [ ] (Rarely needed) Tested as both an analyst and applicant user

### References
- [Code review best practices](../docs/dev-practices/code_review.md)

## Screenshots

<!-- If this PR makes visible interface changes, an image of the finished interface can help reviewers
and casual observers understand the context of the changes.
A before image is optional and can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow.
You may want to use [GIPHY Capture](https://giphy.com/apps/giphycapture) for this! 📸

_Please frame images to show useful context but also highlight the affected regions._
--->
