### PR TITLE
# 5374 - Add "Active" as an option in the Domains filter - [AD]

### DIFF
--- a/src/registrar/templates/includes/domains_table.html
+++ b/src/registrar/templates/includes/domains_table.html
@@ -99,7 +99,7 @@
               value="unknown"
             />
             <label class="usa-checkbox__label" for="filter-status-dns-needed"
-              >DNS Needed</label
+              >DNS needed</label
             >
           </div>
           <div class="usa-checkbox">

--- a/src/registrar/templates/includes/domains_table.html
+++ b/src/registrar/templates/includes/domains_table.html
@@ -117,6 +117,17 @@
           <div class="usa-checkbox">
             <input
               class="usa-checkbox__input"
+              id="filter-status-active"
+              type="checkbox"
+              name="filter-status"
+              value="active"
+            />
+            <label class="usa-checkbox__label" for="filter-status-active"
+              >Active</label>
+          </div>
+          <div class="usa-checkbox">
+            <input
+              class="usa-checkbox__input"
               id="filter-status-on-hold"
               type="checkbox"
               name="filter-status"

--- a/src/registrar/views/domains_json.py
+++ b/src/registrar/views/domains_json.py
@@ -121,7 +121,7 @@ def apply_state_filter(queryset, request):
             status_list.append("dns needed")
         # Split the status list into normal states and custom states
         normal_states = [state for state in status_list if state in Domain.State.values]
-        custom_states = [state for state in status_list if (state == "expired" or state == "expiring")]
+        custom_states = [state for state in status_list if (state in ["expired", "expiring", "active"])]
         # Construct Q objects for normal states that can be queried through ORM
         state_query = Q()
         if normal_states:
@@ -133,6 +133,10 @@ def apply_state_filter(queryset, request):
         if "expiring" in custom_states:
             expiring_domain_ids = [domain.id for domain in queryset if domain.state_display(request) == "Expiring soon"]
             state_query |= Q(id__in=expiring_domain_ids)
+        if "active" in custom_states:
+            active_domain_ids = [domain.id for domain in queryset if domain.state_display(request) == "Active"]
+            state_query |= Q(id__in=active_domain_ids)
+
         # Apply the combined query
         queryset = queryset.filter(state_query)
         # If there are filtered states, and expired is not one of them, domains with

--- a/src/registrar/views/domains_json.py
+++ b/src/registrar/views/domains_json.py
@@ -147,6 +147,9 @@ def apply_state_filter(queryset, request):
         if "expiring" not in custom_states:
             expired_domain_ids = [domain.id for domain in queryset if domain.state_display(request) == "Expiring soon"]
             queryset = queryset.exclude(id__in=expired_domain_ids)
+        if "active" not in custom_states:
+            active_domain_ids  = [domain.id for domain in queryset if domain.state_display(request) == "Active"]
+            queryset = queryset.exclude(id__in=active_domain_ids)
 
     return queryset
 

--- a/src/registrar/views/domains_json.py
+++ b/src/registrar/views/domains_json.py
@@ -148,7 +148,7 @@ def apply_state_filter(queryset, request):
             expired_domain_ids = [domain.id for domain in queryset if domain.state_display(request) == "Expiring soon"]
             queryset = queryset.exclude(id__in=expired_domain_ids)
         if "active" not in custom_states:
-            active_domain_ids  = [domain.id for domain in queryset if domain.state_display(request) == "Active"]
+            active_domain_ids = [domain.id for domain in queryset if domain.state_display(request) == "Active"]
             queryset = queryset.exclude(id__in=active_domain_ids)
 
     return queryset


### PR DESCRIPTION
## Ticket

<!-- PR title format: `#issue_number: Descriptive name ideally matching ticket name - [sandbox]`-->
Resolves #5374 

## Changes

<!-- What was added, updated, or removed in this PR. -->
- Added an "Active" filter to the domains table
- Change the text on the "DNS Needed" to "DNS needed".

<!--
    Please add/remove/edit any of the template below to fit the needs
    of this specific PR.
--->

## Context for reviewers

<!--Background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers.  -->

## Setup

<!--  Add any steps or code to run in this section to help others run your code.

    Example 1:
    ```sh
    echo "Code goes here"
    ```

    Example 2: If the PR was to add a new link with a redirect, this section could simply be:
    -go to /path/to/start/page
    -click the blue link in the <insert location>
    -notice user is redirected to <proper end location>
-->

## Code Review Verification Steps

- Log in to the app
- On the domains table, select "Active". It should give you all of the active domains.

### As the original developer, I have

#### Satisfied acceptance criteria and met development standards

- [ ] Met the acceptance criteria, or will meet them in a subsequent PR
- [ ] Created/modified automated tests
- [ ] Update documentation in READMEs and/or onboarding guide

#### Ensured code standards are met (Original Developer)
<!-- Mark "- N/A" and check at the end of each check that is not applicable to your PR -->
- [ ] If any updated dependencies on Pipfile, also update dependencies in requirements.txt.
- [ ] Interactions with external systems are wrapped in try/except
- [ ] Error handling exists for unusual or missing values

#### Validated user-facing changes (if applicable)

- [ ] [Follow the process for requesting a design review](https://dhscisa.enterprise.slack.com/docs/T02QH7E1MHA/F06CZ6MRUKA). If code is not user-facing, delete design reviewer checklist
- [ ] Verify new pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Checked keyboard navigability
- [ ] Reviewed [accessibility checklist](https://github.com/cisagov/manage.get.gov/blob/main/docs/dev-practices/code_review.md#accessibility-checklist) using screen reader (such as NVDA with Chrome or Voiceover with Safari), ANDI, or WAVE:
  - [ ] Tested general usability
  - [ ] Page header structure
  - [ ] Landmarks
  - [ ] Links and buttons
- [ ] Checked for errors or warnings with an a11y browser tool (such as ANDI or WAVE)

### As a code reviewer, I have

#### Reviewed, tested, and left feedback about the changes

- [x] Pulled this branch locally and tested it
- [x] Verified code meets all checks above. Address any checks that are not satisfied
- [x] Reviewed this code and left comments. Indicate if comments must be addressed before code is merged
- [x] Checked that all code is adequately covered by tests
- [ ] Verify migrations are valid and do not conflict with existing migrations

#### Validated user-facing changes as a developer
**Note:** Multiple code reviewers can share the checklists above, a second reviewer should not make a duplicate checklist. All checks should be checked before approving, even those labeled N/A.

- [ ] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [x] Meets all designs and user flows provided by design/product
- [x] Checked keyboard navigability
- [x] Reviewed [accessibility checklist](https://github.com/cisagov/manage.get.gov/blob/main/docs/dev-practices/code_review.md#accessibility-checklist) using screen reader (such as NVDA with Chrome or Voiceover with Safari), ANDI, or WAVE:
  - [x] Tested general usability
  - [x] Page header structure
  - [x] Landmarks
  - [x] Links and buttons
- [ ] Checked for errors or warnings with an a11y browser tool (such as ANDI or WAVE)
- [ ] (Rarely needed) Tested as both an analyst and applicant user

### As a designer reviewer, I have

#### Verified that the changes match the design intention

- [x] Checked that the design translated visually
- [x] Checked behavior. Comment any found issues or broken flows.
- [x] Checked different states (empty, one, some, error)
- [ ] Checked for landmarks, page heading structure, and links

#### Validated user-facing changes as a designer

- [ ] Checked keyboard navigability
- [ ] Reviewed [accessibility checklist](https://github.com/cisagov/manage.get.gov/blob/main/docs/dev-practices/code_review.md#accessibility-checklist) using screen reader (such as NVDA with Chrome or Voiceover with Safari), ANDI, or WAVE:
  - [ ] Tested general usability
  - [ ] Page header structure
  - [ ] Landmarks
  - [ ] Links and buttons
- [ ] Checked for errors or warnings with an a11y browser tool (such as ANDI or WAVE)
- [ ] Tested with multiple browsers (check off which ones were used)
  - [ ] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari
- [ ] (Rarely needed) Tested as both an analyst and applicant user

### References
- [Code review best practices](../docs/dev-practices/code_review.md)

## Screenshots

<!-- If this PR makes visible interface changes, an image of the finished interface can help reviewers
and casual observers understand the context of the changes.
A before image is optional and can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow.
You may want to use [GIPHY Capture](https://giphy.com/apps/giphycapture) for this! 📸

_Please frame images to show useful context but also highlight the affected regions._
--->
