### PR TITLE
#4997 - Tighten Register Nameservers Error - [GLACIER]

### DIFF
--- a/src/registrar/models/domain.py
+++ b/src/registrar/models/domain.py
@@ -826,12 +826,12 @@ class Domain(TimeStampedModel, DomainHelper):
         if len(hosts) > 13:
             raise NameserverError(code=nsErrorCodes.TOO_MANY_HOSTS)
 
-        if self.state not in [
-            self.State.DNS_NEEDED,
-            self.State.READY,
-            self.State.UNKNOWN,
-        ]:
-            raise ActionNotAllowed("Nameservers can not be " "set in the current state")
+        # if self.state not in [
+        #     self.State.DNS_NEEDED,
+        #     self.State.READY,
+        #     self.State.UNKNOWN,
+        # ]:
+        #     raise ActionNotAllowed("Nameservers can not be " "set in the current state")
 
         logger.info("Setting nameservers")
         logger.info(hosts)

--- a/src/registrar/services/dns_host_service.py
+++ b/src/registrar/services/dns_host_service.py
@@ -392,7 +392,7 @@ class DnsHostService:
                 logger.error(
                             "Register nameservers error %s",
                             domain_name,
-                            extra={"domain_name": domain_name, "nameservers": nameservers, "error_class": e},
+                            extra={"domain_name": domain_name, "nameservers": nameservers},
                 )
                 raise
 

--- a/src/registrar/services/dns_host_service.py
+++ b/src/registrar/services/dns_host_service.py
@@ -19,6 +19,7 @@ from registrar.utility.constants import CURRENT_DNS_VENDOR
 from django.db import transaction
 from registrar.services.utility.dns_helper import make_dns_account_name
 from registrar.services.dns_http_client import build_dns_client
+from epplibwrapper.errors import  RegistryError
 
 logger = logging.getLogger(__name__)
 
@@ -375,6 +376,9 @@ class DnsHostService:
     def register_nameservers(self, domain_name, nameservers):
         domain = Domain.objects.get(name=domain_name)
         # TODO: first check domain state? or status? to ensure it's in the registry?
+
+        # if its deleted from the registry what's the response?
+        # it would be a registry error?
         nameserver_tups = [tuple([n]) for n in nameservers]
 
         try:
@@ -384,8 +388,13 @@ class DnsHostService:
                 extra={"domain_name": domain_name, "nameservers": nameservers},
             )
             domain.nameservers = nameserver_tups  # calls EPP service to post nameservers to registry
-        except (RegistrySystemError, Exception):
-            raise
+        except RegistryError as e:
+                logger.error(
+                            "Error happened %s",
+                            domain_name,
+                            extra={"domain_name": domain_name, "nameservers": nameservers, "error_class": type(e).__name__},
+                )
+                raise
 
     def create_db_account(self, vendor_account_data):
         """

--- a/src/registrar/services/dns_host_service.py
+++ b/src/registrar/services/dns_host_service.py
@@ -390,9 +390,9 @@ class DnsHostService:
             domain.nameservers = nameserver_tups  # calls EPP service to post nameservers to registry
         except RegistryError as e:
                 logger.error(
-                            "Error happened %s",
+                            "Register nameservers error %s",
                             domain_name,
-                            extra={"domain_name": domain_name, "nameservers": nameservers, "error_class": type(e).__name__},
+                            extra={"domain_name": domain_name, "nameservers": nameservers, "error_class": e},
                 )
                 raise
 

--- a/src/registrar/templates/django/admin/domain_change_form.html
+++ b/src/registrar/templates/django/admin/domain_change_form.html
@@ -17,7 +17,7 @@
                 {# Dja has margin styles defined on inputs as is. Lets work with it, rather than fight it. #}
                 <span class="mini-spacer"></span>
                 <input type="submit" value="Get registry status" name="_get_status">
-                {% if dns_hosting_enabled and not original.is_enrolled_in_dns_hosting and not original.is_legacy %}
+                {% if dns_hosting_enabled and not original.is_enrolled_in_dns_hosting and not original.is_legacy and original.state === original.State.READY %}
                 <span class="mini-spacer"></span>
                 <input
                     type="submit"

--- a/src/registrar/templates/django/admin/domain_change_form.html
+++ b/src/registrar/templates/django/admin/domain_change_form.html
@@ -17,7 +17,7 @@
                 {# Dja has margin styles defined on inputs as is. Lets work with it, rather than fight it. #}
                 <span class="mini-spacer"></span>
                 <input type="submit" value="Get registry status" name="_get_status">
-                {% if dns_hosting_enabled and not original.is_enrolled_in_dns_hosting and not original.is_legacy and original.state === original.State.READY %}
+                {% if dns_hosting_enabled and not original.is_enrolled_in_dns_hosting and not original.is_legacy and original.state == original.State.READY %}
                 <span class="mini-spacer"></span>
                 <input
                     type="submit"


### PR DESCRIPTION
## Ticket

<!-- PR title format: `#issue_number: Descriptive name ideally matching ticket name - [sandbox]`-->
Resolves #4997 

## Changes

- Removed the "TO DO" comment from the register_nameservers method, the check already exists in the nameservers domain method

https://github.com/cisagov/manage.get.gov/blob/149489eeded02d6cb25931df31190f04f48ad3ec/src/registrar/models/domain.py#L814-L835

- Updated the register_nameservers exception to just have RegistryError, and added logs to detail the error messages.
- Currently the registryError that can pop up are the ones caused by creating, deleting hosts, and auth errors.


## Context for reviewers

<!--Background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers.  -->

## Setup
- Go to /admin.
- Click to a domain that is eligible to enroll in dns hosting(ex:  baby-sound-debate-a.gov), turn on the filter for .gov Dns and select "No".
- Enroll that domain in dns hosting.
- Go to the [logs](https://logs.fr.cloud.gov/app/dashboards#/view/App-Overview?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-15m,to:now))&_a=(description:'',filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'logs-app*',key:'@cf.app',negate:!f,params:(query:getgov-glacier),type:phrase),query:(match_phrase:('@cf.app':getgov-glacier))),('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'logs-app*',key:'@message',negate:!f,params:(query:'Registry%20Error'),type:phrase),query:(match_phrase:('@message':'Registry%20Error')))),fullScreenMode:!f,options:(darkTheme:!f),query:(language:lucene,query:'*'),timeRestore:!f,title:'App%20-%20Overview',viewMode:view))

## Code Review Verification Steps

### As the original developer, I have

#### Satisfied acceptance criteria and met development standards

- [ ] Met the acceptance criteria, or will meet them in a subsequent PR
- [ ] Created/modified automated tests
- [ ] Update documentation in READMEs and/or onboarding guide

#### Ensured code standards are met (Original Developer)
<!-- Mark "- N/A" and check at the end of each check that is not applicable to your PR -->
- [ ] If any updated dependencies on Pipfile, also update dependencies in requirements.txt.
- [ ] Interactions with external systems are wrapped in try/except
- [ ] Error handling exists for unusual or missing values

#### Validated user-facing changes (if applicable)

- [ ] [Follow the process for requesting a design review](https://dhscisa.enterprise.slack.com/docs/T02QH7E1MHA/F06CZ6MRUKA). If code is not user-facing, delete design reviewer checklist
- [ ] Verify new pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Checked keyboard navigability
- [ ] Reviewed [accessibility checklist](https://github.com/cisagov/manage.get.gov/blob/main/docs/dev-practices/code_review.md#accessibility-checklist) using screen reader (such as NVDA with Chrome or Voiceover with Safari), ANDI, or WAVE:
  - [ ] Tested general usability
  - [x] Page header structure
  - [ ] Landmarks
  - [ ] Links and buttons
- [ ] Checked for errors or warnings with an a11y browser tool (such as ANDI or WAVE)

### As a code reviewer, I have

#### Reviewed, tested, and left feedback about the changes

- [ ] Pulled this branch locally and tested it
- [ ] Verified code meets all checks above. Address any checks that are not satisfied
- [ ] Reviewed this code and left comments. Indicate if comments must be addressed before code is merged
- [ ] Checked that all code is adequately covered by tests
- [ ] Verify migrations are valid and do not conflict with existing migrations

#### Validated user-facing changes as a developer
**Note:** Multiple code reviewers can share the checklists above, a second reviewer should not make a duplicate checklist. All checks should be checked before approving, even those labeled N/A.

- [ ] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Meets all designs and user flows provided by design/product
- [ ] Checked keyboard navigability
- [ ] Reviewed [accessibility checklist](https://github.com/cisagov/manage.get.gov/blob/main/docs/dev-practices/code_review.md#accessibility-checklist) using screen reader (such as NVDA with Chrome or Voiceover with Safari), ANDI, or WAVE:
  - [ ] Tested general usability
  - [ ] Page header structure
  - [ ] Landmarks
  - [ ] Links and buttons
- [ ] Checked for errors or warnings with an a11y browser tool (such as ANDI or WAVE)
- [ ] (Rarely needed) Tested as both an analyst and applicant user

### As a designer reviewer, I have

#### Verified that the changes match the design intention

- [ ] Checked that the design translated visually
- [ ] Checked behavior. Comment any found issues or broken flows.
- [ ] Checked different states (empty, one, some, error)
- [ ] Checked for landmarks, page heading structure, and links

#### Validated user-facing changes as a designer

- [ ] Checked keyboard navigability
- [ ] Reviewed [accessibility checklist](https://github.com/cisagov/manage.get.gov/blob/main/docs/dev-practices/code_review.md#accessibility-checklist) using screen reader (such as NVDA with Chrome or Voiceover with Safari), ANDI, or WAVE:
  - [ ] Tested general usability
  - [ ] Page header structure
  - [ ] Landmarks
  - [ ] Links and buttons
- [ ] Checked for errors or warnings with an a11y browser tool (such as ANDI or WAVE)
- [ ] Tested with multiple browsers (check off which ones were used)
  - [ ] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari
- [ ] (Rarely needed) Tested as both an analyst and applicant user

### References
- [Code review best practices](../docs/dev-practices/code_review.md)

## Screenshots

<!-- If this PR makes visible interface changes, an image of the finished interface can help reviewers
and casual observers understand the context of the changes.
A before image is optional and can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow.
You may want to use [GIPHY Capture](https://giphy.com/apps/giphycapture) for this! 📸

_Please frame images to show useful context but also highlight the affected regions._
--->
